### PR TITLE
Fixed .crai loading of local irods:... caches.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ cram_samtools_h = cram/cram_samtools.h $(htslib_sam_h) $(cram_sam_header_h)
 cram_structs_h = cram/cram_structs.h cram/thread_pool.h cram/string_alloc.h $(htslib_khash_h)
 cram_open_trace_file_h = cram/open_trace_file.h cram/mFILE.h
 hfile_internal_h = hfile_internal.h $(htslib_hfile_h)
-
+hts_internal_h = hts_internal.h $(htslib_hts_h)
 
 # To be effective, config.mk needs to appear after most Makefile variables are
 # set but before most rules appear, so that it can both use previously-set
@@ -232,7 +232,7 @@ knetfile.o knetfile.pico: knetfile.c $(htslib_knetfile_h)
 hfile.o hfile.pico: hfile.c $(htslib_hfile_h) $(hfile_internal_h)
 hfile_irods.o hfile_irods.pico: hfile_irods.c $(hfile_internal_h)
 hfile_net.o hfile_net.pico: hfile_net.c $(hfile_internal_h) $(htslib_knetfile_h)
-hts.o hts.pico: hts.c version.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h)
+hts.o hts.pico: hts.c version.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h) $(hts_internal_h)
 vcf.o vcf.pico: vcf.c $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_kstring_h) $(htslib_khash_str2int_h)
 sam.o sam.pico: sam.c $(htslib_sam_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_kstring_h)
 tbx.o tbx.pico: tbx.c $(htslib_tbx_h) $(htslib_bgzf_h) $(htslib_khash_h)
