### PR TITLE
added option -K in vcfview to exclude SNVs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: cpp
-compiler:
-  - gcc
-  - clang
-# Change this to your needs
-script: make


### PR DESCRIPTION
To be able to separate SNVs and INDELs from a vcf, I added option -K in vcfview to exclude SNVs, complementary to existing option -I to exclude INDELs.
