### PR TITLE
Enforce the use of a local cache when using EBI.

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1900,19 +1900,19 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
     if (fd->verbose)
 	fprintf(stderr, "cram_populate_ref on fd %p, id %d\n", fd, id);
 
-    if (!ref_path || *ref_path == 0) {
+    if (!ref_path || *ref_path == '\0') {
 	/*
 	 * If we have no ref path, we use the EBI server.
 	 * However to avoid spamming it we require a local ref cache too.
 	 */
 	ref_path = "http://www.ebi.ac.uk:80/ena/cram/md5/%s";
-	if (!local_cache || !*local_cache) {
+	if (!local_cache || *local_cache == '\0') {
 	    char *home = getenv("HOME");
-	    if (!home || !*home) {
+	    if (!home || *home == '\0') {
 		home = getenv("TMPDIR");
-		if (!home || !*home) {
+		if (!home || *home == '\0') {
 		    home = getenv("TEMP");
-		    if (!home || !*home)
+		    if (!home || *home == '\0')
 			home = "/tmp";
 		}
 	    }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1923,7 +1923,7 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
 		snprintf(cache, PATH_MAX, "%s/hts-ref/%%2s/%%2s/%%s", home);
 	    }
 	    local_cache = cache;
-	    if (fd->verbose || 1)
+	    if (fd->verbose)
 		fprintf(stderr, "Populating local cache: %s\n", local_cache);
 	}
     }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1893,15 +1893,29 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
     char *ref_path = getenv("REF_PATH");
     SAM_hdr_type *ty;
     SAM_hdr_tag *tag;
-    char path[PATH_MAX], path_tmp[PATH_MAX];
+    char path[PATH_MAX], path_tmp[PATH_MAX], cache[PATH_MAX];
     char *local_cache = getenv("REF_CACHE");
     mFILE *mf;
 
     if (fd->verbose)
 	fprintf(stderr, "cram_populate_ref on fd %p, id %d\n", fd, id);
 
-    if (!ref_path || *ref_path == 0)
+    if (!ref_path || *ref_path == 0) {
+	/*
+	 * If we have no ref path, we use the EBI server.
+	 * However to avoid spamming it we require a local ref cache too.
+	 */
 	ref_path = "http://www.ebi.ac.uk:80/ena/cram/md5/%s";
+	if (!local_cache || !*local_cache) {
+	    char *home = getenv("HOME");
+	    if (!home)
+		home = "/tmp";
+	    snprintf(cache, PATH_MAX, "%s/.cram_cache/%%2s/%%2s/%%s", home);
+	    local_cache = cache;
+	    if (fd->verbose)
+		fprintf(stderr, "Populating local cache: %s\n", local_cache);
+	}
+    }
 
     if (!r->name)
 	return -1;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1908,9 +1908,15 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
 	ref_path = "http://www.ebi.ac.uk:80/ena/cram/md5/%s";
 	if (!local_cache || !*local_cache) {
 	    char *home = getenv("HOME");
-	    if (!home)
-		home = "/tmp";
-	    snprintf(cache, PATH_MAX, "%s/.cram_cache/%%2s/%%2s/%%s", home);
+	    if (!home || !*home) {
+		home = getenv("TMPDIR");
+		if (!home || !*home) {
+		    home = getenv("TEMP");
+		    if (!home || !*home)
+			home = "/tmp";
+		}
+	    }
+	    snprintf(cache, PATH_MAX, "%s/.cache/genome-ref/%%2s/%%2s/%%s", home);
 	    local_cache = cache;
 	    if (fd->verbose)
 		fprintf(stderr, "Populating local cache: %s\n", local_cache);

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1907,18 +1907,23 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
 	 */
 	ref_path = "http://www.ebi.ac.uk:80/ena/cram/md5/%s";
 	if (!local_cache || *local_cache == '\0') {
-	    char *home = getenv("HOME");
+	    char *home = getenv("XDG_CACHE_HOME");
 	    if (!home || *home == '\0') {
-		home = getenv("TMPDIR");
+		home = getenv("HOME");
 		if (!home || *home == '\0') {
-		    home = getenv("TEMP");
-		    if (!home || *home == '\0')
-			home = "/tmp";
+		    home = getenv("TMPDIR");
+		    if (!home || *home == '\0') {
+			home = getenv("TEMP");
+			if (!home || *home == '\0')
+			    home = "/tmp";
+		    }
 		}
+		snprintf(cache, PATH_MAX, "%s/.cache/hts-ref/%%2s/%%2s/%%s", home);
+	    } else {
+		snprintf(cache, PATH_MAX, "%s/hts-ref/%%2s/%%2s/%%s", home);
 	    }
-	    snprintf(cache, PATH_MAX, "%s/.cache/genome-ref/%%2s/%%2s/%%s", home);
 	    local_cache = cache;
-	    if (fd->verbose)
+	    if (fd->verbose || 1)
 		fprintf(stderr, "Populating local cache: %s\n", local_cache);
 	}
     }


### PR DESCRIPTION
Enforce the use of a local cache (use home dir if not defined)
whenever we automatically fall back to using the EBI reference
sequence server.

It is still possible for a user to manually set REF_PATH to the EBI
while not manually setting REF_CACHE, but in such situations the user
is taking responsibility for manual control.