### PR TITLE
hts_file_type: correct return of FT_VCF_GZ

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -417,7 +417,7 @@ int hts_file_type(const char *fname)
         if ( !fp ) return 0;
         if ( bgzf_read(fp, magic, 3)!=3 ) { bgzf_close(fp); return 0; }
         bgzf_close(fp);
-        if ( !strncmp((char*)magic,"##",2) ) return FT_VCF;
+        if ( !strncmp((char*)magic,"##",2) ) return FT_VCF_GZ;
         if ( !strncmp((char*)magic,"BCF",3) ) return FT_BCF_GZ;
     }
     return 0;


### PR DESCRIPTION
Actually I have 3 question about this function:
1. Can we remove the bits about detecting based on filetype extension? `.bcf` returns `FT_BCF_GZ` at the moment, but what if the file is uncompressed BCF? I noticed in a few recent issues that some are using the `.bcf.gz` convention for compressed and `.bcf` for uncompressed. Removing this detection should work with the cases I see in the codebase. Is performance the reason for having this in the first place? 
2. This is called `hts_file_type`, but is specific to VCF/BCF. Should it be in vcf.c/vcf.h and renamed `bcf_file_type`? Or is the intention that we could add in SAM/BAM/CRAM to this too?
3. Is there a way to check that the compression was with bgzip rather than gzip?
