### PR TITLE
Allow synced reader for multiple streams without index.

### DIFF
--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -206,9 +206,7 @@ int bcf_sr_add_reader(bcf_srs_t *files, const char *fname)
     }
     if ( files->streaming && files->nreaders>1 )
     {
-        files->errnum = api_usage_error;
-        fprintf(stderr,"[%s:%d %s] Error: %d readers, yet require_index not set\n", __FILE__,__LINE__,__FUNCTION__,files->nreaders);
-        return 0;
+        fprintf(stderr,"Warning: %d readers, yet require_index not set\n", files->nreaders);
     }
     if ( files->streaming && files->regions )
     {


### PR DESCRIPTION
From my inspection, the synced reader code should also work without and index and multiple streams.
I have changed the error in these cases into a warning, in order to allow an --omit-index functionality for bcftools merge.

This allows to use bcftools merge with multiple named pipes, which can be very handy with large, sorted bcf files that shall not be stored on disk.

I don't know if my changes are appropriate and I am open to any suggestions. Please see the corresponding pull request in bcftools:
https://github.com/samtools/bcftools/pull/252