### PR TITLE
Add c++ name mangling protection where it's missing

### DIFF
--- a/htslib/regidx.h
+++ b/htslib/regidx.h
@@ -73,6 +73,10 @@ regitr_t;
 #define REGITR_PAYLOAD(itr,type_t) ((type_t*)(itr).payload)[(itr).i]
 #define REGITR_OVERLAP(itr,from,to) (itr.i < itr.n && REGITR_START(itr)<=to && REGITR_END(itr)>=from )
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  *  regidx_parse_f - Function to parse one input line, such as regidx_parse_bed
  *  or regidx_parse_tab below. The function is expected to set `chr_from` and
@@ -143,5 +147,8 @@ char **regidx_seq_names(regidx_t *idx, int *n);
 int regidx_seq_nregs(regidx_t *idx, const char *seq);
 int regidx_nregs(regidx_t *idx);
 
+#ifdef __cplusplus
+}
 #endif
 
+#endif

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -728,10 +728,6 @@ extern "C" {
 
     int bcf_index_build(const char *fn, int min_shift);
 
-#ifdef __cplusplus
-}
-#endif
-
 /*******************
  * Typed value I/O *
  *******************/
@@ -879,5 +875,9 @@ static inline int32_t bcf_dec_size(const uint8_t *p, uint8_t **q, int *type)
         return *p>>4;
     } else return bcf_dec_typed_int1(p + 1, q);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/htslib/vcf_sweep.h
+++ b/htslib/vcf_sweep.h
@@ -30,10 +30,18 @@ DEALINGS IN THE SOFTWARE.  */
 
 typedef struct _bcf_sweep_t bcf_sweep_t;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 bcf_sweep_t *bcf_sweep_init(const char *fname);
 void bcf_sweep_destroy(bcf_sweep_t *sw);
 bcf_hdr_t *bcf_sweep_hdr(bcf_sweep_t *sw);
 bcf1_t *bcf_sweep_fwd(bcf_sweep_t *sw);
 bcf1_t *bcf_sweep_bwd(bcf_sweep_t *sw);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/htslib/vcfutils.h
+++ b/htslib/vcfutils.h
@@ -27,6 +27,9 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "vcf.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  *  bcf_trim_alleles() - remove ALT alleles unused in genotype fields
@@ -99,7 +102,12 @@ static inline int bcf_acgt2int(char c)
     if ( c=='T' ) return 3;
     return -1;
 }
+
 #define bcf_int2acgt(i) "ACGT"[i]
+
+#ifdef __cplusplus
+}
+#endif
 
 /**
   * bcf_ij2G() - common task: allele indexes to Number=G index (diploid)


### PR DESCRIPTION
regidx.h
vcf_sweep.h
vcfutils.h

are missing their:

#ifdef __cplusplus
extern C {
#endif
// functions
#ifdef __cplusplus
}
#endif

Anti-name mangling measures. Also vcf.h has some of the inline functions outside the extern C bracers.