### PR TITLE
Avoid __clang_major__ undefined warnings

### DIFF
--- a/htslib/khash.h
+++ b/htslib/khash.h
@@ -152,7 +152,7 @@ typedef unsigned long long khint64_t;
 #endif /* kh_inline */
 
 #ifndef klib_unused
-#if __clang_major__ >= 3 || __GNUC__ >= 3
+#if (defined(__clang__) && __clang_major__ >= 3) || __GNUC__ >= 3
 #define klib_unused __attribute__ ((__unused__))
 #else
 #define klib_unused


### PR DESCRIPTION
Only clang sets __clang_major__ preprocessor macro. To avoid warnings about undefined macros being used, we should check if it is set before using it.