### PR TITLE
bcf_gt_type can now, optionally, give the index of the 2nd alt allele

### DIFF
--- a/htslib/vcfutils.h
+++ b/htslib/vcfutils.h
@@ -52,13 +52,16 @@ int bcf_calc_ac(const bcf_hdr_t *header, bcf1_t *line, int *ac, int which);
  * bcf_gt_type() - determines type of the genotype
  * @fmt_ptr:  the GT format field as set for example by set_fmt_ptr
  * @isample:  sample index (starting from 0)
- * @ial:      index of the non-reference allele (starting from 1)
+ * @ial:      index of the 1st non-reference allele (starting from 1)
+ * @jal:      index of the 2nd non-reference allele (starting from 1)
  *
  * Returns the type of the genotype (one of GT_HOM_RR, GT_HET_RA,
- * GT_HOM_AA, GT_HET_AA, or GT_UNKN). If $ial is not NULL and the
- * genotype has one or more non-reference alleles, $ial will be set.
- * In case of GT_HET_AA, the allele which appeared first in ALT is
- * used.
+ * GT_HOM_AA, GT_HET_AA, GT_HAPL_R, GT_HAPL_A or GT_UNKN). If $ial 
+ * is not NULL and the genotype has one or more non-reference 
+ * alleles, $ial will be set. In case of GT_HET_AA, $ial is the 
+ * position of the allele which appeared first in ALT. If $jal is 
+ * not null and the genotype is GT_HET_AA, $jal will be set and is 
+ * the position of the second allele in ALT.
  */
 #define GT_HOM_RR 0 // note: the actual value of GT_* matters, used in dosage r2 calculation
 #define GT_HOM_AA 1
@@ -67,7 +70,7 @@ int bcf_calc_ac(const bcf_hdr_t *header, bcf1_t *line, int *ac, int which);
 #define GT_HAPL_R 4
 #define GT_HAPL_A 5
 #define GT_UNKN   6
-int bcf_gt_type(bcf_fmt_t *fmt_ptr, int isample, int *ial);
+int bcf_gt_type(bcf_fmt_t *fmt_ptr, int isample, int *ial, int *jal);
 
 static inline int bcf_acgt2int(char c)
 {

--- a/vcfutils.c
+++ b/vcfutils.c
@@ -81,9 +81,9 @@ int bcf_calc_ac(const bcf_hdr_t *header, bcf1_t *line, int *ac, int which)
 	return 0;
 }
 
-int bcf_gt_type(bcf_fmt_t *fmt_ptr, int isample, int *_ial)
+int bcf_gt_type(bcf_fmt_t *fmt_ptr, int isample, int *_ial, int *_jal)
 {
-    int i, nals = 0, has_ref = 0, has_alt = 0, ial = 0;
+    int i, nals = 0, has_ref = 0, has_alt = 0, ial = 0, jal = 0;
     #define BRANCH_INT(type_t,missing,vector_end) { \
         type_t *p = (type_t*) (fmt_ptr->p + isample*fmt_ptr->size); \
         for (i=0; i<fmt_ptr->n; i++) \
@@ -96,7 +96,15 @@ int bcf_gt_type(bcf_fmt_t *fmt_ptr, int isample, int *_ial)
                 if ( !ial ) { ial = tmp; has_alt = 1; } \
                 else if ( tmp!=ial ) \
                 { \
-                    if ( tmp<ial ) ial = tmp; \
+                    if ( tmp<ial ) \
+                    { \
+                        jal = ial; \
+                        ial = tmp; \
+                    } \
+                    else \
+                    { \
+                        jal = tmp; \
+                    } \
                     has_alt = 2; \
                 } \
             } \
@@ -113,6 +121,7 @@ int bcf_gt_type(bcf_fmt_t *fmt_ptr, int isample, int *_ial)
     #undef BRANCH_INT
 
     if ( _ial ) *_ial = ial>0 ? ial-1 : ial;
+    if ( _jal ) *_jal = jal>0 ? jal-1 : jal;
     if ( !nals ) return GT_UNKN;
     if ( nals==1 )
         return has_ref ? GT_HAPL_R : GT_HAPL_A;


### PR DESCRIPTION
bcf_gt_type can now, optionally, give the index of the 2nd alt allele for GT_HET_AA genotypes
