### PR TITLE
CRAM fuzz testing bug fixes

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1624,9 +1624,6 @@ cram_codec *cram_byte_array_stop_decode_init(char *data, int size,
         free(c);
         return NULL;
     }
-    c->decode = (option == E_BYTE_ARRAY_BLOCK)
-	? cram_byte_array_stop_decode_block
-	: cram_byte_array_stop_decode_char;
     c->free   = cram_byte_array_stop_decode_free;
     
     c->byte_array_stop.stop = *cp++;

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1401,7 +1401,7 @@ cram_codec *cram_byte_array_len_decode_init(char *data, int size,
     char *cp   = data;
     char *endp = data + size;
     int32_t encoding = 0;
-    int32_t sub_size = 0;
+    int32_t sub_size = -1;
 
     if (!(c = malloc(sizeof(*c))))
 	return NULL;
@@ -1420,6 +1420,7 @@ cram_codec *cram_byte_array_len_decode_init(char *data, int size,
         goto no_codec;
     cp += sub_size;
 
+    sub_size = -1;
     cp += safe_itf8_get(cp, endp, &encoding);
     cp += safe_itf8_get(cp, endp, &sub_size);
     if (sub_size < 0 || endp - cp < sub_size)

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1395,7 +1395,7 @@ int cram_byte_array_len_decode(cram_slice *slice, cram_codec *c,
                                             in, (char *)&len, &one);
     //printf("ByteArray Len=%d\n", len);
 
-    if (!r && c->byte_array_len.value_codec) {
+    if (!r && c->byte_array_len.value_codec && len >= 0) {
 	r = c->byte_array_len.value_codec->decode(slice,
 						  c->byte_array_len.value_codec,
 						  in, out, &len);

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1569,12 +1569,12 @@ int cram_byte_array_stop_decode_block(cram_slice *slice, cram_codec *c,
 
     stop = c->byte_array_stop.stop;
     if (cp_end - cp < out->alloc - out->byte) {
-	while (*cp != stop && cp != cp_end)
+	while (cp != cp_end && *cp != stop)
 	    *out_cp++ = *cp++;
 	BLOCK_SIZE(out) = out_cp - (char *)BLOCK_DATA(out);
     } else {
 	char *cp_start;
-	for (cp_start = cp; *cp != stop && cp != cp_end; cp++)
+	for (cp_start = cp; cp != cp_end && *cp != stop; cp++)
 	    ;
 	BLOCK_APPEND(out, cp_start, cp - cp_start);
 	BLOCK_GROW(out, cp - cp_start);

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -730,8 +730,8 @@ cram_codec *cram_subexp_decode_init(char *data, int size,
     c->free   = cram_subexp_decode_free;
     c->subexp.k = -1;
 
-    cp += itf8_get(cp, &c->subexp.offset);
-    cp += itf8_get(cp, &c->subexp.k);
+    cp += safe_itf8_get(cp, data + size, &c->subexp.offset);
+    cp += safe_itf8_get(cp, data + size, &c->subexp.k);
 
     if (cp - data != size || c->subexp.k < 0) {
 	fprintf(stderr, "Malformed subexp header stream\n");

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -324,25 +324,14 @@ static char *cram_extract_block(cram_block *b, int size) {
  */
 int cram_external_decode_int(cram_slice *slice, cram_codec *c,
 			     cram_block *in, char *out, int *out_size) {
-  int i, l;
+    int l;
     char *cp;
-    cram_block *b = NULL;
+    cram_block *b;
 
     /* Find the external block */
-    if (slice->block_by_id) {
-	if (!(b = slice->block_by_id[c->external.content_id]))
-	    return *out_size?-1:0;
-    } else {
-	for (i = 0; i < slice->hdr->num_blocks; i++) {
-	    b = slice->block[i];
-	    if (b && b->content_type == EXTERNAL &&
-		b->content_id == c->external.content_id) {
-		break;
-	    }
-	}
-	if (i == slice->hdr->num_blocks || !b)
-	    return -1;
-    }
+    b = cram_get_block_by_id(slice, c->external.content_id);
+    if (!b)
+        return *out_size?-1:0;
 
     cp = (char *)b->data + b->idx;
     // E_INT and E_LONG are guaranteed single item queries
@@ -356,25 +345,13 @@ int cram_external_decode_int(cram_slice *slice, cram_codec *c,
 int cram_external_decode_char(cram_slice *slice, cram_codec *c,
 			      cram_block *in, char *out,
 			      int *out_size) {
-    int i;
     char *cp;
-    cram_block *b = NULL;
+    cram_block *b;
 
     /* Find the external block */
-    if (slice->block_by_id) {
-	if (!(b = slice->block_by_id[c->external.content_id]))
-	    return *out_size?-1:0;
-    } else {
-	for (i = 0; i < slice->hdr->num_blocks; i++) {
-	    b = slice->block[i];
-	    if (b && b->content_type == EXTERNAL &&
-		b->content_id == c->external.content_id) {
-		break;
-	    }
-	}
-	if (i == slice->hdr->num_blocks || !b)
-	    return -1;
-    }
+    b = cram_get_block_by_id(slice, c->external.content_id);
+    if (!b)
+        return *out_size?-1:0;
 
     cp = cram_extract_block(b, *out_size);
     if (!cp)
@@ -387,26 +364,14 @@ int cram_external_decode_char(cram_slice *slice, cram_codec *c,
 static int cram_external_decode_block(cram_slice *slice, cram_codec *c,
 				      cram_block *in, char *out_,
 				      int *out_size) {
-    int i;
     char *cp;
     cram_block *b = NULL;
     cram_block *out = (cram_block *)out_;
 
     /* Find the external block */
-    if (slice->block_by_id) {
-	if (!(b = slice->block_by_id[c->external.content_id]))
-	    return *out_size?-1:0;
-    } else {
-	for (i = 0; i < slice->hdr->num_blocks; i++) {
-	    b = slice->block[i];
-	    if (b && b->content_type == EXTERNAL &&
-		b->content_id == c->external.content_id) {
-		break;
-	    }
-	}
-	if (i == slice->hdr->num_blocks || !b)
-	    return -1;
-    }
+    b = cram_get_block_by_id(slice, c->external.content_id);
+    if (!b)
+        return *out_size?-1:0;
 
     cp = cram_extract_block(b, *out_size);
     if (!cp)
@@ -1560,24 +1525,12 @@ cram_codec *cram_byte_array_len_encode_init(cram_stats *st,
 static int cram_byte_array_stop_decode_char(cram_slice *slice, cram_codec *c,
 					    cram_block *in, char *out,
 					    int *out_size) {
-    int i;
     cram_block *b = NULL;
     char *cp, ch;
 
-    if (slice->block_by_id) {
-	if (!(b = slice->block_by_id[c->byte_array_stop.content_id]))
-	    return *out_size?-1:0;
-    } else {
-	for (i = 0; i < slice->hdr->num_blocks; i++) {
-	    b = slice->block[i];
-	    if (b && b->content_type == EXTERNAL &&
-		b->content_id == c->byte_array_stop.content_id) {
-		break;
-	    }
-	}
-	if (i == slice->hdr->num_blocks || !b)
-	    return -1;
-    }
+    b = cram_get_block_by_id(slice, c->byte_array_stop.content_id);
+    if (!b)
+        return *out_size?-1:0;
 
     if (b->idx >= b->uncomp_size)
 	return -1;
@@ -1599,26 +1552,14 @@ static int cram_byte_array_stop_decode_char(cram_slice *slice, cram_codec *c,
 int cram_byte_array_stop_decode_block(cram_slice *slice, cram_codec *c,
 				      cram_block *in, char *out_,
 				      int *out_size) {
-    cram_block *b = NULL;
+    cram_block *b;
     cram_block *out = (cram_block *)out_;
     char *cp, *out_cp, *cp_end;
     char stop;
 
-    if (slice->block_by_id) {
-	if (!(b = slice->block_by_id[c->byte_array_stop.content_id]))
-	    return *out_size?-1:0;
-    } else {
-	int i;
-	for (i = 0; i < slice->hdr->num_blocks; i++) {
-	    b = slice->block[i];
-	    if (b && b->content_type == EXTERNAL &&
-		b->content_id == c->byte_array_stop.content_id) {
-		break;
-	    }
-	}
-	if (i == slice->hdr->num_blocks || !b)
-	    return -1;
-    }
+    b = cram_get_block_by_id(slice, c->byte_array_stop.content_id);
+    if (!b)
+        return *out_size?-1:0;
 
     if (b->idx >= b->uncomp_size)
 	return -1;

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -91,11 +91,15 @@ static signed int get_bit_MSB(cram_block *block) {
  */
 static int get_one_bits_MSB(cram_block *block) {
     int n = 0, b;
+    if (block->byte >= block->uncomp_size)
+        return -1;
     do {
 	b = block->data[block->byte] >> block->bit;
 	if (--block->bit == -1) {
 	    block->bit = 7;
 	    block->byte++;
+	    if (block->byte == block->uncomp_size && (b&1))
+	        return -1;
 	}
 	n++;
     } while (b&1);
@@ -489,6 +493,9 @@ int cram_beta_decode_int(cram_slice *slice, cram_codec *c, cram_block *in, char 
     int32_t *out_i = (int32_t *)out;
     int i, n;
 
+    if (cram_not_enough_bits(in, c->beta.nbits))
+        return -1;
+
     if (c->beta.nbits) {
 	for (i = 0, n = *out_size; i < n; i++)
 	    out_i[i] = get_bits_MSB(in, c->beta.nbits) - c->beta.offset;
@@ -672,7 +679,8 @@ int cram_subexp_decode(cram_slice *slice, cram_codec *c, cram_block *in, char *o
 	/* Get number of 1s */
 	//while (get_bit_MSB(in) == 1) i++;
 	i = get_one_bits_MSB(in);
-
+        if (i < 0 || cram_not_enough_bits(in, i > 0 ? i + k - 1 : k))
+            return -1;
 	/*
 	 * Val is
 	 * i > 0:  2^(k+i-1) + k+i-1 bits
@@ -720,11 +728,12 @@ cram_codec *cram_subexp_decode_init(char *data, int size,
     c->codec  = E_SUBEXP;
     c->decode = cram_subexp_decode;
     c->free   = cram_subexp_decode_free;
-    
+    c->subexp.k = -1;
+
     cp += itf8_get(cp, &c->subexp.offset);
     cp += itf8_get(cp, &c->subexp.k);
 
-    if (cp - data != size) {
+    if (cp - data != size || c->subexp.k < 0) {
 	fprintf(stderr, "Malformed subexp header stream\n");
 	free(c);
 	return NULL;
@@ -746,7 +755,7 @@ int cram_gamma_decode(cram_slice *slice, cram_codec *c, cram_block *in, char *ou
 	int val;
 	//while (get_bit_MSB(in) == 0) nz++;
 	nz = get_zero_bits_MSB(in);
-        if (nz < 0 || (in->uncomp_size - in->byte)*8 + in->bit < nz + 7)
+        if (cram_not_enough_bits(in, nz))
             return -1;
 	val = 1;
 	while (nz > 0) {
@@ -841,7 +850,7 @@ int cram_huffman_decode_char(cram_slice *slice, cram_codec *c,
 
 	for (;;) {
 	    int dlen = codes[idx].len - last_len;
-	    if (dlen <= 0 || (in->uncomp_size - in->byte)*8 + in->bit < dlen + 7)
+	    if (cram_not_enough_bits(in, dlen))
 		return -1;
 
 	    //val <<= dlen;
@@ -891,7 +900,7 @@ int cram_huffman_decode_int(cram_slice *slice, cram_codec *c,
 	// Now one bit at a time for remaining checks
 	for (;;) {
 	    int dlen = codes[idx].len - last_len;
-	    if (dlen <= 0 || (in->uncomp_size - in->byte)*8 + in->bit < dlen + 7)
+	    if (cram_not_enough_bits(in, dlen))
 		return -1;
 	    
 	    //val <<= dlen;

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1389,21 +1389,23 @@ int cram_byte_array_len_decode(cram_slice *slice, cram_codec *c,
 			       int *out_size) {
     /* Fetch length */
     int32_t len = 0, one = 1;
+    int r;
 
-    c->byte_array_len.len_codec->decode(slice, c->byte_array_len.len_codec, in, (char *)&len, &one);
+    r = c->byte_array_len.len_codec->decode(slice, c->byte_array_len.len_codec,
+                                            in, (char *)&len, &one);
     //printf("ByteArray Len=%d\n", len);
 
-    if (c->byte_array_len.value_codec) {
-	c->byte_array_len.value_codec->decode(slice,
-					      c->byte_array_len.value_codec,
-					      in, out, &len);
+    if (!r && c->byte_array_len.value_codec) {
+	r = c->byte_array_len.value_codec->decode(slice,
+						  c->byte_array_len.value_codec,
+						  in, out, &len);
     } else {
 	return -1;
     }
 
     *out_size = len;
 
-    return 0;
+    return r;
 }
 
 void cram_byte_array_len_decode_free(cram_codec *c) {

--- a/cram/cram_codecs.h
+++ b/cram/cram_codecs.h
@@ -152,6 +152,22 @@ cram_codec *cram_encoder_init(enum cram_encoding codec, cram_stats *st,
 #define GET_BIT_MSB(b,v) (void)(v<<=1, v|=(b->data[b->byte] >> b->bit)&1, b->byte += (--b->bit<0), b->bit&=7)
 
 /*
+ * Check that enough bits are left in a block to satisy a bit-based decoder.
+ * Return  0 if there are enough
+ *         1 if not.
+ */
+
+static inline int cram_not_enough_bits(cram_block *blk, int nbits) {
+    if (nbits < 0 ||
+	blk->byte >= blk->uncomp_size ||
+	(blk->uncomp_size - blk->byte <= INT32_MAX / 8 + 1 &&
+	 (blk->uncomp_size - blk->byte) * 8 + blk->bit - 7 < nbits)) {
+        return 1;
+    }
+    return 0;
+}
+
+/*
  * Returns the content_id used by this codec, also in id2 if byte_array_len.
  * Returns -1 for the CORE block and -2 for unneeded.
  * id2 is only filled out for BYTE_ARRAY_LEN which uses 2 codecs.

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1126,6 +1126,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 	if (!c->comp_hdr->codecs[DS_FN]) return -1;
 	r |= c->comp_hdr->codecs[DS_FN]->decode(s,c->comp_hdr->codecs[DS_FN],
 						blk, (char *)&fn, &out_sz);
+        if (r) return r;
     } else {
 	fn = 0;
     }
@@ -1153,6 +1154,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 						    c->comp_hdr->codecs[DS_FC],
 						    blk,
 						    &op,  &out_sz);
+	    if (r) return r;
 	}
 
 	if (!(ds & CRAM_FP))
@@ -1163,6 +1165,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 						c->comp_hdr->codecs[DS_FP],
 						blk,
 						(char *)&pos, &out_sz);
+	if (r) return r;
 	pos += prev_pos;
 
 	if (pos > seq_pos) {
@@ -1251,6 +1254,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 //					      blk, &seq[pos-1], &out_sz2)
 //			: (seq[pos-1] = 'N', out_sz2 = 1, 0);
 		}
+		if (r) return r;
 		cigar[ncigar++] = (out_sz2<<4) + BAM_CSOFT_CLIP;
 		cig_op = BAM_CSOFT_CLIP;
 		seq_pos += out_sz2;
@@ -1284,6 +1288,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_BS]
 		                ->decode(s, c->comp_hdr->codecs[DS_BS], blk,
 					 (char *)&base, &out_sz);
+		if (r) return -1;
 		if (ref_pos >= bfd->ref[cr->ref_id].len || !s->ref) {
 		    seq[pos-1] = c->comp_hdr->
 			substitution_matrix[fd->L1['N']][base];
@@ -1326,6 +1331,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_DL]
 		                ->decode(s, c->comp_hdr->codecs[DS_DL], blk,
 					 (char *)&i32, &out_sz);
+		if (r) return r;
 		if (decode_md || decode_nm) {
 		    if (md_dist >= 0 && decode_md)
 			BLOCK_APPEND_UINT(s->aux_blk, md_dist);
@@ -1378,6 +1384,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_IN]
 		                ->decode(s, c->comp_hdr->codecs[DS_IN], blk,
 					 &seq[pos-1], &out_sz2);
+		if (r) return r;
 		cig_op = BAM_CINS;
 		cig_len += out_sz2;
 		seq_pos += out_sz2;
@@ -1397,6 +1404,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_BA]
 		                ->decode(s, c->comp_hdr->codecs[DS_BA], blk,
 					 (char *)&seq[pos-1], &out_sz);
+		if (r) return r;
 	    }
 	    cig_op = BAM_CINS;
 	    cig_len++;
@@ -1418,6 +1426,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_BB]
 		    ->decode(s, c->comp_hdr->codecs[DS_BB], blk,
 			     (char *)&seq[pos-1], &len);
+		if (r) return r;
 
 		if (decode_md || decode_nm) {
 		    int x;
@@ -1464,6 +1473,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_QQ]
 		    ->decode(s, c->comp_hdr->codecs[DS_QQ], blk,
 			     (char *)&qual[pos-1], &len);
+		if (r) return r;
 	    }
 
 	    cig_op = BAM_CMATCH;
@@ -1546,6 +1556,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_HC]
 		                ->decode(s, c->comp_hdr->codecs[DS_HC], blk,
 					 (char *)&i32, &out_sz);
+		if (r) return r;
 		cig_op = BAM_CHARD_CLIP;
 		cig_len += i32;
 	    }
@@ -1562,6 +1573,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_PD]
 		                ->decode(s, c->comp_hdr->codecs[DS_PD], blk,
 					 (char *)&i32, &out_sz);
+		if (r) return r;
 		cig_op = BAM_CPAD;
 		cig_len += i32;
 		nm      += i32;
@@ -1579,6 +1591,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_RS]
 		                ->decode(s, c->comp_hdr->codecs[DS_RS], blk,
 					 (char *)&i32, &out_sz);
+		if (r) return r;
 		cig_op = BAM_CREF_SKIP;
 		cig_len += i32;
 		ref_pos += i32;
@@ -1827,6 +1840,7 @@ static int cram_decode_aux(cram_container *c, cram_slice *s,
 
 	if (!m->codec) return -1;
 	r |= m->codec->decode(s, m->codec, blk, (char *)s->aux_blk, &out_sz);
+	if (r) break;
 	cr->aux_size += out_sz + 3;
     }
     
@@ -2164,7 +2178,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 	    r |= c->comp_hdr->codecs[DS_BF]
 		            ->decode(s, c->comp_hdr->codecs[DS_BF], blk,
 				     (char *)&bf, &out_sz);
-	    if (bf < 0 ||
+	    if (r || bf < 0 ||
 		bf >= sizeof(fd->bam_flag_swap)/sizeof(*fd->bam_flag_swap))
 		return -1;
 	    bf = fd->bam_flag_swap[bf];
@@ -2179,14 +2193,15 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		if (!c->comp_hdr->codecs[DS_CF]) return -1;
 		r |= c->comp_hdr->codecs[DS_CF]
 		                ->decode(s, c->comp_hdr->codecs[DS_CF], blk,
-					 (char *)&cf, &out_sz);
+				 	 (char *)&cf, &out_sz);
+		if (r) return -1;
 		cr->cram_flags = cf;
 	    } else {
 		if (!c->comp_hdr->codecs[DS_CF]) return -1;
 		r |= c->comp_hdr->codecs[DS_CF]
 		                ->decode(s, c->comp_hdr->codecs[DS_CF], blk,
-					 (char *)&cr->cram_flags,
-					 &out_sz);
+					 (char *)&cr->cram_flags, &out_sz);
+		if (r) return -1;
 		cf = cr->cram_flags;
 	    }
 	}
@@ -2197,6 +2212,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_RI]
 		                ->decode(s, c->comp_hdr->codecs[DS_RI], blk,
 					 (char *)&cr->ref_id, &out_sz);
+		if (r) return -1;
 		if ((fd->required_fields & (SAM_SEQ|SAM_TLEN))
 		    && cr->ref_id >= 0
 		    && cr->ref_id != last_ref_id) {
@@ -2233,6 +2249,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 	    r |= c->comp_hdr->codecs[DS_RL]
 		            ->decode(s, c->comp_hdr->codecs[DS_RL], blk,
 				     (char *)&cr->len, &out_sz);
+	    if (r) return r;
 	}
 
 	if (ds & CRAM_AP) {
@@ -2240,6 +2257,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 	    r |= c->comp_hdr->codecs[DS_AP]
 		            ->decode(s, c->comp_hdr->codecs[DS_AP], blk,
 				     (char *)&cr->apos, &out_sz);
+	    if (r) return r;
 	    if (c->comp_hdr->AP_delta)
 		cr->apos += s->last_apos;
 	    s->last_apos=  cr->apos;
@@ -2252,6 +2270,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 	    r |= c->comp_hdr->codecs[DS_RG]
 		           ->decode(s, c->comp_hdr->codecs[DS_RG], blk,
 				    (char *)&cr->rg, &out_sz);
+	    if (r) return r;
 	    if (cr->rg == unknown_rg)
 		cr->rg = -1;
 	} else {
@@ -2270,6 +2289,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_RN]
 		                ->decode(s, c->comp_hdr->codecs[DS_RN], blk,
 					 (char *)s->name_blk, &out_sz2);
+		if (r) return r;
 		cr->name_len = out_sz2;
 	    }
 	}
@@ -2286,6 +2306,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		    r |= c->comp_hdr->codecs[DS_MF]
 			            ->decode(s, c->comp_hdr->codecs[DS_MF],
 					     blk, (char *)&mf, &out_sz);
+		    if (r) return r;
 		    cr->mate_flags = mf;
 		} else {
 		    if (!c->comp_hdr->codecs[DS_MF]) return -1;
@@ -2294,6 +2315,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 					     blk,
 					     (char *)&cr->mate_flags,
 					     &out_sz);
+		    if (r) return r;
 		}
 	    } else {
 		cr->mate_flags = 0;
@@ -2310,6 +2332,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 			            ->decode(s, c->comp_hdr->codecs[DS_RN],
 					     blk, (char *)s->name_blk,
 					     &out_sz2);
+		    if (r) return r;
 		    cr->name_len = out_sz2;
 		}
 	    }
@@ -2319,6 +2342,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_NS]
 		                ->decode(s, c->comp_hdr->codecs[DS_NS], blk,
 					 (char *)&cr->mate_ref_id, &out_sz);
+		if (r) return r;
 	    }
 
 // Skip as mate_ref of "*" is legit. It doesn't mean unmapped, just unknown.
@@ -2332,6 +2356,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_NP]
 		                ->decode(s, c->comp_hdr->codecs[DS_NP], blk,
 					 (char *)&cr->mate_pos, &out_sz);
+		if (r) return r;
 	    }
 
 	    if (ds & CRAM_TS) {
@@ -2339,6 +2364,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_TS]
 		                ->decode(s, c->comp_hdr->codecs[DS_TS], blk,
 					 (char *)&cr->tlen, &out_sz);
+		if (r) return r;
 	    } else {
 		cr->tlen = INT_MIN;
 	    }
@@ -2348,6 +2374,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_NF]
 		                ->decode(s, c->comp_hdr->codecs[DS_NF], blk,
 					 (char *)&cr->mate_line, &out_sz);
+		if (r) return r;
 		cr->mate_line += rec + 1;
 
 		//cr->name_len = sprintf(name, "%d", name_id++);
@@ -2384,6 +2411,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 	    r |= cram_decode_aux_1_0(c, s, blk, cr);
 	else
 	    r |= cram_decode_aux(c, s, blk, cr, &has_MD, &has_NM);
+	if (r) return r;
 
 	/* Fake up dynamic string growth and appending */
 	if (ds & CRAM_RL) {
@@ -2409,6 +2437,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 	    if (ds & (CRAM_SEQ | CRAM_MQ)) {
 		r |= cram_decode_seq(fd, c, s, blk, cr, bfd, cf, seq, qual,
 				     has_MD, has_NM);
+		if (r) return r;
 	    } else {
 		cr->cigar = 0;
 		cr->ncigar = 0;
@@ -2429,6 +2458,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		r |= c->comp_hdr->codecs[DS_BA]
 		                ->decode(s, c->comp_hdr->codecs[DS_BA], blk,
 					 (char *)seq, &out_sz2);
+		if (r) return r;
 	    }
 
 	    if ((ds & CRAM_CF) && (cf & CRAM_FLAG_PRESERVE_QUAL_SCORES)) {
@@ -2438,6 +2468,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 		    r |= c->comp_hdr->codecs[DS_QS]
 			            ->decode(s, c->comp_hdr->codecs[DS_QS],
 					     blk, qual, &out_sz2);
+		    if (r) return r;
 		}
 	    } else {
 		if (ds & CRAM_RL)

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -64,30 +64,33 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Returns number of bytes decoded on success
  *        -1 on failure
  */
-int cram_decode_TD(char *cp, cram_block_compression_hdr *h) {
+int cram_decode_TD(char *cp, const char *endp, cram_block_compression_hdr *h) {
     char *op = cp;
     unsigned char *dat;
     cram_block *b;
-    int32_t blk_size;
+    int32_t blk_size = 0;
     int nTL, i, sz;
 
     if (!(b = cram_new_block(0, 0)))
 	return -1;
-    h->TD_blk = b;
 
     /* Decode */
-    cp += itf8_get(cp, &blk_size);
+    cp += safe_itf8_get(cp, endp, &blk_size);
     if (!blk_size) {
 	h->nTL = 0;
 	h->TL = NULL;
 	cram_free_block(b);
-        return cp - op;
+	return cp - op;
+    }
+
+    if (blk_size < 0 || endp - cp < blk_size) {
+        cram_free_block(b);
+	return -1;
     }
 
     BLOCK_APPEND(b, cp, blk_size);
     cp += blk_size;
     sz = cp - op;
-
     // Force nul termination if missing
     if (BLOCK_DATA(b)[BLOCK_SIZE(b)-1])
 	BLOCK_APPEND_CHAR(b, '\0');
@@ -104,13 +107,16 @@ int cram_decode_TD(char *cp, cram_block_compression_hdr *h) {
 
     // Copy
     h->nTL = nTL;
-    if (!(h->TL = calloc(h->nTL, sizeof(unsigned char *))))
-	return -1;
+    if (!(h->TL = calloc(h->nTL, sizeof(unsigned char *)))) {
+        cram_free_block(b);
+        return -1;
+    }
     for (nTL = i = 0; i < BLOCK_SIZE(b); i++) {
 	h->TL[nTL++] = &dat[i];
 	while (dat[i])
 	    i++;
     }
+    h->TD_blk = b;
     
     return sz;
 }
@@ -122,10 +128,10 @@ int cram_decode_TD(char *cp, cram_block_compression_hdr *h) {
  */
 cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
 							   cram_block *b) {
-    char *cp, *cp_copy;
+    char *cp, *endp, *cp_copy;
     cram_block_compression_hdr *hdr = calloc(1, sizeof(*hdr));
     int i;
-    int32_t map_size, map_count;
+    int32_t map_size = 0, map_count = 0;
 
     if (!hdr)
 	return NULL;
@@ -138,19 +144,20 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
     }
 
     cp = (char *)b->data;
+    endp = cp + b->uncomp_size;
 
     if (CRAM_MAJOR_VERS(fd->version) == 1) {
-	cp += itf8_get(cp, &hdr->ref_seq_id);
-	cp += itf8_get(cp, &hdr->ref_seq_start);
-	cp += itf8_get(cp, &hdr->ref_seq_span);
-	cp += itf8_get(cp, &hdr->num_records);
-	cp += itf8_get(cp, &hdr->num_landmarks);
+	cp += safe_itf8_get(cp, endp, &hdr->ref_seq_id);
+	cp += safe_itf8_get(cp, endp, &hdr->ref_seq_start);
+	cp += safe_itf8_get(cp, endp, &hdr->ref_seq_span);
+	cp += safe_itf8_get(cp, endp, &hdr->num_records);
+	cp += safe_itf8_get(cp, endp, &hdr->num_landmarks);
 	if (!(hdr->landmark = malloc(hdr->num_landmarks * sizeof(int32_t)))) {
 	    free(hdr);
 	    return NULL;
 	}
 	for (i = 0; i < hdr->num_landmarks; i++) {
-	    cp += itf8_get(cp, &hdr->landmark[i]);
+	    cp += safe_itf8_get(cp, endp, &hdr->landmark[i]);
 	}
     }
 
@@ -176,13 +183,17 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
     memcpy(hdr->substitution_matrix, "CGTNAGTNACTNACGNACGT", 20);
 
     /* Preservation map */
-    cp += itf8_get(cp, &map_size); cp_copy = cp;
-    cp += itf8_get(cp, &map_count);
+    cp += safe_itf8_get(cp, endp, &map_size); cp_copy = cp;
+    cp += safe_itf8_get(cp, endp, &map_count);
     for (i = 0; i < map_count; i++) {
 	pmap_t hd;
 	khint_t k;
 	int r;
 
+	if (endp - cp < 2) {
+	    cram_free_compression_header(hdr);
+	    return NULL;
+	}
 	cp += 2;
 	switch(CRAM_KEY(cp[-2],cp[-1])) {
 	case CRAM_KEY('M','I'):
@@ -258,6 +269,10 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
 	    break;
 
 	case CRAM_KEY('S','M'):
+	    if (endp - cp < 5) {
+	        cram_free_compression_header(hdr);
+		return NULL;
+	    }
 	    hdr->substitution_matrix[0][(cp[0]>>6)&3] = 'C';
 	    hdr->substitution_matrix[0][(cp[0]>>4)&3] = 'G';
 	    hdr->substitution_matrix[0][(cp[0]>>2)&3] = 'T';
@@ -295,7 +310,7 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
 	    break;
 
 	case CRAM_KEY('T','D'): {
-	    int sz = cram_decode_TD(cp, hdr); // tag dictionary
+	    int sz = cram_decode_TD(cp, endp, hdr); // tag dictionary
 	    if (sz < 0) {
 		cram_free_compression_header(hdr);
 		return NULL;
@@ -327,22 +342,23 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
     }
 
     /* Record encoding map */
-    cp += itf8_get(cp, &map_size); cp_copy = cp;
-    cp += itf8_get(cp, &map_count);
+    cp += safe_itf8_get(cp, endp, &map_size); cp_copy = cp;
+    cp += safe_itf8_get(cp, endp, &map_count);
     for (i = 0; i < map_count; i++) {
 	char *key = cp;
-	int32_t encoding;
-	int32_t size;
+	int32_t encoding = E_NULL;
+	int32_t size = 0;
 	cram_map *m = malloc(sizeof(*m)); // FIXME: use pooled_alloc
 
-	if (!m) {
+	if (!m || endp - cp < 4) {
+	    free(m);
 	    cram_free_compression_header(hdr);
 	    return NULL;
 	}
 
 	cp += 2;
-	cp += itf8_get(cp, &encoding);
-	cp += itf8_get(cp, &size);
+	cp += safe_itf8_get(cp, endp, &encoding);
+	cp += safe_itf8_get(cp, endp, &size);
 
 	// Fill out cram_map purely for cram_dump to dump out.
 	m->key = (key[0]<<8)|key[1];
@@ -353,6 +369,12 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
 
 	if (m->encoding == E_NULL)
 	    continue;
+
+	if (size < 0 || endp - cp < size) {
+	    free(m);
+	    cram_free_compression_header(hdr);
+	    return NULL;
+	}
 
 	//printf("%s codes for %.2s\n", cram_encoding2str(encoding), key);
 
@@ -592,29 +614,32 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
     }
 
     /* Tag encoding map */
-    cp += itf8_get(cp, &map_size); cp_copy = cp;
-    cp += itf8_get(cp, &map_count);
+    cp += safe_itf8_get(cp, endp, &map_size); cp_copy = cp;
+    cp += safe_itf8_get(cp, endp, &map_count);
     for (i = 0; i < map_count; i++) {
-	int32_t encoding;
-	int32_t size;
+	int32_t encoding = E_NULL;
+	int32_t size = 0;
 	cram_map *m = malloc(sizeof(*m)); // FIXME: use pooled_alloc
-	char *key = cp+1;
+	char *key;
 
-	if (!m) {
+	if (!m || endp - cp < 6) {
+	    free(m);
 	    cram_free_compression_header(hdr);
 	    return NULL;
 	}
 
+	key = cp + 1;
 	m->key = (key[0]<<16)|(key[1]<<8)|key[2];
 
 	cp += 4; // Strictly ITF8, but this suffices
-	cp += itf8_get(cp, &encoding);
-	cp += itf8_get(cp, &size);
+	cp += safe_itf8_get(cp, endp, &encoding);
+	cp += safe_itf8_get(cp, endp, &size);
 
 	m->encoding = encoding;
 	m->size     = size;
 	m->offset   = cp - (char *)b->data;
-	if (!(m->codec = cram_decoder_init(encoding, cp, size,
+	if (size < 0 || endp - cp < size ||
+	    !(m->codec = cram_decoder_init(encoding, cp, size,
 					   E_BYTE_ARRAY_BLOCK, fd->version))) {
 	    cram_free_compression_header(hdr);
 	    free(m);
@@ -962,8 +987,18 @@ int cram_dependent_data_series(cram_fd *fd,
  */
 cram_block_slice_hdr *cram_decode_slice_header(cram_fd *fd, cram_block *b) {
     cram_block_slice_hdr *hdr;
-    char *cp = (char *)b->data;
+    char *cp;
+    char *cp_end;
     int i;
+
+    if (b->method != RAW) {
+        /* Spec. says slice header should be RAW, but we can future-proof
+	   by trying to decode it if it isn't. */
+        if (cram_uncompress_block(b) < 0)
+            return NULL;
+    }
+    cp =  (char *)b->data;
+    cp_end = cp + b->uncomp_size;
 
     if (b->content_type != MAPPED_SLICE &&
 	b->content_type != UNMAPPED_SLICE)
@@ -975,23 +1010,23 @@ cram_block_slice_hdr *cram_decode_slice_header(cram_fd *fd, cram_block *b) {
     hdr->content_type = b->content_type;
 
     if (b->content_type == MAPPED_SLICE) {
-	cp += itf8_get(cp, &hdr->ref_seq_id);
-	cp += itf8_get(cp, &hdr->ref_seq_start);
-	cp += itf8_get(cp, &hdr->ref_seq_span);
+        cp += safe_itf8_get(cp,  cp_end, &hdr->ref_seq_id);
+        cp += safe_itf8_get(cp,  cp_end, &hdr->ref_seq_start);
+        cp += safe_itf8_get(cp,  cp_end, &hdr->ref_seq_span);
     }
-    cp += itf8_get(cp, &hdr->num_records);
+    cp += safe_itf8_get(cp,  cp_end, &hdr->num_records);
     hdr->record_counter = 0;
     if (CRAM_MAJOR_VERS(fd->version) == 2) {
-	int32_t i32;
-	cp += itf8_get(cp, &i32);
+	int32_t i32 = 0;
+	cp += safe_itf8_get(cp, cp_end, &i32);
 	hdr->record_counter = i32;
     } else if (CRAM_MAJOR_VERS(fd->version) >= 3) {
 	cp += ltf8_get(cp, &hdr->record_counter);
     }
 
-    cp += itf8_get(cp, &hdr->num_blocks);
+    cp += safe_itf8_get(cp, cp_end, &hdr->num_blocks);
 
-    cp += itf8_get(cp, &hdr->num_content_ids);
+    cp += safe_itf8_get(cp, cp_end, &hdr->num_content_ids);
     hdr->block_content_ids = malloc(hdr->num_content_ids * sizeof(int32_t));
     if (!hdr->block_content_ids) {
 	free(hdr);
@@ -999,14 +1034,19 @@ cram_block_slice_hdr *cram_decode_slice_header(cram_fd *fd, cram_block *b) {
     }
 
     for (i = 0; i < hdr->num_content_ids; i++) {
-	cp += itf8_get(cp, &hdr->block_content_ids[i]);
+        cp += safe_itf8_get(cp,  cp_end,
+                            &hdr->block_content_ids[i]);
     }
 
     if (b->content_type == MAPPED_SLICE) {
-	cp += itf8_get(cp, &hdr->ref_base_id);
+        cp += safe_itf8_get(cp,  cp_end, &hdr->ref_base_id);
     }
 
     if (CRAM_MAJOR_VERS(fd->version) != 1) {
+        if (cp_end - cp < 16) {
+            free(hdr);
+            return NULL;
+        }
 	memcpy(hdr->md5, cp, 16);
     } else {
 	memset(hdr->md5, 0, 16);

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1181,12 +1181,15 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 				"sequence boundary\n");
 		    whinged = 1;
 		    rlen = bfd->ref[cr->ref_id].len - ref_pos;
-		    if (rlen > 0)
+		    if (rlen > 0) {
 			memcpy(&seq[seq_pos-1],
 			       &s->ref[ref_pos - s->ref_start +1], rlen);
-		    if ((pos - seq_pos) - rlen > 0)
-			memset(&seq[seq_pos-1+rlen], 'N',
-			       (pos - seq_pos) - rlen);
+			if ((pos - seq_pos) - rlen > 0)
+			    memset(&seq[seq_pos-1+rlen], 'N',
+				   (pos - seq_pos) - rlen);
+		    } else {
+		        memset(&seq[seq_pos-1], 'N', cr->len - seq_pos + 1);
+		    }
 		} else {
 		    memcpy(&seq[seq_pos-1], &s->ref[ref_pos - s->ref_start +1],
 			   pos - seq_pos);
@@ -1618,12 +1621,15 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		    fprintf(stderr, "Ref pos outside of ref sequence boundary\n");
 		whinged = 1;
 		rlen = bfd->ref[cr->ref_id].len - ref_pos;
-		if (rlen > 0)
+		if (rlen > 0) {
 		    memcpy(&seq[seq_pos-1],
 			   &s->ref[ref_pos - s->ref_start +1], rlen);
-		if ((cr->len - seq_pos + 1) - rlen > 0)
-		    memset(&seq[seq_pos-1+rlen], 'N',
-			   (cr->len - seq_pos + 1) - rlen);
+		    if ((cr->len - seq_pos + 1) - rlen > 0)
+		        memset(&seq[seq_pos-1+rlen], 'N',
+                               (cr->len - seq_pos + 1) - rlen);
+		} else {
+		    memset(&seq[seq_pos-1], 'N', cr->len - seq_pos + 1);
+		}
 	    } else {
 		memcpy(&seq[seq_pos-1], &s->ref[ref_pos - s->ref_start +1],
 		       cr->len - seq_pos + 1);

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2031,6 +2031,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 
     /* Look for unknown RG, added as last by Java CRAM? */
     if (bfd->nrg > 0 &&
+	bfd->rg[bfd->nrg-1].name != NULL &&
 	!strcmp(bfd->rg[bfd->nrg-1].name, "UNKNOWN"))
 	unknown_rg = bfd->nrg-1;
 

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2063,9 +2063,8 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 			"no embedded reference is available.\n");
 		return -1;
 	    }
-	    /* FIXME should search for the block if this fails */
-	    if (!s->block_by_id || s->hdr->ref_base_id >= 1024 ||
-		!(b = s->block_by_id[s->hdr->ref_base_id]))
+	    b = cram_get_block_by_id(s, s->hdr->ref_base_id);
+	    if (!b)
 		return -1;
 	    if (cram_uncompress_block(b) != 0)
 		return -1;
@@ -2143,8 +2142,8 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 	    hts_md5_final(digest, md5);
 	    hts_md5_destroy(md5);
 	} else if (!s->ref && s->hdr->ref_base_id >= 0) {
-	    cram_block *b;
-	    if (s->block_by_id && (b = s->block_by_id[s->hdr->ref_base_id])) {
+	    cram_block *b = cram_get_block_by_id(s, s->hdr->ref_base_id);
+	    if (b) {
 		if (!(md5 = hts_md5_init()))
 		    return -1;
 		hts_md5_update(md5, b->data, b->uncomp_size);

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2908,6 +2908,7 @@ cram_record *cram_get_seq(cram_fd *fd) {
 	} else {
 	    if (!(s = cram_next_slice(fd, &c)))
 		return NULL;
+	    continue; /* In case slice contains no records */
 	}
 
 	if (fd->range.refid != -2) {

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3532,7 +3532,7 @@ SAM_hdr *cram_read_SAM_hdr(cram_fd *fd) {
 	    return NULL;
 
 	/* Alloc and read */
-	if (header_len < 0 || NULL == (header = malloc(header_len+1)))
+	if (header_len < 0 || NULL == (header = malloc((size_t) header_len+1)))
 	    return NULL;
 
 	if (header_len != hread(fd->fp, header, header_len))
@@ -3575,7 +3575,7 @@ SAM_hdr *cram_read_SAM_hdr(cram_fd *fd) {
 	    cram_free_block(b);
 	    return NULL;
 	}
-	if (NULL == (header = malloc(header_len+1))) {
+	if (NULL == (header = malloc((size_t) header_len+1))) {
 	    cram_free_container(c);
 	    cram_free_block(b);
 	    return NULL;
@@ -3597,7 +3597,7 @@ SAM_hdr *cram_read_SAM_hdr(cram_fd *fd) {
 	    cram_free_block(b);
 	}
 
-	if (c->length && c->length > len) {
+	if (c->length > 0 && len > 0 && c->length > len) {
 	    // Consume padding
 	    char *pads = malloc(c->length - len);
 	    if (!pads) {

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -238,6 +238,11 @@ int itf8_encode(cram_fd *fd, int32_t val) {
     int len = itf8_put(buf, val);
     return hwrite(fd->fp, buf, len) == len ? 0 : -1;
 }
+ 
+const int itf8_bytes[16] = {
+    1, 1, 1, 1, 1, 1, 1, 1,
+    2, 2, 2, 2, 3, 3, 4, 5
+};
 
 #ifndef ITF8_MACROS
 /*

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3569,6 +3569,7 @@ SAM_hdr *cram_read_SAM_hdr(cram_fd *fd) {
 
 	/* Extract header from 1st block */
 	if (-1 == int32_get(b, &header_len) ||
+            header_len < 0 || /* Spec. says signed...  why? */
 	    b->uncomp_size - 4 < header_len) {
 	    cram_free_container(c);
 	    cram_free_block(b);

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3532,12 +3532,12 @@ SAM_hdr *cram_read_SAM_hdr(cram_fd *fd) {
 	    return NULL;
 
 	/* Alloc and read */
-	if (NULL == (header = malloc(header_len+1)))
+	if (header_len < 0 || NULL == (header = malloc(header_len+1)))
 	    return NULL;
 
-	*header = 0;
 	if (header_len != hread(fd->fp, header, header_len))
 	    return NULL;
+	header[header_len] = '\0';
 
 	fd->first_container += 4 + header_len;
     } else {

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3396,6 +3396,11 @@ cram_slice *cram_read_slice(cram_fd *fd) {
 	goto err;
     }
 
+    if (s->hdr->num_blocks < 1) {
+        fprintf(stderr, "Slice does not include any data blocks.\n");
+	goto err;
+    }
+
     s->block = calloc(n = s->hdr->num_blocks, sizeof(*s->block));
     if (!s->block)
 	goto err;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1130,7 +1130,8 @@ int cram_uncompress_block(cram_block *b) {
     case RANS: {
 	unsigned int usize = b->uncomp_size, usize2;
 	uncomp = (char *)rans_uncompress(b->data, b->comp_size, &usize2);
-	assert(usize == usize2);
+	if (!uncomp || usize != usize2)
+ 	    return -1;
 	free(b->data);
 	b->data = (unsigned char *)uncomp;
 	b->alloc = usize2;

--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -217,6 +217,24 @@ cram_metrics *cram_new_metrics(void);
 char *cram_block_method2str(enum cram_block_method m);
 char *cram_content_type2str(enum cram_content_type t);
 
+/*
+ * Find an external block by its content_id
+ */
+
+static inline cram_block *cram_get_block_by_id(cram_slice *slice, int id) {
+    if (slice->block_by_id && id >= 0 && id < 1024) {
+        return slice->block_by_id[id];
+    } else {
+        int i;
+        for (i = 0; i < slice->hdr->num_blocks; i++) {
+	    cram_block *b = slice->block[i];
+	    if (b && b->content_type == EXTERNAL && b->content_id == id)
+	        return b;
+	}
+    }
+    return NULL;
+}
+
 /* --- Accessor macros for manipulating blocks on a byte by byte basis --- */
 
 /* Block size and data pointer. */

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -106,7 +106,8 @@ enum cram_encoding {
     E_BETA               = 6,
     E_SUBEXP             = 7,
     E_GOLOMB_RICE        = 8,
-    E_GAMMA              = 9
+    E_GAMMA              = 9,
+    E_NUM_CODECS         = 10, /* Number of codecs, not a real one. */
 };
 
 enum cram_external_type {

--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -724,6 +724,10 @@ unsigned char *rans_compress(unsigned char *in, unsigned int in_size,
 
 unsigned char *rans_uncompress(unsigned char *in, unsigned int in_size,
 			       unsigned int *out_size) {
+    /* Both rans_uncompress functions need to be able to read at least 9
+       bytes. */
+    if (in_size < 9)
+        return NULL;
     return in[0]
 	? rans_uncompress_O1(in, in_size, out_size)
 	: rans_uncompress_O0(in, in_size, out_size);


### PR DESCRIPTION
These commits fix various problems found by the "american fuzzy lop" tool.  It was actually run on scram_flagstats from the Staden io_lib.  The fixes put in there are all ported to htslib in this branch.
