### PR TITLE
Fix bin calculation

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -798,6 +798,7 @@ int sam_parse1(kstring_t *s, bam_hdr_t *h, bam1_t *b)
         q = _read_token(p);
         i = 1;
     }
+    if(c->flag & BAM_FUNMAP) i = 1;
     c->bin = hts_reg2bin(c->pos, c->pos + i, 14, 5);
     // mate chr
     q = _read_token(p);


### PR DESCRIPTION
According to the spec (see footnote 17 on page 13), unmapped reads should be treated as having length 1 for the purposes of bin calculation. This makes sense, as it ensures that they're assigned to the lowest level of bins, regardless of their cigar string. This part of the spec. is currently not adhered to, but doing so prevents picard from complaining as much.