### PR TITLE
Include unistd.h & exec bash instead of /bin/bash

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <zlib.h>
 #ifdef HAVE_LIBBZ2
 #include <bzlib.h>

--- a/test/test.pl
+++ b/test/test.pl
@@ -93,7 +93,7 @@ sub _cmd
     else
     {
         # child
-        exec('/bin/bash', '-o','pipefail','-c', $cmd) or error("Cannot execute the command [/bin/sh -o pipefail -c $cmd]: $!");
+        exec('bash', '-o','pipefail','-c', $cmd) or error("Cannot execute the command [/bin/sh -o pipefail -c $cmd]: $!");
     }
     return ($? >> 8, join('',@out));
 }


### PR DESCRIPTION
The following compile error was observed on FreeBSD 9.3:

```
gcc -g -Wall -O2 -I. -c -o cram/cram_io.o cram/cram_io.c
cram/cram_io.c: In function 'paranoid_fclose':
cram/cram_io.c:1432: warning: implicit declaration of function 'fsync'
cram/cram_io.c: In function 'bgzf_open_ref':
cram/cram_io.c:1546: warning: implicit declaration of function 'access'
cram/cram_io.c:1546: error: 'R_OK' undeclared (first use in this function)
cram/cram_io.c:1546: error: (Each undeclared identifier is reported only once
cram/cram_io.c:1546: error: for each function it appears in.)
cram/cram_io.c: In function 'cram_populate_ref':
cram/cram_io.c:2052: warning: implicit declaration of function 'unlink'
cram/cram_io.c: In function 'full_path':
cram/cram_io.c:3427: warning: implicit declaration of function 'getcwd'
```

Per POSIX, the R_OK symbolic constant is defined in unistd.h (and access(), fsync(), and getcwd() functions are declared there as well), so it should enhance portability to explicitly include unistd.h.

Also, "make test" failed due to test.pl exec'ing /bin/bash, which doesn't exist on FreeBSD (if it's installed, it will exist in at /usr/local/bin/bash). Using exec('bash', ...) instead of exec('/bin/bash', ...) is a more portable alternative, and also allows the user the flexibility to specify a different version of bash via their PATH environment variable.