### PR TITLE
Fix function prototypes for knetfile and bgzf

### DIFF
--- a/htslib/bgzf.c
+++ b/htslib/bgzf.c
@@ -346,7 +346,7 @@ int bgzf_read_block(BGZF *fp)
 	return 0;
 }
 
-ssize_t bgzf_read(BGZF *fp, void *data, ssize_t length)
+ssize_t bgzf_read(BGZF *fp, void *data, size_t length)
 {
 	ssize_t bytes_read = 0;
 	uint8_t *output = (uint8_t*)data;
@@ -515,7 +515,7 @@ static int mt_lazy_flush(BGZF *fp)
 	return -1;
 }
 
-static ssize_t mt_write(BGZF *fp, const void *data, ssize_t length)
+static ssize_t mt_write(BGZF *fp, const void *data, size_t length)
 {
 	const uint8_t *input = (const uint8_t*)data;
 	ssize_t rest = length;
@@ -562,7 +562,7 @@ int bgzf_flush_try(BGZF *fp, ssize_t size)
 	return -1;
 }
 
-ssize_t bgzf_write(BGZF *fp, const void *data, ssize_t length)
+ssize_t bgzf_write(BGZF *fp, const void *data, size_t length)
 {
 	const uint8_t *input = (const uint8_t*)data;
 	int block_length = BGZF_BLOCK_SIZE, bytes_written = 0;

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -103,7 +103,7 @@ extern "C" {
 	 * @param length size of data to read
 	 * @return       number of bytes actually read; 0 on end-of-file and -1 on error
 	 */
-	ssize_t bgzf_read(BGZF *fp, void *data, ssize_t length);
+	ssize_t bgzf_read(BGZF *fp, void *data, size_t length);
 
 	/**
 	 * Write _length_ bytes from _data_ to the file.
@@ -113,7 +113,7 @@ extern "C" {
 	 * @param length size of data to write
 	 * @return       number of bytes actually written; -1 on error
 	 */
-	ssize_t bgzf_write(BGZF *fp, const void *data, ssize_t length);
+	ssize_t bgzf_write(BGZF *fp, const void *data, size_t length);
 
 	/**
 	 * Write the data in the buffer to the file.

--- a/htslib/knetfile.c
+++ b/htslib/knetfile.c
@@ -500,7 +500,7 @@ knetFile *knet_dopen(int fd, const char *mode)
 	return fp;
 }
 
-off_t knet_read(knetFile *fp, void *buf, off_t len)
+ssize_t knet_read(knetFile *fp, void *buf, size_t len)
 {
 	off_t l = 0;
 	if (fp->fd == -1) return 0;
@@ -514,7 +514,7 @@ off_t knet_read(knetFile *fp, void *buf, off_t len)
 			khttp_connect_file(fp);
 	}
 	if (fp->type == KNF_TYPE_LOCAL) { // on Windows, the following block is necessary; not on UNIX
-		off_t rest = len, curr;
+		size_t rest = len, curr;
 		while (rest) {
 			do {
 				curr = read(fp->fd, (void*)((char*)buf + l), rest);
@@ -528,12 +528,12 @@ off_t knet_read(knetFile *fp, void *buf, off_t len)
 	return l;
 }
 
-off_t knet_seek(knetFile *fp, int64_t off, int whence)
+off64_t knet_seek(knetFile *fp, off64_t off, int whence)
 {
 	if (whence == SEEK_SET && off == fp->offset) return 0;
 	if (fp->type == KNF_TYPE_LOCAL) {
 		/* Be aware that lseek() returns the offset after seeking, while fseek() returns zero on success. */
-		off_t offset = lseek(fp->fd, off, whence);
+		off64_t offset = lseek64(fp->fd, off, whence);
 		if (offset == -1) return -1;
 		fp->offset = offset;
 		return fp->offset;

--- a/htslib/knetfile.h
+++ b/htslib/knetfile.h
@@ -39,6 +39,11 @@ typedef struct knetFile_s {
 #define knet_tell(fp) ((fp)->offset)
 #define knet_fileno(fp) ((fp)->fd)
 
+#if defined(__FreeBSD__) || defined(__APPLE__) // In BSD all off_t are 64 bits
+typedef off_t off64_t;
+#define lseek64(fd, offset, whence) lseek(fd, offset, whence)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -59,13 +64,13 @@ extern "C" {
 	  If ->is_ready==0, this routine updates ->fd; otherwise, it simply
 	  reads from ->fd.
 	 */
-	off_t knet_read(knetFile *fp, void *buf, off_t len);
+	ssize_t knet_read(knetFile *fp, void *buf, size_t len);
 
 	/*
 	  This routine only sets ->offset and ->is_ready=0. It does not
 	  communicate with the FTP server.
 	 */
-	off_t knet_seek(knetFile *fp, int64_t off, int whence);
+	off64_t knet_seek(knetFile *fp, off64_t off, int whence);
 	int knet_close(knetFile *fp);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix function prototypes for knetfile and bgzf to match system read and write.
