### PR TITLE
Parsing scientific notation as integers

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -1,6 +1,6 @@
 /*  hts.c -- format-neutral I/O, indexing, and iterator API functions.
 
-    Copyright (C) 2008, 2009, 2012-2014 Genome Research Ltd.
+    Copyright (C) 2008, 2009, 2012-2015 Genome Research Ltd.
     Copyright (C) 2012, 2013 Broad Institute.
 
     Author: Heng Li <lh3@sanger.ac.uk>
@@ -1351,59 +1351,96 @@ void hts_itr_destroy(hts_itr_t *iter)
     if (iter) { free(iter->off); free(iter->bins.a); free(iter); }
 }
 
-int hts_parse_decimal(const char *str, char **end)
+static inline long long push_digit(long long i, char c)
 {
-    char *s;
-    int i = strtol(str, &s, 10);
-    if (*s == '.' || *s == 'e' || *s == 'E') i = strtod(str, &s);
-    *end = s;
-    return i;
+    // ensure subtraction occurs first, avoiding overflow for >= MAX-48 or so
+    int digit = c - '0';
+    return 10 * i + digit;
+}
+
+long long hts_parse_decimal(const char *str, char **end)
+{
+    long long n = 0;
+    int decimals = 0, e = 0, lost = 0;
+    char sign = '+', esign = '+';
+    const char *s;
+
+    while (isspace(*str)) str++;
+    s = str;
+
+    if (*s == '+' || *s == '-') sign = *s++;
+    while (*s)
+        if (isdigit(*s)) n = push_digit(n, *s++);
+        else if (*s == ',') s++;
+        else break;
+
+    if (*s == '.') {
+        s++;
+        while (isdigit(*s)) decimals++, n = push_digit(n, *s++);
+    }
+
+    if (*s == 'E' || *s == 'e') {
+        s++;
+        if (*s == '+' || *s == '-') esign = *s++;
+        while (isdigit(*s)) e = push_digit(e, *s++);
+        if (esign == '-') e = -e;
+    }
+
+    e -= decimals;
+    while (e > 0) n *= 10, e--;
+    while (e < 0) lost += n % 10, n /= 10, e++;
+
+    if (lost > 0 && hts_verbose >= 3)
+        fprintf(stderr, "[W::%s] discarding fractional part of %.*s\n",
+                __func__, (int)(s - str), str);
+
+    if (end) *end = (char *) s;
+    else if (*s && hts_verbose >= 2)
+        fprintf(stderr, "[W::%s] ignoring unknown characters after %.*s[%s]\n",
+                __func__, (int)(s - str), str, s);
+
+    return (sign == '+')? n : -n;
 }
 
 const char *hts_parse_reg(const char *s, int *beg, int *end)
 {
-    int i, k, l, name_end;
-    *beg = *end = -1;
-    name_end = l = strlen(s);
-    // determine the sequence name
-    for (i = l - 1; i >= 0; --i) if (s[i] == ':') break; // look for colon from the end
-    if (i >= 0) name_end = i;
-    if (name_end < l) { // check if this is really the end
-        int n_hyphen = 0;
-        for (i = name_end + 1; i < l; ++i) {
-            if (s[i] == '-') ++n_hyphen;
-            else if (!isdigit(s[i]) && s[i] != ',' && s[i]!='.' && s[i]!='e' && s[i]!='E' ) break;
-        }
-        if (i < l || n_hyphen > 1) name_end = l; // malformated region string; then take str as the name
+    char *hyphen;
+    const char *colon = strrchr(s, ':');
+    if (colon == NULL) {
+        *beg = 0; *end = INT_MAX;
+        return s + strlen(s);
     }
-    // parse the interval
-    if (name_end < l) {
-        char *tmp;
-        tmp = (char*)alloca(l - name_end + 1);
-        for (i = name_end + 1, k = 0; i < l; ++i)
-            if (s[i] != ',') tmp[k++] = s[i];
-        tmp[k] = 0;
-        if ((*beg = hts_parse_decimal(tmp, &tmp) - 1) < 0) *beg = 0;
-        *end = *tmp? hts_parse_decimal(tmp + 1, &tmp) : INT_MAX;
-        if (*beg > *end) name_end = l;
-    }
-    if (name_end == l) *beg = 0, *end = INT_MAX;
-    return s + name_end;
+
+    *beg = hts_parse_decimal(colon+1, &hyphen) - 1;
+    if (*beg < 0) *beg = 0;
+
+    if (*hyphen == '\0') *end = INT_MAX;
+    else if (*hyphen == '-') *end = hts_parse_decimal(hyphen+1, NULL);
+    else return NULL;
+
+    if (*beg >= *end) return NULL;
+    return colon;
 }
 
 hts_itr_t *hts_itr_querys(const hts_idx_t *idx, const char *reg, hts_name2id_f getid, void *hdr, hts_itr_query_func *itr_query, hts_readrec_func *readrec)
 {
     int tid, beg, end;
-    char *q, *tmp;
+    const char *q;
     if (strcmp(reg, ".") == 0)
         return itr_query(idx, HTS_IDX_START, 0, 0, readrec);
     else if (strcmp(reg, "*") != 0) {
-        q = (char*)hts_parse_reg(reg, &beg, &end);
-        tmp = (char*)alloca(q - reg + 1);
-        strncpy(tmp, reg, q - reg);
-        tmp[q - reg] = 0;
-        if ((tid = getid(hdr, tmp)) < 0)
+        q = hts_parse_reg(reg, &beg, &end);
+        if (q) {
+            char *tmp = (char*)alloca(q - reg + 1);
+            strncpy(tmp, reg, q - reg);
+            tmp[q - reg] = 0;
+            tid = getid(hdr, tmp);
+        }
+        else {
+            // not parsable as a region, but possibly a sequence named "foo:a"
             tid = getid(hdr, reg);
+            beg = 0; end = INT_MAX;
+        }
         if (tid < 0) return 0;
         return itr_query(idx, tid, beg, end, readrec);
     } else return itr_query(idx, HTS_IDX_NOCOOR, 0, 0, readrec);

--- a/hts.c
+++ b/hts.c
@@ -1351,6 +1351,15 @@ void hts_itr_destroy(hts_itr_t *iter)
     if (iter) { free(iter->off); free(iter->bins.a); free(iter); }
 }
 
+int hts_parse_decimal(const char *str, char **end)
+{
+    char *s;
+    int i = strtol(str, &s, 10);
+    if (*s == '.' || *s == 'e' || *s == 'E') i = strtod(str, &s);
+    *end = s;
+    return i;
+}
+
 const char *hts_parse_reg(const char *s, int *beg, int *end)
 {
     int i, k, l, name_end;
@@ -1374,8 +1383,8 @@ const char *hts_parse_reg(const char *s, int *beg, int *end)
         for (i = name_end + 1, k = 0; i < l; ++i)
             if (s[i] != ',') tmp[k++] = s[i];
         tmp[k] = 0;
-        if ((*beg = strtod(tmp, &tmp) - 1) < 0) *beg = 0;
-        *end = *tmp? strtod(tmp + 1, &tmp) : INT_MAX;
+        if ((*beg = hts_parse_decimal(tmp, &tmp) - 1) < 0) *beg = 0;
+        *end = *tmp? hts_parse_decimal(tmp + 1, &tmp) : INT_MAX;
         if (*beg > *end) name_end = l;
     }
     if (name_end == l) *beg = 0, *end = INT_MAX;

--- a/hts.c
+++ b/hts.c
@@ -1363,7 +1363,7 @@ const char *hts_parse_reg(const char *s, int *beg, int *end)
         int n_hyphen = 0;
         for (i = name_end + 1; i < l; ++i) {
             if (s[i] == '-') ++n_hyphen;
-            else if (!isdigit(s[i]) && s[i] != ',') break;
+            else if (!isdigit(s[i]) && s[i] != ',' && s[i]!='.' && s[i]!='e' && s[i]!='E' ) break;
         }
         if (i < l || n_hyphen > 1) name_end = l; // malformated region string; then take str as the name
     }
@@ -1374,8 +1374,8 @@ const char *hts_parse_reg(const char *s, int *beg, int *end)
         for (i = name_end + 1, k = 0; i < l; ++i)
             if (s[i] != ',') tmp[k++] = s[i];
         tmp[k] = 0;
-        if ((*beg = strtol(tmp, &tmp, 10) - 1) < 0) *beg = 0;
-        *end = *tmp? strtol(tmp + 1, &tmp, 10) : INT_MAX;
+        if ((*beg = strtod(tmp, &tmp) - 1) < 0) *beg = 0;
+        *end = *tmp? strtod(tmp + 1, &tmp) : INT_MAX;
         if (*beg > *end) name_end = l;
     }
     if (name_end == l) *beg = 0, *end = INT_MAX;

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -363,6 +363,9 @@ extern "C" {
     int hts_idx_get_stat(const hts_idx_t* idx, int tid, uint64_t* mapped, uint64_t* unmapped);
     uint64_t hts_idx_get_n_no_coor(const hts_idx_t* idx);
 
+    // strtol(str,end,10), or strtod(str,end) if scientific notation is present
+    int hts_parse_decimal(const char *str, char **end);
+
     const char *hts_parse_reg(const char *s, int *beg, int *end);
     hts_itr_t *hts_itr_query(const hts_idx_t *idx, int tid, int beg, int end, hts_readrec_func *readrec);
     void hts_itr_destroy(hts_itr_t *iter);

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -1,6 +1,6 @@
 /*  hts.h -- format-neutral I/O, indexing, and iterator API functions.
 
-    Copyright (C) 2012-2014 Genome Research Ltd.
+    Copyright (C) 2012-2015 Genome Research Ltd.
     Copyright (C) 2012 Broad Institute.
 
     Author: Heng Li <lh3@sanger.ac.uk>
@@ -363,10 +363,28 @@ extern "C" {
     int hts_idx_get_stat(const hts_idx_t* idx, int tid, uint64_t* mapped, uint64_t* unmapped);
     uint64_t hts_idx_get_n_no_coor(const hts_idx_t* idx);
 
-    // strtol(str,end,10), or strtod(str,end) if scientific notation is present
-    int hts_parse_decimal(const char *str, char **end);
+/// Parse a numeric string
+/** The number may be expressed in scientific notation, and may contain commas
+    in the integer part (before any decimal point or E notation).
+    @param str  String to be parsed
+    @param end  If non-NULL, set on return to point to the first character
+                in @a str after those forming the parsed number
+    @return  Converted value of the parsed number.
 
-    const char *hts_parse_reg(const char *s, int *beg, int *end);
+    When @a end is NULL, a warning will be printed (if hts_verbose is 2
+    or more) if there are any trailing characters after the number.
+*/
+long long hts_parse_decimal(const char *str, char **end);
+
+/// Parse a "CHR:START-END"-style region string
+/** @param str  String to be parsed
+    @param beg  Set on return to the 0-based start of the region
+    @param end  Set on return to the 1-based end of the region
+    @return  Pointer to the colon or '\0' after the reference sequence name,
+             or NULL if @a str could not be parsed.
+*/
+const char *hts_parse_reg(const char *str, int *beg, int *end);
+
     hts_itr_t *hts_itr_query(const hts_idx_t *idx, int tid, int beg, int end, hts_readrec_func *readrec);
     void hts_itr_destroy(hts_itr_t *iter);
 

