### PR TITLE
Changed the initial CRAM EOF value to be 1 (expected EOF) and then

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1853,6 +1853,8 @@ static cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
     cram_container *c;
     cram_slice *s = NULL;
 
+    fd->eof = 0;
+
     if (!(c = fd->ctr)) {
 	// Load first container.
 	do {

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3326,7 +3326,7 @@ cram_fd *cram_dopen(cram_FILE *fp, const char *filename, const char *mode) {
 	fd->m[i] = cram_new_metrics();
 
     fd->range.refid = -2; // no ref.
-    fd->eof = 0;
+    fd->eof = 1;          // See samtools issue #150
     fd->ref_fn = NULL;
 
     fd->bl = NULL;


### PR DESCRIPTION
explicitly set it to 0 at the start of each slice decode.

This resolves https://github.com/samtools/samtools/issues/150 where "samtools view -H" would
return EOF as 0 and yield an error.
