### PR TITLE
Buffer overflow error in synced_bcf_reader.c

### DIFF
--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -81,7 +81,7 @@ static int *init_filters(bcf_hdr_t *hdr, const char *filters, int *nfilters)
     {
         if ( *tmp==',' || !*tmp )
         {
-            out = (int*) realloc(out, sizeof(int));
+            out = (int*) realloc(out, (nout+1)*sizeof(int));
             if ( tmp-prev==1 && *prev=='.' )
                 out[nout] = -1;
             else


### PR DESCRIPTION
out is being accessed at location nout, so it should be at least size nout+1.
