### PR TITLE
Misc CRAM fixes (mainly unsorted data)

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1456,6 +1456,13 @@ int cram_byte_array_len_encode(cram_slice *slice, cram_codec *c,
 void cram_byte_array_len_encode_free(cram_codec *c) {
     if (!c)
 	return;
+
+    if (c->e_byte_array_len.len_codec)
+	c->e_byte_array_len.len_codec->free(c->e_byte_array_len.len_codec);
+
+    if (c->e_byte_array_len.val_codec)
+	c->e_byte_array_len.val_codec->free(c->e_byte_array_len.val_codec);
+
     free(c);
 }
 

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1238,10 +1238,8 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
 
     if (!fd->no_ref && c->refs_used) {
 	for (i = 0; i < nref; i++) {
-	    if (c->refs_used[i]) {	
+	    if (c->refs_used[i])
 		cram_get_ref(fd, i, 1, 0);
-		cram_ref_incr(fd->refs, i);
-	    }
 	}
     }
 
@@ -1325,6 +1323,11 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
 	    s->hdr->ref_seq_span  = last_base - first_base + 1;
 	}
 	s->hdr->num_records = r2;
+    }
+
+    if (c->multi_seq && !fd->no_ref) {
+	if (c->ref_seq_id >= 0)
+	    cram_ref_decr(fd->refs, c->ref_seq_id);
     }
 
     /* Link our bams[] array onto the spare bam list for reuse */

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -2961,7 +2961,7 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
 
 	// Have we seen this reference before?
 	if (bam_ref(b) >= 0 && bam_ref(b) != curr_ref && !fd->embed_ref &&
-	    !fd->unsorted) {
+	    !fd->unsorted && multi_seq) {
 	    
 	    if (!c->refs_used) {
 		pthread_mutex_lock(&fd->ref_lock);

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1233,10 +1233,11 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
     nref = fd->refs->nref;
     pthread_mutex_unlock(&fd->ref_lock);
 
-    if (c->refs_used) {
+    if (!fd->no_ref && c->refs_used) {
 	for (i = 0; i < nref; i++) {
 	    if (c->refs_used[i]) {	
 		cram_get_ref(fd, i, 1, 0);
+		cram_ref_incr(fd->refs, i);
 	    }
 	}
     }
@@ -1657,7 +1658,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
     }
 
     /* Cache references up-front if we have unsorted access patterns */
-    if (c->refs_used) {
+    if (!fd->no_ref && c->refs_used) {
 	for (i = 0; i < fd->refs->nref; i++) {
 	    if (c->refs_used[i])
 		cram_ref_decr(fd->refs, i);

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1199,8 +1199,11 @@ static int cram_encode_slice(cram_fd *fd, cram_container *c,
 	for (i = j = 1; i < DS_END; i++) {
 	    if (!s->block[i] || s->block[i] == s->block[0])
 		continue;
-	    if (s->block[i]->uncomp_size == 0)
+	    if (s->block[i]->uncomp_size == 0) {
+		cram_free_block(s->block[i]);
+		s->block[i] = NULL;
 		continue;
+	    }
 	    s->block[j] = s->block[i];
 	    s->hdr->block_content_ids[j-1] = s->block[i]->content_id;
 	    j++;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3802,7 +3802,7 @@ cram_fd *cram_dopen(hFILE *fp, const char *filename, const char *mode) {
     fd->use_bz2 = 0;
     fd->use_rans = (CRAM_MAJOR_VERS(fd->version) >= 3);
     fd->use_lzma = 0;
-    fd->multi_seq = 0;
+    fd->multi_seq = -1;
     fd->unsorted   = 0;
     fd->shared_ref = 0;
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2301,6 +2301,8 @@ char *cram_get_ref(cram_fd *fd, int id, int start, int end) {
 	    return NULL;
 	}
 	r = fd->refs->ref_id[id];
+	if (fd->unsorted)
+	    cram_ref_incr_locked(fd->refs, id);
     }
 
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2060,10 +2060,8 @@ static void cram_ref_decr_locked(refs_t *r, int id) {
 		r->ref_id[r->last_id]->seq = NULL;
 		r->ref_id[r->last_id]->length = 0;
 	    }
-	    r->last_id = -1;
-	} else {
-	    r->last_id = id;
 	}
+	r->last_id = id;
     }
 }
 

--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -356,7 +356,7 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
 
 unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
 				unsigned int *out_size) {
-    unsigned char *out_buf = malloc(1.05*in_size + 257*257*3 + 9);
+    unsigned char *out_buf;
     unsigned char *cp = out_buf, *out_end;
     unsigned int last_i, tab_size, rle_i, rle_j;
     RansEncSymbol syms[256][256];
@@ -364,6 +364,7 @@ unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
     if (in_size < 4)
 	return rans_compress_O0(in, in_size, out_size);
 
+    out_buf = malloc(1.05*in_size + 257*257*3 + 9);
     if (!out_buf)
 	return NULL;
 


### PR DESCRIPTION
CRAM supported unsorted data OK, but wasn't so well optimised.  Sometimes it deremented the reference sequence ref-counters too early, causing it to have to reload the same sequence file multiple times.  Other times it didn't decrement them early enough, causing it to fail to free memory at an appropriate time (it did on file close instead).

In the process of testing it all under valgrind, I also found and fixed a couple small but genuine memory leaks.