### PR TITLE
bcf_hdr_remove: NULL to remove all records of the given type

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -410,7 +410,7 @@ typedef struct {
     /**
      *  bcf_hdr_remove() - remove VCF header tag
      *  @param type:      one of BCF_HL_*
-     *  @param key:       tag name
+     *  @param key:       tag name or NULL to remove all tags of the given type
      */
     void bcf_hdr_remove(bcf_hdr_t *h, int type, const char *key);
 

--- a/vcf.c
+++ b/vcf.c
@@ -612,8 +612,34 @@ int bcf_hdr_append(bcf_hdr_t *hdr, const char *line)
 
 void bcf_hdr_remove(bcf_hdr_t *hdr, int type, const char *key)
 {
-    int i;
+    int i = 0;
     bcf_hrec_t *hrec;
+    if ( !key )
+    {
+        while ( i<hdr->nhrec )
+        {
+            if ( hdr->hrec[i]->type!=type ) { i++; continue; }
+            hrec = hdr->hrec[i];
+
+            if ( type==BCF_HL_FLT || type==BCF_HL_INFO || type==BCF_HL_FMT || type== BCF_HL_CTG )
+            {
+                int j = bcf_hrec_find_key(hdr->hrec[i], "ID");
+                if ( j>0 )
+                {
+                    vdict_t *d = type==BCF_HL_CTG ? (vdict_t*)hdr->dict[BCF_DT_CTG] : (vdict_t*)hdr->dict[BCF_DT_ID];
+                    khint_t k = kh_get(vdict, d, hdr->hrec[i]->vals[j]);
+                    kh_val(d, k).hrec[type==BCF_HL_CTG?0:type] = NULL;
+                }
+            }
+
+            hdr->dirty = 1;
+            hdr->nhrec--;
+            if ( i < hdr->nhrec )
+                memmove(&hdr->hrec[i],&hdr->hrec[i+1],(hdr->nhrec-i)*sizeof(bcf_hrec_t*));
+            bcf_hrec_destroy(hrec);
+        }
+        return;
+    }
     while (1)
     {
         if ( type==BCF_HL_FLT || type==BCF_HL_INFO || type==BCF_HL_FMT || type== BCF_HL_CTG )


### PR DESCRIPTION
if key is NULL in bcf_hdr_remove, then remove all records of the given type