### PR TITLE
Add bam_mplp_set_mask()

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -280,6 +280,7 @@ extern "C" {
      */
     void bam_mplp_init_overlaps(bam_mplp_t iter);
 	void bam_mplp_destroy(bam_mplp_t iter);
+	void bam_mplp_set_mask(bam_mplp_t iter, int mask);
 	void bam_mplp_set_maxcnt(bam_mplp_t iter, int maxcnt);
 	int bam_mplp_auto(bam_mplp_t iter, int *_tid, int *_pos, int *n_plp, const bam_pileup1_t **plp);
 

--- a/sam.c
+++ b/sam.c
@@ -1490,6 +1490,14 @@ bam_mplp_t bam_mplp_init(int n, bam_plp_auto_f func, void **data)
 	return iter;
 }
 
+void bam_mplp_set_mask(bam_mplp_t iter, int mask)
+{
+    int i;
+    for (i = 0; i < iter->n; ++i) {
+        bam_plp_set_mask(iter->iter[i], mask);
+    }
+}
+
 void bam_mplp_init_overlaps(bam_mplp_t iter)
 {
     int i;


### PR DESCRIPTION
This function is analogous to and implemented using bam_plp_set_mask(), and is required to support having the user-supplied flag mask option to mpileup (--ff) replace, rather than adding to default mask.  
