### PR TITLE
warn if no BGZF EOF for VCF/BCF files

### DIFF
--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -113,7 +113,7 @@ bcf_sr_t;
 typedef enum
 {
     open_failed, not_bgzf, idx_load_failed, file_type_error, api_usage_error,
-    header_error
+    header_error, no_eof
 }
 bcf_sr_error;
 

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -68,6 +68,8 @@ char *bcf_sr_strerror(int errnum)
             return "API usage error"; break;
         case header_error:
             return "could not parse header"; break;
+        case no_eof:
+            return "no BGZF EOF marker; file may be truncated"; break;
         default: return ""; 
     }
 }
@@ -146,6 +148,15 @@ int bcf_sr_add_reader(bcf_srs_t *files, const char *fname)
     reader->file = file_ptr;
 
     files->errnum = 0;
+
+    if ( reader->file->format.compression==bgzf )
+    {
+        BGZF *bgzf = hts_get_bgzfp(reader->file);
+        if ( bgzf && bgzf_check_EOF(bgzf) == 0 ) {
+            files->errnum = no_eof;
+            fprintf(stderr,"[%s] Warning: no BGZF EOF marker; file may be truncated.\n", fname);
+        }
+    }
 
     if ( files->require_index )
     {


### PR DESCRIPTION
see samtools/bcftools#220

bcf_synced_reader will warn if the BGZF EOF marker is missing
when adding a new file. Error is added to bcf_sr_strerror so it
could be used. However, we don't fall over, just warn. We want
to be able to, say, view a BCF file while it is still being
written. Samtools also just warns when EOF missing from a BAM.