### PR TITLE
Adjust library linking and provide PkgConfig support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 *.o
+*.pc
 *.pico
 /version.h
 
 lib*.a
 lib*.dylib
-lib*.pc
 lib*.so
 lib*.so.*
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ BUILT_TEST_PROGRAMS = \
 	test/test-vcf-api \
 	test/test-vcf-sweep
 
-all: lib-static lib-shared $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS)
+all: lib-static lib-shared $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS) htslib.pc
 
 HTSPREFIX =
 include htslib_vars.mk
@@ -93,14 +93,8 @@ endif
 version.h:
 	echo '#define HTS_VERSION "$(PACKAGE_VERSION)"' > $@
 
-libhts.pc:
-	echo "Name: LibHTS" > $@
-	echo "Description: A high-thoughput sequencing handling library" >> $@
-	echo "Version: $(PACKAGE_VERSION)" >> $@
-	echo "Requires:" >> $@
-	echo "Libs: -L$(libdir) -lhts" >> $@
-	echo "Libs.private: -L$(libdir) -lhts -lm -lpthread" >> $@
-	echo "Cflags: -I$(includedir)" >> $@
+htslib.pc: htslib.pc.in
+	sed -e 's#@VERSION@#$(PACKAGE_VERSION)#g;s#@LIBDIR@#$(libdir)#g;s#@INCLUDEDIR@#$(includedir)#g' $< > $@
 
 .SUFFIXES: .c .o .pico
 
@@ -256,11 +250,11 @@ test/test-vcf-api.o: test/test-vcf-api.c $(htslib_hts_h) $(htslib_vcf_h) htslib/
 test/test-vcf-sweep.o: test/test-vcf-sweep.c $(htslib_vcf_sweep_h)
 
 
-install: installdirs install-$(SHLIB_FLAVOUR)
+install: installdirs install-$(SHLIB_FLAVOUR) htslib.pc
 	$(INSTALL_PROGRAM) $(BUILT_PROGRAMS) $(DESTDIR)$(bindir)
 	$(INSTALL_DATA) htslib/*.h $(DESTDIR)$(includedir)/htslib
 	$(INSTALL_DATA) libhts.a $(DESTDIR)$(libdir)/libhts.a
-	$(INSTALL_DATA) -D libhts.pc $(DESTDIR)$(pkgconfigdir)/libhts.pc
+	$(INSTALL_DATA) -D htslib.pc $(DESTDIR)$(pkgconfigdir)/htslib.pc
 	$(INSTALL_DATA) *.1 $(DESTDIR)$(man1dir)
 	$(INSTALL_DATA) *.5 $(DESTDIR)$(man5dir)
 

--- a/htslib.pc.in
+++ b/htslib.pc.in
@@ -1,0 +1,7 @@
+Name: HTSLib
+Description: A high-thoughput sequencing handling library
+Version: @VERSION@
+Requires.private: zlib
+Libs: -L@LIBDIR@ -lhts
+Libs.private: -L@LIBDIR@ -lhts -lm -lpthread
+Cflags: -I@INCLUDEDIR@


### PR DESCRIPTION
Two changes are provided (which are somewhat dependent).
1. `libhts.so` makes use of `libm.so` and `libpthread.so`, but does not link against these libraries. When uses link against it, they must also include its dependencies, which is awkward. Linking against static library `libhts.a` for `bgzf` and `tabix` does not exhibit this problem because the linker discards all the unused object files, and so discards `kfunc.o` that needs `libm` and both include `-pthread`.
2. Pkg-Config is a popular method for linking against shared libraries. This provides the pkg-config description for consuming `libhts` using pkg-config macros in GNU AutoTools.
