### PR TITLE
Fix buffer read-past-end when loading CRAM indices

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -157,6 +157,7 @@ int cram_index_load(cram_fd *fd, const char *fn) {
 	kstr.l = l;
     }
 
+    kputc(0, &kstr); kstr.l--; // in order to make loop below work
 
     // Parse it line at a time
     do {


### PR DESCRIPTION
Force nul termination of the kstr holding the CRAM index so that sscanf doesn't attempt to check beyond the bounds of the string memory.

On correctly formatted indices it has no need to do this (but apparently does), but the fix is necessary anyway in order to be robust on invalid indices.

Fixes samtools/samtools#288
