### PR TITLE
Increase size of max format string size from 2^16 to 2^32.

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -1478,7 +1478,7 @@ uint8_t *bcf_fmt_sized_array(kstring_t *s, uint8_t *ptr)
 
 typedef struct {
     int key, max_m, size, offset;
-    uint32_t is_gt:1, max_g:15, max_l:16;
+    uint64_t is_gt:1, max_g:31, max_l:32;
     uint32_t y;
     uint8_t *buf;
 } fmt_aux_t;


### PR DESCRIPTION
Fixes the issue of integer overflow when a VCF format string
contains a large string (in our case, nucleotide sequence).
2^32 should be a large enough number of characters (> 1 GB) such
that its an acceptable upper bound.

Note that bcftools will now crash with format field values > 2^16 characters (~65 KB). With this patch, that value is increased to 2^32 characters (~4.2 GB).