### PR TITLE
Fixes incorrect MD5 calculation in cram_write_SAM_hdr

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2952,8 +2952,11 @@ int cram_write_SAM_hdr(cram_fd *fd, SAM_hdr *hdr) {
 		rlen = fd->refs->ref_id[i]->length;
 		MD5_Init(&md5);
 		ref = cram_get_ref(fd, i, 1, rlen);
+		if (NULL == ref) return -1;
+		rlen = fd->refs->ref_id[i]->length; /* In case it just loaded */
 		MD5_Update(&md5, ref, rlen);
 		MD5_Final(buf, &md5);
+		cram_ref_decr(fd->refs, i);
 
 		for (j = 0; j < 16; j++) {
 		    buf2[j*2+0] = "0123456789abcdef"[buf[j]>>4];
@@ -2962,7 +2965,6 @@ int cram_write_SAM_hdr(cram_fd *fd, SAM_hdr *hdr) {
 		buf2[32] = 0;
 		if (sam_hdr_update(hdr, ty, "M5", buf2, NULL))
 		    return -1;
-		cram_ref_decr(fd->refs, i);
 	    }
 
 	    if (fd->ref_fn) {


### PR DESCRIPTION
This fixes https://github.com/samtools/htslib/issues/67

cram_write_SAM_hdr adds a @SQ M5 tag if not already present.  When doing
this, if the reference had not already been loaded it would incorrectly
pass rlen = 0 to MD5_Update, resulting in it calculating the MD5 of an
empty file.  This patch updates rlen after the reference has been loaded
so the correct MD5 is calculated.

It also adds a check for cram_get_ref returning NULL, and calls cram_ref_decr
earlier to prevent a possible memory leak if sam_hdr_update returns non-zero.
