### PR TITLE
Removal of bogus CRAM warnings.

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1963,7 +1963,7 @@ int cram_load_reference(cram_fd *fd, char *fn) {
     }
     fd->ref_fn = fn;
 
-    if (!fd->refs && fd->header) {
+    if ((!fd->refs || (fd->refs->nref == 0 && !fn)) && fd->header) {
 	if (!(fd->refs = refs_create()))
 	    return -1;
 	if (-1 == refs_from_header(fd->refs, fd, fd->header))


### PR DESCRIPTION
Removed bogus "Unable to find ref name"\* errors when converting a SAM
file UR:local/path/name syntax and without finding an MD5 reference to
use. The code previously went on to work fine as a subsequent refs2id
call worked.

This is avoided in Staden io_lib by the use of a scram_set_refs()
function which is called on the result of a scram_get_refs() call on a
SAM/BAM file, returning NULL and then resetting fd->refs to NULL.

We have no such call in HTSlib, but can resolve it by a smarter
implementation of cram_load_reference().
