### PR TITLE
Cigar P support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,8 @@ BUILT_TEST_PROGRAMS = \
 	test/test-regidx \
 	test/test_view \
 	test/test-vcf-api \
-	test/test-vcf-sweep
+	test/test-vcf-sweep \
+	test/pileup
 
 all: lib-static lib-shared $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS)
 
@@ -291,6 +292,9 @@ test/test-vcf-api: test/test-vcf-api.o libhts.a
 
 test/test-vcf-sweep: test/test-vcf-sweep.o libhts.a
 	$(CC) -pthread $(LDFLAGS) -o $@ test/test-vcf-sweep.o libhts.a $(LDLIBS) -lz
+
+test/pileup: test/pileup.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/pileup.o libhts.a $(LDLIBS) -lz
 
 test/fieldarith.o: test/fieldarith.c $(htslib_sam_h)
 test/hfile.o: test/hfile.c $(htslib_hfile_h) $(htslib_hts_defs_h)

--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -361,6 +361,9 @@ cram_index *cram_index_query(cram_fd *fd, int refid, int pos,
 	    continue;
 	}
     }
+    // i==j or i==j-1. Check if j is better.
+    if (from->e[j].start < pos && from->e[j].refid == refid)
+	i = j;
 
     /* The above found *a* bin overlapping, but not necessarily the first */
     while (i > 0 && from->e[i-1].end >= pos)

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -359,10 +359,11 @@ extern "C" {
  @field  indel      indel length; 0 for no indel, positive for ins and negative for del
  @field  level      the level of the read in the "viewer" mode
  @field  is_del     1 iff the base on the padded read is a deletion
- @field  is_head    ???
- @field  is_tail    ???
+ @field  is_head    1 iff this is the first base in the query sequence
+ @field  is_tail    1 iff this is the last base in the query sequence
  @field  is_refskip ???
  @field  aux        ???
+ @field  insertion  aligned contents of the inserted bases
 
  @discussion See also bam_plbuf_push() and bam_lplbuf_push(). The
  difference between the two functions is that the former does not
@@ -375,6 +376,7 @@ typedef struct {
     int32_t qpos;
     int indel, level;
     uint32_t is_del:1, is_head:1, is_tail:1, is_refskip:1, aux:28;
+    int cigar_ind;
 } bam_pileup1_t;
 
 typedef int (*bam_plp_auto_f)(void *data, bam1_t *b);
@@ -417,6 +419,14 @@ extern "C" {
     void bam_mplp_set_maxcnt(bam_mplp_t iter, int maxcnt);
     int bam_mplp_auto(bam_mplp_t iter, int *_tid, int *_pos, int *n_plp, const bam_pileup1_t **plp);
 
+    /*
+     * Fills out the kstring with the padded insertion sequence for the current
+     * location in 'p'.  If this is not an insertion site, the string is blank.
+     *
+     * Returns the length of insertion string on success;
+     *        -1 on failure.
+     */
+    int bam_plp_insertion(const bam_pileup1_t *p, kstring_t *ins);
 #ifdef __cplusplus
 }
 #endif

--- a/sam.c
+++ b/sam.c
@@ -1409,7 +1409,78 @@ static inline int resolve_cigar2(bam_pileup1_t *p, int32_t pos, cstate_t *s)
         } // cannot be other operations; otherwise a bug
         p->is_head = (pos == c->pos); p->is_tail = (pos == s->end);
     }
+    p->cigar_ind = s->k;
     return 1;
