### PR TITLE
Makefile: Add razf.o to LIBHTS_OBJS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ LIBHTS_OBJS = \
 	hfile.o \
 	hfile_net.o \
 	hts.o \
+	razf.o \
 	sam.o \
 	synced_bcf_reader.o \
 	vcf_sweep.o \


### PR DESCRIPTION
Is it intentional that razf.o is not built?
