### PR TITLE
Fixes bam_index/bam_index_build to handle truncated or corrupted BAMs

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -445,6 +445,10 @@ int bam_index_build(const char *fn, int min_shift)
         break;
 
     case bam:
+        if (bgzf_check_EOF(fp->fp.bgzf) <= 0) {
+            // return -1 if EOF check fails (but try to build index anyway)
+            ret = -1;
+        } 
         idx = bam_index(fp->fp.bgzf, min_shift);
         if (idx) {
             hts_idx_save(idx, fn, (min_shift > 0)? HTS_FMT_CSI : HTS_FMT_BAI);

--- a/sam.c
+++ b/sam.c
@@ -115,7 +115,7 @@ bam_hdr_t *bam_hdr_read(BGZF *fp)
     // check EOF
     has_EOF = bgzf_check_EOF(fp);
     if (has_EOF < 0) {
-        perror("[W::sam_hdr_read] bgzf_check_EOF");
+        perror("[W::bam_hdr_read] bgzf_check_EOF");
     } else if (has_EOF == 0 && hts_verbose >= 2)
         fprintf(stderr, "[W::%s] EOF marker is absent. The input is probably truncated.\n", __func__);
     // read "BAM1"


### PR DESCRIPTION
Adds an EOF check to bam_index_build .

Adds a check of error status from bam_read1 to bam_index and bails out on the index if it has failed (i.e. due to corruption). 

These fixes address samtools issue: samtools/samtools#362