### PR TITLE
CRAM to SAM/BAM now outputs NM/MD tags

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -155,7 +155,7 @@ htsFile *hts_open(const char *fn, const char *mode)
 	else if (fp->is_cram) {
 		fp->fp.cram = cram_dopen(hfile, fn, mode);
 		if (fp->fp.cram == NULL) goto error;
-		if (fp->is_write)
+		if (!fp->is_write)
 		    cram_set_option(fp->fp.cram, CRAM_OPT_DECODE_MD, 1);
 
 	}

--- a/test/test_view.pl
+++ b/test/test_view.pl
@@ -33,14 +33,14 @@ foreach my $sam (glob("*#*.sam")) {
     # SAM -> CRAM -> SAM
     test "./test_view -t $ref -S -C $sam > $cram";
     test "./test_view -D $cram > $cram.sam_";
-    test "./compare_sam.pl $sam $cram.sam_";
+    test "./compare_sam.pl -nomd $sam $cram.sam_";
 
     # BAM -> CRAM -> BAM -> SAM
     $cram = "$bam.cram";
     test "./test_view -t $ref -C $bam > $cram";
     test "./test_view -b -D $cram > $cram.bam";
     test "./test_view $cram.bam > $cram.bam.sam_";
-    test "./compare_sam.pl $sam $cram.bam.sam_";
+    test "./compare_sam.pl -nomd $sam $cram.bam.sam_";
 }
 
 print "\nSuccesses $suc_count\n";


### PR DESCRIPTION
See also the related pull request for samtools which is necessary to stop this change breaking "make check".