--- a/regidx.c
+++ b/regidx.c
@@ -295,11 +295,11 @@ int regidx_parse_bed(const char *line, char **chr_beg, char **chr_end, reg_t *re
     *chr_end = se-1;
 
     ss = se+1;
-    reg->start = strtol(ss, &se, 10);
+    reg->start = strtod(ss, &se);
     if ( ss==se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
 
     ss = se+1;
-    reg->end = strtol(ss, &se, 10) - 1;
+    reg->end = strtod(ss, &se) - 1;
     if ( ss==se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
     
     return 0;
@@ -320,7 +320,7 @@ int regidx_parse_tab(const char *line, char **chr_beg, char **chr_end, reg_t *re
     *chr_end = se-1;
 
     ss = se+1;
-    reg->start = strtol(ss, &se, 10) - 1;
+    reg->start = strtod(ss, &se) - 1;
     if ( ss==se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
 
     if ( !se[0] || !se[1] )
@@ -328,7 +328,7 @@ int regidx_parse_tab(const char *line, char **chr_beg, char **chr_end, reg_t *re
     else
     {
         ss = se+1;
-        reg->end = strtol(ss, &se, 10);
+        reg->end = strtod(ss, &se);
         if ( ss==se ) reg->end = reg->start;
         else reg->end--;
     }

--- a/regidx.c
+++ b/regidx.c
@@ -295,11 +295,11 @@ int regidx_parse_bed(const char *line, char **chr_beg, char **chr_end, reg_t *re
     *chr_end = se-1;
 
     ss = se+1;
-    reg->start = strtod(ss, &se);
+    reg->start = hts_parse_decimal(ss, &se);
     if ( ss==se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
 
     ss = se+1;
-    reg->end = strtod(ss, &se) - 1;
+    reg->end = hts_parse_decimal(ss, &se) - 1;
     if ( ss==se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
     
     return 0;
@@ -320,7 +320,7 @@ int regidx_parse_tab(const char *line, char **chr_beg, char **chr_end, reg_t *re
     *chr_end = se-1;
 
     ss = se+1;
-    reg->start = strtod(ss, &se) - 1;
+    reg->start = hts_parse_decimal(ss, &se) - 1;
     if ( ss==se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
 
     if ( !se[0] || !se[1] )
@@ -328,7 +328,7 @@ int regidx_parse_tab(const char *line, char **chr_beg, char **chr_end, reg_t *re
     else
     {
         ss = se+1;
-        reg->end = strtod(ss, &se);
+        reg->end = hts_parse_decimal(ss, &se);
         if ( ss==se ) reg->end = reg->start;
         else reg->end--;
     }

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -402,6 +402,7 @@ static int _reader_seek(bcf_sr_t *reader, const char *seq, int start, int end)
         if ( tid==-1 ) return -1;    // the sequence not present in this file
         reader->itr = bcf_itr_queryi(reader->bcf_idx,tid,start,end+1);
     }
+    if ( !reader->itr ) fprintf(stderr,"Could not seek: %s:%d-%d\n",seq,start+1,end+1);
     assert(reader->itr);
     return 0;
 }
@@ -872,7 +873,7 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
         if ( *ep==':' )
         {
             sp = ep+1;
-            from = strtol(sp,(char**)&ep,10);
+            from = strtod(sp,(char**)&ep);
             if ( sp==ep )
             {
                 fprintf(stderr,"[%s:%d %s] Could not parse the region(s): %s\n", __FILE__,__LINE__,__FUNCTION__,str);
@@ -891,7 +892,7 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
             }
             ep++;
             sp = ep;
-            to = strtol(sp,(char**)&ep,10);
+            to = strtod(sp,(char**)&ep);
             if ( *ep && *ep!=',' )
             {
                 fprintf(stderr,"[%s:%d %s] Could not parse the region(s): %s\n", __FILE__,__LINE__,__FUNCTION__,str);
@@ -938,15 +939,15 @@ static int _regions_parse_line(char *line, int ichr,int ifrom,int ito, char **ch
     if ( i<=k ) return -1;
     if ( k==l )
     {
-        *from = *to = strtol(ss, &tmp, 10);
+        *from = *to = strtod(ss, &tmp);
         if ( tmp==ss ) return -1;
     }
     else
     {
         if ( k==ifrom )
-            *from = strtol(ss, &tmp, 10);
+            *from = strtod(ss, &tmp);
         else
-            *to = strtol(ss, &tmp, 10);
+            *to = strtod(ss, &tmp);
         if ( ss==tmp ) return -1;
 
         for (i=k; i<l && *se; i++)
@@ -956,9 +957,9 @@ static int _regions_parse_line(char *line, int ichr,int ifrom,int ito, char **ch
         }
         if ( i<l ) return -1;
         if ( k==ifrom )
-            *to = strtol(ss, &tmp, 10);
+            *to = strtod(ss, &tmp);
         else
-            *from = strtol(ss, &tmp, 10);
+            *from = strtod(ss, &tmp);
         if ( ss==tmp ) return -1;
     }
 

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -873,7 +873,7 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
         if ( *ep==':' )
         {
             sp = ep+1;
-            from = strtod(sp,(char**)&ep);
+            from = hts_parse_decimal(sp,(char**)&ep);
             if ( sp==ep )
             {
                 fprintf(stderr,"[%s:%d %s] Could not parse the region(s): %s\n", __FILE__,__LINE__,__FUNCTION__,str);
@@ -892,7 +892,7 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
             }
             ep++;
             sp = ep;
-            to = strtod(sp,(char**)&ep);
+            to = hts_parse_decimal(sp,(char**)&ep);
             if ( *ep && *ep!=',' )
             {
                 fprintf(stderr,"[%s:%d %s] Could not parse the region(s): %s\n", __FILE__,__LINE__,__FUNCTION__,str);
@@ -939,15 +939,15 @@ static int _regions_parse_line(char *line, int ichr,int ifrom,int ito, char **ch
     if ( i<=k ) return -1;
     if ( k==l )
     {
-        *from = *to = strtod(ss, &tmp);
+        *from = *to = hts_parse_decimal(ss, &tmp);
         if ( tmp==ss ) return -1;
     }
     else
     {
         if ( k==ifrom )
-            *from = strtod(ss, &tmp);
+            *from = hts_parse_decimal(ss, &tmp);
         else
-            *to = strtod(ss, &tmp);
+            *to = hts_parse_decimal(ss, &tmp);
         if ( ss==tmp ) return -1;
 
         for (i=k; i<l && *se; i++)
@@ -957,9 +957,9 @@ static int _regions_parse_line(char *line, int ichr,int ifrom,int ito, char **ch
         }
         if ( i<l ) return -1;
         if ( k==ifrom )
-            *to = strtod(ss, &tmp);
+            *to = hts_parse_decimal(ss, &tmp);
         else
-            *from = strtod(ss, &tmp);
+            *from = hts_parse_decimal(ss, &tmp);
         if ( ss==tmp ) return -1;
     }
 

--- a/tabix.c
+++ b/tabix.c
@@ -411,6 +411,7 @@ int main(int argc, char *argv[])
         {0,0,0,0}
     };
 
+    char *tmp;
     while ((c = getopt_long(argc, argv, "hH?0b:c:e:fm:p:s:S:lr:iCR:T:", loptions,NULL)) >= 0)
     {
         switch (c)
@@ -424,11 +425,20 @@ int main(int argc, char *argv[])
             case 'H': args.header_only = 1; break;
             case 'l': list_chroms = 1; break;
             case '0': conf.preset |= TBX_UCSC; break;
-            case 'b': conf.bc = atoi(optarg); break;
-            case 'e': conf.ec = atoi(optarg); break;
+            case 'b':
+                conf.bc = strtol(optarg,&tmp,10); 
+                if ( *tmp ) error("Could not parse argument: -b %s\n", optarg);
+                break;
+            case 'e':
+                conf.ec = strtol(optarg,&tmp,10);
+                if ( *tmp ) error("Could not parse argument: -e %s\n", optarg);
+                break;
             case 'c': conf.meta_char = *optarg; break;
             case 'f': is_force = 1; break;
-            case 'm': min_shift = atoi(optarg); break;
+            case 'm':
+                min_shift = strtol(optarg,&tmp,10);
+                if ( *tmp ) error("Could not parse argument: -m %s\n", optarg);
+                break;
             case 'p':
                       if (strcmp(optarg, "gff") == 0) conf_ptr = &tbx_conf_gff;
                       else if (strcmp(optarg, "bed") == 0) conf_ptr = &tbx_conf_bed;
@@ -438,8 +448,14 @@ int main(int argc, char *argv[])
                       else if (strcmp(optarg, "bam") == 0) ;    // same as bcf
                       else error("The preset string not recognised: '%s'\n", optarg);
                       break;
-            case 's': conf.sc = atoi(optarg); break;
-            case 'S': conf.line_skip = atoi(optarg); break;
+            case 's':
+                conf.sc = strtol(optarg,&tmp,10);
+                if ( *tmp ) error("Could not parse argument: -s %s\n", optarg);
+                break;
+            case 'S':
+                conf.line_skip = strtol(optarg,&tmp,10);
+                if ( *tmp ) error("Could not parse argument: -S %s\n", optarg);
+                break;
             default: return usage();
         }
     }


### PR DESCRIPTION
This suggested pull request adds to the previous scientific notation functionality (772ba54000b33ece0b823a1e2f446f34112d286d), adding a utility function that uses strtol() when it can (so faithful accuracy is clear and obvious) or strtod() if needed (because scientific notation has been used).