@@ -246,7 +246,7 @@ regidx.o regidx.pico: regidx.c $(htslib_hts_h) $(htslib_kstring_h) $(htslib_kseq
 cram/cram_codecs.o cram/cram_codecs.pico: cram/cram_codecs.c $(cram_h)
 cram/cram_decode.o cram/cram_decode.pico: cram/cram_decode.c $(cram_h) cram/os.h cram/md5.h
 cram/cram_encode.o cram/cram_encode.pico: cram/cram_encode.c $(cram_h) cram/os.h cram/md5.h
-cram/cram_index.o cram/cram_index.pico: cram/cram_index.c $(htslib_hfile_h) $(cram_h) cram/os.h cram/zfio.h
+cram/cram_index.o cram/cram_index.pico: cram/cram_index.c $(htslib_hfile_h) $(cram_h) cram/os.h cram/zfio.h $(hts_internal_h)
 cram/cram_io.o cram/cram_io.pico: cram/cram_io.c $(cram_h) cram/os.h cram/md5.h $(cram_open_trace_file_h) cram/rANS_static.h $(htslib_hfile_h) $(htslib_bgzf_h) $(htslib_faidx_h)
 cram/cram_samtools.o cram/cram_samtools.pico: cram/cram_samtools.c $(cram_h) $(htslib_sam_h)
 cram/cram_stats.o cram/cram_stats.pico: cram/cram_stats.c $(cram_h) cram/os.h

--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -64,6 +64,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ctype.h>
 
 #include "htslib/hfile.h"
+#include "hts_internal.h"
 #include "cram/cram.h"
 #include "cram/os.h"
 #include "cram/zfio.h"

--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -139,11 +139,11 @@ static int kget_int64(kstring_t *k, size_t *pos, int64_t *val_p) {
  *        -1 for failure
  */
 int cram_index_load(cram_fd *fd, const char *fn) {
-    char fn2[PATH_MAX];
+    char *fn2;
     char buf[65536];
     ssize_t len;
     kstring_t kstr = {0};
-    hFILE *fp;
+    FILE *fp;
     cram_index *idx;
     cram_index **idx_stack = NULL, *ep, e;
     int idx_stack_alloc = 0, idx_stack_ptr = 0;
@@ -165,27 +165,36 @@ int cram_index_load(cram_fd *fd, const char *fn) {
     idx_stack = calloc(++idx_stack_alloc, sizeof(*idx_stack));
     idx_stack[idx_stack_ptr] = idx;
 
-    sprintf(fn2, "%s.crai", fn);
-    if (!(fp = hopen(fn2, "r"))) {
+    fn2 = hts_idx_getfn(fn, ".crai");
+    if (!fn2) {
 	perror(fn2);
 	free(idx_stack);
 	return -1; 
     }
 
+    if (!(fp = fopen(fn2, "r"))) {
+	perror(fn2);
+	free(idx_stack);
+	free(fn2);
+	return -1; 
+    }
+
     // Load the file into memory
-    while ((len = hread(fp, buf, 65536)) > 0)
+    while ((len = fread(buf, 1, 65536, fp)) > 0)
 	kputsn(buf, len, &kstr);
     if (len < 0 || kstr.l < 2) {
 	if (kstr.s)
 	    free(kstr.s);
 	free(idx_stack);
+	free(fn2);
 	return -1;
     }
 
-    if (hclose(fp)) {
+    if (fclose(fp)) {
 	if (kstr.s)
 	    free(kstr.s);
 	free(idx_stack);
+	free(fn2);
 	return -1;
     }
 	
@@ -197,6 +206,7 @@ int cram_index_load(cram_fd *fd, const char *fn) {
 	free(kstr.s);
 	if (!s) {
 	    free(idx_stack);
+	    free(fn2);
 	    return -1;
 	}
 	kstr.s = s;
@@ -210,22 +220,22 @@ int cram_index_load(cram_fd *fd, const char *fn) {
     do {
 	/* 1.1 layout */
 	if (kget_int32(&kstr, &pos, &e.refid) == -1) {
-	    free(kstr.s); free(idx_stack); return -1;
+	    free(kstr.s); free(idx_stack); free(fn2); return -1;
 	}
 	if (kget_int32(&kstr, &pos, &e.start) == -1) {
-	    free(kstr.s); free(idx_stack); return -1;
+	    free(kstr.s); free(idx_stack); free(fn2); return -1;
 	}
 	if (kget_int32(&kstr, &pos, &e.end) == -1) {
-	    free(kstr.s); free(idx_stack); return -1;
+	    free(kstr.s); free(idx_stack); free(fn2); return -1;
 	}
 	if (kget_int64(&kstr, &pos, &e.offset) == -1) {
-	    free(kstr.s); free(idx_stack); return -1;
+	    free(kstr.s); free(idx_stack); free(fn2); return -1;
 	}
 	if (kget_int32(&kstr, &pos, &e.slice) == -1) {
-	    free(kstr.s); free(idx_stack); return -1;
+	    free(kstr.s); free(idx_stack); free(fn2); return -1;
 	}
 	if (kget_int32(&kstr, &pos, &e.len) == -1) {
-	    free(kstr.s); free(idx_stack); return -1;
+	    free(kstr.s); free(idx_stack); free(fn2); return -1;
 	}
 
 	e.end += e.start-1;
@@ -234,6 +244,7 @@ int cram_index_load(cram_fd *fd, const char *fn) {
 	if (e.refid < -1) {
 	    free(kstr.s);
 	    free(idx_stack);
+	    free(fn2);
 	    fprintf(stderr, "Malformed index file, refid %d\n", e.refid);
 	    return -1;
 	}
@@ -283,6 +294,7 @@ int cram_index_load(cram_fd *fd, const char *fn) {
 
     free(idx_stack);
     free(kstr.s);
+    free(fn2);
 
     // dump_index(fd);
 

--- a/hts.c
+++ b/hts.c
@@ -37,6 +37,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "cram/cram.h"
 #include "htslib/hfile.h"
 #include "version.h"
+#include "hts_internal.h"
 
 #include "htslib/kseq.h"
 #define KS_BGZF 1

--- a/hts_internal.h
+++ b/hts_internal.h
@@ -1,0 +1,31 @@
+char *hts_idx_getfn(const char *fn, const char *ext);
+/*  hts_int.h -- internal functions; not part of the public API.
+
+    Copyright (C) 2015 Genome Research Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#ifndef HTSLIB_HTS_INTERNAL_H
+#define HTSLIB_HTS_INTERNAL_H
+
+#include "htslib/hts.h"
+
+char *hts_idx_getfn(const char *fn, const char *ext);
+
+#endif

--- a/hts_internal.h
+++ b/hts_internal.h
@@ -1,5 +1,4 @@
-char *hts_idx_getfn(const char *fn, const char *ext);
-/*  hts_int.h -- internal functions; not part of the public API.
+/*  hts_internal.h -- internal functions; not part of the public API.
 
     Copyright (C) 2015 Genome Research Ltd.
 

--- a/htslib.mk
+++ b/htslib.mk
@@ -75,6 +75,7 @@ HTSLIB_ALL = \
 	$(HTSDIR)/hfile_irods.c \
 	$(HTSDIR)/hfile_net.c \
 	$(HTSDIR)/hts.c \
+	$(HTSDIR)/hts_internal.h \
 	$(HTSDIR)/knetfile.c \
 	$(HTSDIR)/kstring.c \
 	$(HTSDIR)/regidx.c \

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -366,7 +366,6 @@ extern "C" {
 
     int hts_idx_get_stat(const hts_idx_t* idx, int tid, uint64_t* mapped, uint64_t* unmapped);
     uint64_t hts_idx_get_n_no_coor(const hts_idx_t* idx);
-    char *hts_idx_getfn(const char *fn, const char *ext);
 
     const char *hts_parse_reg(const char *s, int *beg, int *end);
     hts_itr_t *hts_itr_query(const hts_idx_t *idx, int tid, int beg, int end, hts_readrec_func *readrec);

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -366,6 +366,7 @@ extern "C" {
 
     int hts_idx_get_stat(const hts_idx_t* idx, int tid, uint64_t* mapped, uint64_t* unmapped);
     uint64_t hts_idx_get_n_no_coor(const hts_idx_t* idx);
+    char *hts_idx_getfn(const char *fn, const char *ext);
 
     const char *hts_parse_reg(const char *s, int *beg, int *end);
     hts_itr_t *hts_itr_query(const hts_idx_t *idx, int tid, int beg, int end, hts_readrec_func *readrec);

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -187,17 +187,17 @@ int main(int argc, char *argv[])
     if (optind + 1 < argc && !(flag&1)) { // BAM input and has a region
         int i;
         hts_idx_t *idx;
-        if ((idx = bam_index_load(argv[optind])) == 0) {
+        if ((idx = sam_index_load(in, argv[optind])) == 0) {
             fprintf(stderr, "[E::%s] fail to load the BAM index\n", __func__);
             return 1;
         }
         for (i = optind + 1; i < argc; ++i) {
             hts_itr_t *iter;
-            if ((iter = bam_itr_querys(idx, h, argv[i])) == 0) {
+            if ((iter = sam_itr_querys(idx, h, argv[i])) == 0) {
                 fprintf(stderr, "[E::%s] fail to parse region '%s'\n", __func__, argv[i]);
                 continue;
             }
-            while ((r = bam_itr_next(in, iter, b)) >= 0) {
+            while ((r = sam_itr_next(in, iter, b)) >= 0) {
                 if (sam_write1(out, h, b) < 0) {
                     fprintf(stderr, "Error writing output.\n");
                     exit_code = 1;


### PR DESCRIPTION
For .bai files on remote protocols we download the .bai locally and
use the local copy.

The previous .crai implementation just used hopen so it opened the
remote end and never cached it.  We now follow the same procedure used
in hts_idx_load for bai.