### PR TITLE
Fix more crashes found while fuzz testing

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -481,25 +481,24 @@ int bgzf_read_block(BGZF *fp)
         }
         if ( header[3] & 0x8 ) // FLG.FNAME
         {
-            while ( nskip<BGZF_BLOCK_SIZE && cblock[nskip] ) nskip++;
-            if ( nskip==BGZF_BLOCK_SIZE )
-            {
-                fp->errcode |= BGZF_ERR_HEADER;
-                return -1;
-            }
+            while ( nskip<count && cblock[nskip] ) nskip++;
             nskip++;
         }
         if ( header[3] & 0x10 ) // FLG.FCOMMENT
         {
-            while ( nskip<BGZF_BLOCK_SIZE && cblock[nskip] ) nskip++;
-            if ( nskip==BGZF_BLOCK_SIZE )
-            {
-                fp->errcode |= BGZF_ERR_HEADER;
-                return -1;
-            }
+            while ( nskip<count && cblock[nskip] ) nskip++;
             nskip++;
         }
         if ( header[3] & 0x2 ) nskip += 2;  //  FLG.FHCRC
+
+        /* FIXME: Should handle this better.  There's no reason why
+           someone shouldn't include a massively long comment in their
+           gzip stream. */
+        if ( nskip >= count )
+        {
+            fp->errcode |= BGZF_ERR_HEADER;
+            return -1;
+        }
 
         fp->is_gzip = 1;
         fp->gz_stream = (z_stream*) calloc(1,sizeof(z_stream));

--- a/cram/sam_header.c
+++ b/cram/sam_header.c
@@ -100,11 +100,13 @@ static int sam_hdr_update_hashes(SAM_hdr *sh,
     /* Add to reference hash? */
     if ((type>>8) == 'S' && (type&0xff) == 'Q') {
 	SAM_hdr_tag *tag;
+        SAM_SQ *new_ref;
 	int nref = sh->nref;
 
-	sh->ref = realloc(sh->ref, (sh->nref+1)*sizeof(*sh->ref));
-	if (!sh->ref)
+	new_ref = realloc(sh->ref, (sh->nref+1)*sizeof(*sh->ref));
+	if (!new_ref)
 	    return -1;
+        sh->ref = new_ref;
 
 	tag = h_type->tag;
 	sh->ref[nref].name = NULL;
@@ -130,7 +132,9 @@ static int sam_hdr_update_hashes(SAM_hdr *sh,
 	    k = kh_put(m_s2i, sh->ref_hash, sh->ref[nref].name, &r);
 	    if (-1 == r) return -1;
 	    kh_val(sh->ref_hash, k) = nref;
-	}
+	} else {
+            return -1; // SN should be present, according to spec.
+        }
 
 	sh->nref++;
     }
@@ -138,11 +142,13 @@ static int sam_hdr_update_hashes(SAM_hdr *sh,
     /* Add to read-group hash? */
     if ((type>>8) == 'R' && (type&0xff) == 'G') {
 	SAM_hdr_tag *tag;
+        SAM_RG *new_rg;
 	int nrg = sh->nrg;
 
-	sh->rg = realloc(sh->rg, (sh->nrg+1)*sizeof(*sh->rg));
-	if (!sh->rg)
+	new_rg = realloc(sh->rg, (sh->nrg+1)*sizeof(*sh->rg));
+	if (!new_rg)
 	    return -1;
+        sh->rg = new_rg;
 
 	tag = h_type->tag;
 	sh->rg[nrg].name = NULL;
@@ -168,7 +174,9 @@ static int sam_hdr_update_hashes(SAM_hdr *sh,
 	    k = kh_put(m_s2i, sh->rg_hash, sh->rg[nrg].name, &r);
 	    if (-1 == r) return -1;
 	    kh_val(sh->rg_hash, k) = nrg;
-	}
+	} else {
+            return -1; // ID should be present, according to spec.
+        }
 
 	sh->nrg++;
     }
@@ -176,11 +184,13 @@ static int sam_hdr_update_hashes(SAM_hdr *sh,
     /* Add to program hash? */
     if ((type>>8) == 'P' && (type&0xff) == 'G') {
 	SAM_hdr_tag *tag;
+        SAM_PG *new_pg;
 	int npg = sh->npg;
 
-	sh->pg = realloc(sh->pg, (sh->npg+1)*sizeof(*sh->pg));
-	if (!sh->pg)
+	new_pg = realloc(sh->pg, (sh->npg+1)*sizeof(*sh->pg));
+	if (!new_pg)
 	    return -1;
+        sh->pg = new_pg;
 
 	tag = h_type->tag;
 	sh->pg[npg].name = NULL;
@@ -235,17 +245,20 @@ static int sam_hdr_update_hashes(SAM_hdr *sh,
 	    k = kh_put(m_s2i, sh->pg_hash, sh->pg[npg].name, &r);
 	    if (-1 == r) return -1;
 	    kh_val(sh->pg_hash, k) = npg;
-	}
+	} else {
+            return -1; // ID should be present, according to spec.
+        }
 
 	/* Add to npg_end[] array. Remove later if we find a PP line */
 	if (sh->npg_end >= sh->npg_end_alloc) {
-	    sh->npg_end_alloc = sh->npg_end_alloc
-		? sh->npg_end_alloc*2
-		: 4;
-	    sh->pg_end = realloc(sh->pg_end,
-				 sh->npg_end_alloc * sizeof(int));
-	    if (!sh->pg_end)
+            int *new_pg_end;
+            int  new_alloc = sh->npg_end_alloc ? sh->npg_end_alloc*2 : 4;
+	    
+	    new_pg_end = realloc(sh->pg_end, new_alloc * sizeof(int));
+	    if (!new_pg_end)
 		return -1;
+            sh->npg_end_alloc = new_alloc;
+            sh->pg_end = new_pg_end;
 	}
 	sh->pg_end[sh->npg_end++] = npg;
 

--- a/sam.c
+++ b/sam.c
@@ -750,6 +750,7 @@ int sam_parse1(kstring_t *s, bam_hdr_t *h, bam1_t *b)
     }
     // qname
     q = _read_token(p);
+    _parse_err(p - q > 255, "query name too long");
     kputsn_(q, p - q, &str);
     c->l_qname = p - q;
     // flag


### PR DESCRIPTION
Stop sam_hdr_update_hashes from returning partly filled-in structures when certain header tags are missing.

Prevent sam_parse1 from reading qnames longer then 255 chars (as the length must fit in a byte).

Stop bgzf_read_block from reading uninitialised memory in its gzip handler if the file ends part way through the header.