### PR TITLE
Extra checks in bam_hdr_read.

### DIFF
--- a/htsfile.c
+++ b/htsfile.c
@@ -77,11 +77,12 @@ static int view_sam(hFILE *hfp, const char *filename, int *status)
     }
     if (mode == view_all) {
         bam1_t *b = bam_init1();
-        while (sam_read1(in, hdr, b) >= 0)
-            if (sam_write1(out, hdr, b) != 0) {
+        while (sam_read1(in, hdr, b) >= 0) {
+            if (sam_write1(out, hdr, b) < 0) {
                 *status = EXIT_FAILURE;
                 goto clean;
             }
+        }
         bam_destroy1(b);
     }
 

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -28,6 +28,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <stdint.h>
 #include "hts.h"
+#include "hts_defs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -254,7 +255,7 @@ typedef struct {
      ***************/
 
     bam_hdr_t *bam_hdr_init(void);
-    bam_hdr_t *bam_hdr_read(BGZF *fp);
+    bam_hdr_t *bam_hdr_read(BGZF *fp) HTS_RESULT_USED;
     int bam_hdr_write(BGZF *fp, const bam_hdr_t *h);
     void bam_hdr_destroy(bam_hdr_t *h);
     int bam_name2id(bam_hdr_t *h, const char *ref);
@@ -321,7 +322,7 @@ typedef struct {
 
     typedef htsFile samFile;
     bam_hdr_t *sam_hdr_parse(int l_text, const char *text);
-    bam_hdr_t *sam_hdr_read(samFile *fp);
+    bam_hdr_t *sam_hdr_read(samFile *fp) HTS_RESULT_USED;
     int sam_hdr_write(samFile *fp, const bam_hdr_t *h);
 
     int sam_parse1(kstring_t *s, bam_hdr_t *h, bam1_t *b);

--- a/sam.c
+++ b/sam.c
@@ -113,7 +113,8 @@ bam_hdr_t *bam_hdr_read(BGZF *fp)
     bam_hdr_t *h;
     char buf[4];
     int magic_len, has_EOF;
-    int32_t i = 1, name_len;
+    int32_t i, name_len, num_names = 0;
+    ssize_t bytes;
     // check EOF
     has_EOF = bgzf_check_EOF(fp);
     if (has_EOF < 0) {
@@ -127,26 +128,95 @@ bam_hdr_t *bam_hdr_read(BGZF *fp)
         return 0;
     }
     h = bam_hdr_init();
+    if (!h) return 0;
+
     // read plain text and the number of reference sequences
-    bgzf_read(fp, &h->l_text, 4);
+    bytes = bgzf_read(fp, &h->l_text, 4);
+    if (bytes != 4) goto read_err;
     if (fp->is_be) ed_swap_4p(&h->l_text);
-    h->text = (char*)malloc(h->l_text + 1);
+
+    h->text = (h->l_text < SIZE_MAX - 1
+               ? (char*)malloc((size_t) h->l_text + 1) : NULL);
+    if (!h->text) goto nomem;
     h->text[h->l_text] = 0; // make sure it is NULL terminated
-    bgzf_read(fp, h->text, h->l_text);
-    bgzf_read(fp, &h->n_targets, 4);
+    bytes = bgzf_read(fp, h->text, h->l_text);
+    if (bytes != h->l_text) goto read_err;
+
+    bytes = bgzf_read(fp, &h->n_targets, 4);
+    if (bytes != 4) goto read_err;
     if (fp->is_be) ed_swap_4p(&h->n_targets);
+
+    if (h->n_targets < 0) goto invalid;
+
+    // Ensure no wrap-around problems for the next two mallocs.
+    // If the test below isn't true, one of the mallocs will fail anyway.
+    // Only matters on 32-bit platforms.
+    if (h->n_targets >= (ssize_t) (SIZE_MAX
+                                   / (sizeof(char *) + sizeof(uint32_t)) - 1)) {
+        goto nomem;
+    }
+
     // read reference sequence names and lengths
-    h->target_name = (char**)calloc(h->n_targets, sizeof(char*));
-    h->target_len = (uint32_t*)calloc(h->n_targets, sizeof(uint32_t));
+    h->target_name = (char**)malloc((h->n_targets > 0 ? h->n_targets : 1)
+                                    * sizeof(char *));
+    if (!h->target_name) goto nomem;
+    h->target_len = (uint32_t*)malloc((h->n_targets > 0 ? h->n_targets : 1)
+                                      * sizeof(uint32_t));
+    if (!h->target_len) goto nomem;
+
     for (i = 0; i != h->n_targets; ++i) {
-        bgzf_read(fp, &name_len, 4);
+        bytes = bgzf_read(fp, &name_len, 4);
+        if (bytes != 4) goto read_err;
         if (fp->is_be) ed_swap_4p(&name_len);
-        h->target_name[i] = (char*)calloc(name_len, 1);
-        bgzf_read(fp, h->target_name[i], name_len);
-        bgzf_read(fp, &h->target_len[i], 4);
+        if (name_len <= 0) goto invalid;
+
+        h->target_name[i] = (char*)malloc(name_len);
+        if (!h->target_name[i]) goto nomem;
+        num_names++;
+
+        bytes = bgzf_read(fp, h->target_name[i], name_len);
+        if (bytes != name_len) goto read_err;
+
+        if (h->target_name[i][name_len - 1] != '\0') {
+            /* Fix missing NUL-termination.  Is this being too nice?
+               We could alternatively bail out with an error. */
+            char *new_name;
+            if (name_len == INT32_MAX) goto invalid;
+            new_name = realloc(h->target_name[i], name_len + 1);
+            if (new_name == NULL) goto nomem;
+            h->target_name[i] = new_name;
+            h->target_name[i][name_len] = '\0';
+        }
+
+        bytes = bgzf_read(fp, &h->target_len[i], 4);
+        if (bytes != 4) goto read_err;
         if (fp->is_be) ed_swap_4p(&h->target_len[i]);
     }
     return h;
+
+ nomem:
+    if (hts_verbose >= 1) fprintf(stderr, "[E::%s] out of memory\n", __func__);
+    goto clean;
+
+ read_err:
+    if (hts_verbose >= 1) {
+        if (bytes < 0) {
+            fprintf(stderr, "[E::%s] error reading BGZF stream\n", __func__);
+        } else {
+            fprintf(stderr, "[E::%s] truncated bam header\n", __func__);
+        }
+    }
+    goto clean;
+
+ invalid:
+    if (hts_verbose >= 1) {
+        fprintf(stderr, "[E::%s] invalid BAM binary header\n", __func__);
+    }
+
+ clean:
+    h->n_targets = num_names; // ensure we free only allocated target_names
+    bam_hdr_destroy(h);
+    return NULL;
 }
 
 int bam_hdr_write(BGZF *fp, const bam_hdr_t *h)

--- a/sam.c
+++ b/sam.c
@@ -468,6 +468,7 @@ static hts_idx_t *bam_index(BGZF *fp, int min_shift)
     hts_idx_t *idx;
     bam_hdr_t *h;
     h = bam_hdr_read(fp);
+    if (h == NULL) return NULL;
     if (min_shift > 0) {
         int64_t max_len = 0, s;
         for (i = 0; i < h->n_targets; ++i)

--- a/sam.c
+++ b/sam.c
@@ -128,7 +128,7 @@ bam_hdr_t *bam_hdr_read(BGZF *fp)
         return 0;
     }
     h = bam_hdr_init();
-    if (!h) return 0;
+    if (!h) goto nomem;
 
     // read plain text and the number of reference sequences
     bytes = bgzf_read(fp, &h->l_text, 4);
@@ -214,8 +214,10 @@ bam_hdr_t *bam_hdr_read(BGZF *fp)
     }
 
  clean:
-    h->n_targets = num_names; // ensure we free only allocated target_names
-    bam_hdr_destroy(h);
+    if (h != NULL) {
+        h->n_targets = num_names; // ensure we free only allocated target_names
+        bam_hdr_destroy(h);
+    }
     return NULL;
 }
 

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -152,6 +152,10 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
     h = sam_hdr_read(in);
+    if (h == NULL) {
+        fprintf(stderr, "Couldn't read header for \"%s\"\n", argv[optind]);
+        return EXIT_FAILURE;
+    }
     h->ignore_sam_err = ignore_sam_err;
     b = bam_init1();
 


### PR DESCRIPTION
Makes bam_hdr_read more resistant to broken bam files.  Fixes valgrind failures in several of my American Fuzzy Lop test cases.