+}
+
+/*******************************
+ *** Expansion of insertions ***
+ *******************************/
+
+/*
+ * Fills out the kstring with the padded insertion sequence for the current
+ * location in 'p'.  If this is not an insertion site, the string is blank.
+ *
+ * Returns the length of insertion string on success;
+ *        -1 on failure.
+ */
+int bam_plp_insertion(const bam_pileup1_t *p, kstring_t *ins) {
+    int j, k, indel;
+    uint32_t *cigar;
+
+    if (p->indel <= 0) {
+        ks_resize(ins, 1);
+        ins->l = 0;
+        ins->s[0] = '\0';
+        return 0;
+    }
+
+    // Measure indel length including pads
+    indel = 0;
+    k = p->cigar_ind+1;
+    cigar = bam_get_cigar(p->b);
+    while (k < p->b->core.n_cigar) {
+        switch (cigar[k] & BAM_CIGAR_MASK) {
+        case BAM_CPAD:
+        case BAM_CINS:
+            indel += (cigar[k] >> BAM_CIGAR_SHIFT);
+            break;
+        default:
+            k = p->b->core.n_cigar;
+            break;
+        }
+        k++;
+    }
+    ins->l = indel;
+
+    // Produce sequence
+    ks_resize(ins, indel+1);
+    indel = 0;
+    k = p->cigar_ind+1;
+    j = 1;
+    while (k < p->b->core.n_cigar) {
+        int l, c;
+        switch (cigar[k] & BAM_CIGAR_MASK) {
+        case BAM_CPAD:
+            for (l = 0; l < (cigar[k]>>BAM_CIGAR_SHIFT); l++)
+                ins->s[indel++] = '*';
+            break;
+        case BAM_CINS:
+            for (l = 0; l < (cigar[k]>>BAM_CIGAR_SHIFT); l++, j++) {
+                c = seq_nt16_str[bam_seqi(bam_get_seq(p->b),
+                                          p->qpos + j - p->is_del)];
+                ins->s[indel++] = c;
+            }
+            break;
+        default:
+            k = p->b->core.n_cigar;
+            break;
+        }
+        k++;
+    }
+    ins->s[indel] = '\0';
+    
+    return indel;
 }
 
 /***********************

--- a/test/pileup.c
+++ b/test/pileup.c
@@ -1,0 +1,103 @@
+/*  test/pileup.c -- simple pileup tester
+
+    Copyright (C) 2014 Genome Research Ltd.
+
+    Author: James Bonfield <jkb@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <stdio.h>
+#include "htslib/sam.h"
+
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+typedef struct ptest_t {
+    samFile *fp;
+    bam_hdr_t *fp_hdr;
+} ptest_t;
+
+static int readaln(void *data, bam1_t *b) {
+    ptest_t *g = (ptest_t*)data;
+    int ret;
+
+    while (1) {
+	ret = sam_read1(g->fp, g->fp_hdr, b);
+	if (ret < 0) break;
+	if ( b->core.flag & (BAM_FUNMAP | BAM_FSECONDARY | BAM_FQCFAIL | BAM_FDUP) ) continue;
+	break;
+    }
+
+    return ret;
+}
+
+int main(int argc, char **argv) {
+    bam_plp_t plp;
+    const bam_pileup1_t *p;
+    int tid, pos, n;
+    ptest_t g;
+
+    if (argc != 2) {
+	fprintf(stderr, "Usage: pileup foo.bam\n");
+	return 1;
+    }
+
+    g.fp = sam_open(argv[1], "r");
+    g.fp_hdr = sam_hdr_read(g.fp);
+
+    plp = bam_plp_init(readaln, &g);
+    while ((p = bam_plp_auto(plp, &tid, &pos, &n)) != 0) {
+	int i;
+
+        if (tid < 0) break;
+
+	printf("%2d\t%6d\t", tid, pos+1);
+
+	for (i = 0; i < n; i++, p++) {
+            uint8_t *seq = bam_get_seq(p->b);
+	    if (p->is_head) 
+		putchar('^'), putchar('!'+MIN(p->b->core.qual,93));
+
+	    if (p->is_del)
+		putchar('*');
+	    else
+		putchar(seq_nt16_str[bam_seqi(seq, p->qpos)]);
+
+	    if (p->indel > 0) {
+		int j;
+		printf("%+d(", p->indel);
+		for (j = 1; j<=p->indel; j++)
+		    putchar(seq_nt16_str[bam_seqi(seq, p->qpos+j-p->is_del)]);
+		putchar(')');
+	    }
+	    if (p->indel < 0) {
+		printf("%+d(?)", p->indel);
+	    }
+	    if (p->is_tail)
+		putchar('$');
+	}
+
+	putchar('\n');
+    }
+    bam_plp_destroy(plp);
+
+    bam_hdr_destroy(g.fp_hdr);
+    sam_close(g.fp);
+
+    return 0;
+}


### PR DESCRIPTION
Adds a bam_plp_insertion() function that queries the cigar string to cope with multiple I and P operators, producing an aligned insertion sequence.
