### PR TITLE
vcf: separate header lookup from field getter

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -591,6 +591,17 @@ extern "C" {
     bcf_info_t *bcf_get_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key);
 
     /**
+     * bcf_get_*_id() - returns pointer to FORMAT/INFO field data given the header index instead of the string ID
+     * @line: VCF line obtained from vcf_parse1
+     * @id:  The header index for the tag, obtained from bcf_hdr_id2int()
+     * 
+     * Returns bcf_fmt_t* / bcf_info_t*. These functions do not check if the index is valid 
+     * as their goal is to avoid the header lookup.
+     */
+    bcf_fmt_t *bcf_get_fmt_id(bcf1_t *line, const int id);
+    bcf_info_t *bcf_get_info_id(bcf1_t *line, const int id);
+
+    /**
      *  bcf_get_info_*() - get INFO values, integers or floats
      *  @hdr:       BCF header
      *  @line:      BCF record

--- a/vcf.c
+++ b/vcf.c
@@ -2947,8 +2947,21 @@ int bcf_update_id(const bcf_hdr_t *hdr, bcf1_t *line, const char *id)
 
 bcf_fmt_t *bcf_get_fmt(const bcf_hdr_t *hdr, bcf1_t *line, const char *key)
 {
-    int i, id = bcf_hdr_id2int(hdr, BCF_DT_ID, key);
+    int id = bcf_hdr_id2int(hdr, BCF_DT_ID, key);
     if ( !bcf_hdr_idinfo_exists(hdr,BCF_HL_FMT,id) ) return NULL;   // no such FMT field in the header
+    return bcf_get_fmt_id(line, id);
+}
+
+bcf_info_t *bcf_get_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key)
+{
+    int id = bcf_hdr_id2int(hdr, BCF_DT_ID, key);
+    if ( !bcf_hdr_idinfo_exists(hdr,BCF_HL_INFO,id) ) return NULL;   // no such INFO field in the header
+    return bcf_get_info_id(line, id);
+}
+
+bcf_fmt_t *bcf_get_fmt_id(bcf1_t *line, const int id) 
+{
+    int i;
     if ( !(line->unpacked & BCF_UN_FMT) ) bcf_unpack(line, BCF_UN_FMT);
     for (i=0; i<line->n_fmt; i++)
     {
@@ -2957,10 +2970,9 @@ bcf_fmt_t *bcf_get_fmt(const bcf_hdr_t *hdr, bcf1_t *line, const char *key)
     return NULL;
 }
 
-bcf_info_t *bcf_get_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key)
+bcf_info_t *bcf_get_info_id(bcf1_t *line, const int id) 
 {
-    int i, id = bcf_hdr_id2int(hdr, BCF_DT_ID, key);
-    if ( !bcf_hdr_idinfo_exists(hdr,BCF_HL_INFO,id) ) return NULL;   // no such INFO field in the header
+    int i;
     if ( !(line->unpacked & BCF_UN_INFO) ) bcf_unpack(line, BCF_UN_INFO);
     for (i=0; i<line->n_info; i++)
     {
@@ -2968,6 +2980,7 @@ bcf_info_t *bcf_get_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key)
     }
     return NULL;
 }
+
 
 int bcf_get_info_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, void **dst, int *ndst, int type)
 {


### PR DESCRIPTION
Create two alternatives to bcf_get_info and bcf_get_fmt allowing the
user to query the header id for the tag once and then accessing the
fields directly using index lookups.  Modified the two existing
functions to use the index lookups so we don't repeat functionality.

Added the following functions to the public API:

``` c
bcf_get_fmt_id (bcf_t* line, const int id)
bcf_get_info_id (bcf_t* line, const int id)
```
