### PR TITLE
Fixes imported from Staden io_lib revisions 3792/3795.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1689,10 +1689,13 @@ static void cram_decode_slice_xref(cram_slice *s) {
 		    int aleft = cr->apos, aright = cr->aend;
 		    int tlen;
 		    int ref = cr->ref_id;
+		    int left_cnt = 0;
 
 		    do {
 			if (aleft > s->crecs[id2].apos)
-			    aleft = s->crecs[id2].apos;
+			    aleft = s->crecs[id2].apos, left_cnt = 1;
+			else if (aleft == s->crecs[id2].apos)
+			    left_cnt++;
 			if (aright < s->crecs[id2].aend)
 			    aright = s->crecs[id2].aend;
 			if (s->crecs[id2].mate_line == -1) {
@@ -1716,9 +1719,8 @@ static void cram_decode_slice_xref(cram_slice *s) {
 			 * bit flags instead, as a tie breaker.
 			 */
 			if (s->crecs[id2].apos == aleft) {
-			    if (s->crecs[id2].aend != aright)
-				s->crecs[id2].tlen = tlen;
-			    else if (s->crecs[id2].flags & BAM_FREAD1)
+			    if (left_cnt == 1 || 
+				(s->crecs[id2].flags & BAM_FREAD1))
 				s->crecs[id2].tlen = tlen;
 			    else
 				s->crecs[id2].tlen = -tlen;
@@ -1729,9 +1731,8 @@ static void cram_decode_slice_xref(cram_slice *s) {
 			id2 = s->crecs[id2].mate_line;
 			while (id2 != id1) {
 			    if (s->crecs[id2].apos == aleft) {
-				if (s->crecs[id2].aend != aright)
-				    s->crecs[id2].tlen = tlen;
-				else if (s->crecs[id2].flags & BAM_FREAD1)
+				if (left_cnt == 1 || 
+				    (s->crecs[id2].flags & BAM_FREAD1))
 				    s->crecs[id2].tlen = tlen;
 				else
 				    s->crecs[id2].tlen = -tlen;

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1689,6 +1689,8 @@ static void cram_decode_slice_xref(cram_slice *s) {
 		    int aleft = cr->apos, aright = cr->aend;
 		    int tlen;
 		    int ref = cr->ref_id;
+
+		    // number of segments starting at the same point.
 		    int left_cnt = 0;
 
 		    do {

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -2817,7 +2817,6 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 	    //fprintf(stderr, "paired %"PRId64"\n", kh_val(s->pair[sec], k));
 
 	    // This vs p: tlen, matepos, flags
-	    //if (bam_ins_size(b) != -(cr->aend - p->apos + 1)) {
 	    if (bam_ins_size(b) != sign*(aright-aleft+1))
 		goto detached;
 
@@ -2834,7 +2833,6 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 
 
 	    // p vs this: tlen, matepos, flags
-	    //if (p->tlen != cr->aend - p->apos + 1) {
 	    if (p->tlen != -sign*(aright-aleft+1))
 		goto detached;
 
@@ -2854,35 +2852,38 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 		(p->flags & BAM_FSUPPLEMENTARY))
 		goto detached;
 
-	    // copy from p to cr
+	    /*
+	     * The fields below are unused when encoding this read as it is
+	     * no longer detached.  In theory they may get referred to when
+	     * processing a 3rd or 4th read in this template?, so we set them
+	     * here just to be sure.
+	     *
+	     * They do not need cram_stats_add() calls those as they are
+	     * not emitted.
+	     */
 	    cr->mate_pos = p->apos;
-	    cram_stats_add(c->stats[DS_NP], cr->mate_pos);
-
-	    cr->tlen = cr->aend - p->apos;
-	    cram_stats_add(c->stats[DS_TS], cr->tlen);
-
+	    cr->tlen = sign*(aright-aleft+1);
 	    cr->mate_flags =
-		((p->flags & BAM_FMUNMAP)   == BAM_FMUNMAP)   * CRAM_M_UNMAP +
-		((p->flags & BAM_FMREVERSE) == BAM_FMREVERSE) * CRAM_M_REVERSE;
-	    cram_stats_add(c->stats[DS_MF], cr->mate_flags);
+	    	((p->flags & BAM_FMUNMAP)   == BAM_FMUNMAP)   * CRAM_M_UNMAP +
+	    	((p->flags & BAM_FMREVERSE) == BAM_FMREVERSE) * CRAM_M_REVERSE;
 
-	    // copy from cr to p
+	    // Decrement statistics aggregated earlier
 	    cram_stats_del(c->stats[DS_NP], p->mate_pos);
-	    p->mate_pos = cr->apos;
-	    cram_stats_add(c->stats[DS_NP], p->mate_pos);
-
 	    cram_stats_del(c->stats[DS_MF], p->mate_flags);
-	    p->mate_flags =
-		((cr->flags & BAM_FMUNMAP)   == BAM_FMUNMAP)  * CRAM_M_UNMAP +
-		((cr->flags & BAM_FMREVERSE) == BAM_FMREVERSE)* CRAM_M_REVERSE;
-	    cram_stats_add(c->stats[DS_MF], p->mate_flags);
-
 	    cram_stats_del(c->stats[DS_TS], p->tlen);
+	    cram_stats_del(c->stats[DS_NS], p->mate_ref_id);
+
+	    /* Similarly we could correct the p-> values too, but these will no
+	     * longer have any code that refers back to them as the new 'p'
+	     * for this template is our current 'cr'.
+	     */
+	    //p->mate_pos = cr->apos;
+	    //p->mate_flags =
+	    //	((cr->flags & BAM_FMUNMAP)   == BAM_FMUNMAP)  * CRAM_M_UNMAP +
+	    //	((cr->flags & BAM_FMREVERSE) == BAM_FMREVERSE)* CRAM_M_REVERSE;
 	    //p->tlen = p->apos - cr->aend;
-	    //cram_stats_add(c->stats[DS_TS], p->tlen);
 
 	    // Clear detached from cr flags
-	    //cram_stats_del(c->stats[DS_CF], cr->cram_flags);
 	    cr->cram_flags &= ~CRAM_FLAG_DETACHED;
 	    cram_stats_add(c->stats[DS_CF], cr->cram_flags);
 
@@ -2917,6 +2918,7 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 
 	    cr->cram_flags |= CRAM_FLAG_DETACHED;
 	    cram_stats_add(c->stats[DS_CF], cr->cram_flags);
+	    cram_stats_add(c->stats[DS_NS], bam_mate_ref(b));
 	}
     }
 
@@ -2924,7 +2926,6 @@ static int process_one_read(cram_fd *fd, cram_container *c,
     cram_stats_add(c->stats[DS_MQ], cr->mqual);
 
     cr->mate_ref_id = bam_mate_ref(b);
-    cram_stats_add(c->stats[DS_NS], cr->mate_ref_id);
 
     if (!(bam_flag(b) & BAM_FUNMAP)) {
 	if (c->first_base > cr->apos)


### PR DESCRIPTION
Bug fix the TLEN decoding sign.  It wasn't correctly handling the case
when two reads start at the same coordinate.

Overhauled the pnext/tlen/flags for detached reads.

Now when we find a second (or more) copy of a read within a slice, we
do not automatically mark is as non-detached.  We check whether the
derived fields match those found in the file and if not we emit a
"detached" read causing these fields to be written verbatim.  We also
do this if the data is supplementary, as the meaning of that flag is
poorly defined.

This is particularly useful on bwa-mem output where there is currently
a disparity between bwa and io_lib on the interpretation of
supplementary/primary.

PS. Sorry about the gotos! However they are pretty clear.

Also in time this may be better done by a complete reorganisation of the process_one_read() function, breaking it into two parts, gathering data and then encoding the data.  This could allow for shared use of the decoding (cram_decode_xref or similar?) function that resolves tlen, pnext, etc so we can check with the actual same code rather than a quick and dirty replication of it here.  Time is of the essence though!