### PR TITLE
CRAM reference loading bug fix

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1660,6 +1660,11 @@ static char *load_ref_portion(FILE *fp, ref_entry *e, int start, int end) {
 	    free(seq);
 	    return NULL;
 	}
+    } else {
+	int i;
+	for (i = 0; i < len; i++) {
+	    seq[i] = seq[i] & ~0x20; // uppercase in ASCII
+	}
     }
 
     return seq;


### PR DESCRIPTION
Fixed a bug  loading in fasta files consisting of all sequence on a single line and in lowercase. The uppercasing code was only being called during the loop to strip out newlines.

I am aware the code is perhaps a bit "hopeful" still in that it doesn't explicitly check the fasta file contains sequence instead of punctuation marks, but frankly garbage in garbage out. It won't scribble over memory or do something foul.
