### PR TITLE
Added the c++ macro __STDC_LIMIT_MACROS to all header files that include stdint.h to allow compilation in c++

### DIFF
--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -29,6 +29,12 @@
 #ifndef HTSLIB_BGZF_H
 #define HTSLIB_BGZF_H
 
+// inclusion of stdint.h needs the c++ macro __STDC_LIMIT_MACROS to be set because
+// some macros defined in c99 and made available in stdint.h are not part of c++11
+#ifdef __cplusplus
+#define __STDC_LIMIT_MACROS 1
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 #include <zlib.h>

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -26,6 +26,12 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef HTSLIB_HTS_H
 #define HTSLIB_HTS_H
 
+// inclusion of stdint.h needs the c++ macro __STDC_LIMIT_MACROS to be set because
+// some macros defined in c99 and made available in stdint.h are not part of c++11
+#ifdef __cplusplus
+#define __STDC_LIMIT_MACROS 1
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/htslib/knetfile.h
+++ b/htslib/knetfile.h
@@ -27,6 +27,12 @@
 #ifndef KNETFILE_H
 #define KNETFILE_H
 
+// inclusion of stdint.h needs the c++ macro __STDC_LIMIT_MACROS to be set because
+// some macros defined in c99 and made available in stdint.h are not part of c++11
+#ifdef __cplusplus
+#define __STDC_LIMIT_MACROS 1
+#endif
+
 #include <stdint.h>
 #include <fcntl.h>
 

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -26,6 +26,12 @@
 #ifndef KSTRING_H
 #define KSTRING_H
 
+// inclusion of stdint.h needs the c++ macro __STDC_LIMIT_MACROS to be set because
+// some macros defined in c99 and made available in stdint.h are not part of c++11
+#ifdef __cplusplus
+#define __STDC_LIMIT_MACROS 1
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -26,6 +26,12 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef HTSLIB_SAM_H
 #define HTSLIB_SAM_H
 
+// inclusion of stdint.h needs the c++ macro __STDC_LIMIT_MACROS to be set because
+// some macros defined in c99 and made available in stdint.h are not part of c++11
+#ifdef __cplusplus
+#define __STDC_LIMIT_MACROS 1
+#endif
+
 #include <stdint.h>
 #include "hts.h"
 

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -32,6 +32,12 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef HTSLIB_VCF_H
 #define HTSLIB_VCF_H
 
+// inclusion of stdint.h needs the c++ macro __STDC_LIMIT_MACROS to be set because
+// some macros defined in c99 and made available in stdint.h are not part of c++11
+#ifdef __cplusplus
+#define __STDC_LIMIT_MACROS 1
+#endif
+
 #include <stdint.h>
 #include <limits.h>
 #include <assert.h>


### PR DESCRIPTION
inclusion of stdint.h needs the c++ macro `__STDC_LIMIT_MACROS` to be set because some macros defined in c99 and made available in stdint.h are not part of c++11
