### PR TITLE
Add duplication function for the bam1_t interface

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -165,6 +165,7 @@ extern "C" {
 	int bam_read1(BGZF *fp, bam1_t *b);
 	int bam_write1(BGZF *fp, const bam1_t *b);
 	bam1_t *bam_copy1(bam1_t *bdst, const bam1_t *bsrc);
+	bam1_t *bam_dup1(const bam1_t *bsrc);
 
 	int bam_cigar2qlen(int n_cigar, const uint32_t *cigar);
 	int bam_cigar2rlen(int n_cigar, const uint32_t *cigar);

--- a/sam.c
+++ b/sam.c
@@ -207,6 +207,12 @@ bam1_t *bam_copy1(bam1_t *bdst, const bam1_t *bsrc)
 	return bdst;
 }
 
+bam1_t *bam_dup1(const bam1_t *bsrc)
+{
+  bam1_t *bdst = bam_init1();
+  return bam_copy1(bdst, bsrc);
+}
+
 int bam_cigar2qlen(int n_cigar, const uint32_t *cigar)
 {
 	int k, l;


### PR DESCRIPTION
Function is present in the bam header interface (bam_hdr_dup) and only
existed in the bam_copy1(dst, src) format. Hence, code using this
interface and the header interface was incoherent.

This commit adds a bam_dup1 function implemented as a call to bam_copy1
with the proper initialization to make the API's more uniform.
