### PR TITLE
Make hts_idx_push no longer return 0 after the first unmapped read. This...

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -708,10 +708,6 @@ int hts_idx_push(hts_idx_t *idx, int tid, int beg, int end, uint64_t offset, int
         idx->z.save_off = idx->z.last_off;
         idx->z.save_bin = idx->z.last_bin = bin;
         idx->z.save_tid = tid;
-        if (tid < 0) { // come to the end of the records having coordinates
-            hts_idx_finish(idx, offset);
-            return 0;
-        }
     }
     if (is_mapped) ++idx->z.n_mapped;
     else ++idx->z.n_unmapped;


### PR DESCRIPTION
This ends up being a fix for samtools issue #283, which is due to htslib created indexes.

Currently, hts_idx_push returns 0 after the first met unmapped alignment. This causes bam_index to immediately return and unmapped reads to essentially not be included in the resulting index. This ends up breaking the last line of samtools idxstats.

There are two alternative fixes. Firstly, samtools idxstats could be changed to not include unmapped reads. This, however, would be a change from previous versions that will likely break a few pipelines. The alternative would be to alter bam_index() to not return when hts_idx_push returns 0. Someone familiar with VCF/tabix indexing should review this to determine which is the better solution.
