### PR TITLE
do not round per-sample average depths to integer values

### DIFF
--- a/misc/plot-vcfcheck
+++ b/misc/plot-vcfcheck
@@ -647,7 +647,7 @@ sub plot_per_sample_stats
 	{ 
 		my $tstv = $vals[$i][5] ? $vals[$i][4]/$vals[$i][5] : 0;
         my $hethom = $vals[$i][2] ? $vals[$i][3]/$vals[$i][2] : 0;
-		iprint $fh, sprintf("\t[ %d, %f, %f, %d, %d, %d, %d, r'%s' ],\n", $i, $tstv, $hethom, $vals[$i][4]+$vals[$i][5], $vals[$i][6], $vals[$i][7], $vals[$i][8], $vals[$i][0]);
+		iprint $fh, sprintf("\t[ %d, %f, %f, %d, %d, %f, %d, r'%s' ],\n", $i, $tstv, $hethom, $vals[$i][4]+$vals[$i][5], $vals[$i][6], $vals[$i][7], $vals[$i][8], $vals[$i][0]);
 	}
 	iprint $fh, "]
 

--- a/vcfcheck.c
+++ b/vcfcheck.c
@@ -680,8 +680,8 @@ static void print_stats(args_t *args)
             stats_t *stats = &args->stats[id];
             for (i=0; i<args->files->n_smpl; i++)
             {
-                float dp = stats->smpl_ndp[i] ? stats->smpl_dp[i]/stats->smpl_ndp[i] : 0;
-                printf("PSC\t%d\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%.0f\t%d\n", id,args->files->samples[i], 
+                float dp = stats->smpl_ndp[i] ? stats->smpl_dp[i]/(float)stats->smpl_ndp[i] : 0;
+                printf("PSC\t%d\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%.1f\t%d\n", id,args->files->samples[i], 
                     stats->smpl_homRR[i], stats->smpl_homAA[i], stats->smpl_hets[i], stats->smpl_ts[i], 
                     stats->smpl_tv[i], stats->smpl_indels[i],dp, stats->smpl_sngl[i]);
             }


### PR DESCRIPTION
fixes up some plots which look "blocky" on low coverage data because of rounding average depths to integers
