### PR TITLE
Allow INFO field name to have underscores

### DIFF
--- a/vcfquery.c
+++ b/vcfquery.c
@@ -306,7 +306,7 @@ static char *parse_tag(args_t *args, char *p, int is_gtf)
             if ( *q!='/' ) error("Could not parse format string: %s\n", args->format);
             p = ++q;
             str.l = 0;
-            while ( *q && isalnum(*q) ) q++;
+            while ( *q && (isalnum(*q) || *q=='_') ) q++;
             if ( q-p==0 ) error("Could not parse format string: %s\n", args->format);
             kputsn(p, q-p, &str);
             register_tag(args, T_INFO, str.s, is_gtf);


### PR DESCRIPTION
INFO fields with underscores were not parsed correctly. Now they should be fine.

Before:

```
htscmd vcfquery -f '%CHROM\t%POS\t%REF\t%ALT\t%INFO/GENE_NAME\n' file.vcf.gz
Error: no such tag defined in the VCF header: INFO/GENE
```

After:

```
htscmd vcfquery -f '%CHROM\t%POS\t%REF\t%ALT\t%INFO/GENE_NAME\n' file.vcf.gz
Error: no such tag defined in the VCF header: INFO/GENE_NAME
```
