### PR TITLE
Fix for issue #119: System endiannes and unaligned memory access issues on mips 

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1068,10 +1068,17 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 	BLOCK_APPEND_CHAR(s->aux_blk, '\0'); // null terminate MD:Z:
 	cr->aux_size += BLOCK_SIZE(s->aux_blk) - orig_aux;
 	buf[0] = 'N'; buf[1] = 'M'; buf[2] = 'I';
+#ifdef SP_LITTLE_ENDIAN
 	buf[3] = (nm>> 0) & 0xff;
 	buf[4] = (nm>> 8) & 0xff;
 	buf[5] = (nm>>16) & 0xff;
 	buf[6] = (nm>>24) & 0xff;
+#else
+	buf[6] = (nm>> 0) & 0xff;
+	buf[5] = (nm>> 8) & 0xff;
+	buf[4] = (nm>>16) & 0xff;
+	buf[3] = (nm>>24) & 0xff;
+#endif
 	BLOCK_APPEND(s->aux_blk, buf, 7);
 	cr->aux_size += 7;
     }

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1801,10 +1801,18 @@ static char *cram_encode_aux_1_0(cram_fd *fd, bam_seq_t *b, cram_container *c,
 
 	case 'B': {
 	    int type = aux[3], blen;
+
+#ifdef SP_LITTLE_ENDIAN
 	    uint32_t count = (uint32_t)((((unsigned char *)aux)[4]<< 0) +
 					(((unsigned char *)aux)[5]<< 8) +
 					(((unsigned char *)aux)[6]<<16) +
 					(((unsigned char *)aux)[7]<<24));
+#else
+	    uint32_t count = (uint32_t)((((unsigned char *)aux)[7]<< 0) +
+					(((unsigned char *)aux)[6]<< 8) +
+					(((unsigned char *)aux)[5]<<16) +
+					(((unsigned char *)aux)[4]<<24));
+#endif
 	    // skip TN field
 	    aux+=3; //*tmp++=*aux++; *tmp++=*aux++; *tmp++=*aux++;
 
@@ -1949,10 +1957,18 @@ static char *cram_encode_aux(cram_fd *fd, bam_seq_t *b, cram_container *c,
 
 	case 'B': {
 	    int type = aux[3], blen;
+
+#ifdef SP_LITTLE_ENDIAN
 	    uint32_t count = (uint32_t)((((unsigned char *)aux)[4]<< 0) +
 					(((unsigned char *)aux)[5]<< 8) +
 					(((unsigned char *)aux)[6]<<16) +
 					(((unsigned char *)aux)[7]<<24));
+#else
+	    uint32_t count = (uint32_t)((((unsigned char *)aux)[7]<< 0) +
+					(((unsigned char *)aux)[6]<< 8) +
+					(((unsigned char *)aux)[5]<<16) +
+					(((unsigned char *)aux)[4]<<24));
+#endif
 	    // skip TN field
 	    aux+=3;
 

--- a/cram/os.h
+++ b/cram/os.h
@@ -88,8 +88,15 @@ extern "C" {
  * processor type too.
  */
 
-/* Set by autoconf */
-#define SP_LITTLE_ENDIAN
+#if !defined(SP_BIG_ENDIAN) && !defined(SP_LITTLE_ENDIAN)
+
+# if __BYTE_ORDER == __BIG_ENDIAN
+#   define SP_BIG_ENDIAN
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
+#   define SP_LITTLE_ENDIAN
+#endif
+
+#endif
 
 /* Mac FAT binaries or unknown. Auto detect based on CPU type */
 #if !defined(SP_BIG_ENDIAN) && !defined(SP_LITTLE_ENDIAN)


### PR DESCRIPTION
Note: This patch only fixes system endianness issues (fix for unaligned memory access issue will be submitted as soon as I'm done with it)
