### PR TITLE
Fix handling of zero-bit beta codec case.

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -493,10 +493,10 @@ int cram_beta_decode_int(cram_slice *slice, cram_codec *c, cram_block *in, char 
     int32_t *out_i = (int32_t *)out;
     int i, n;
 
-    if (cram_not_enough_bits(in, c->beta.nbits))
-        return -1;
-
     if (c->beta.nbits) {
+        if (cram_not_enough_bits(in, c->beta.nbits))
+            return -1;
+
 	for (i = 0, n = *out_size; i < n; i++)
 	    out_i[i] = get_bits_MSB(in, c->beta.nbits) - c->beta.offset;
     } else {
@@ -510,10 +510,11 @@ int cram_beta_decode_int(cram_slice *slice, cram_codec *c, cram_block *in, char 
 int cram_beta_decode_char(cram_slice *slice, cram_codec *c, cram_block *in, char *out, int *out_size) {
     int i, n;
 
-    if (cram_not_enough_bits(in, c->beta.nbits))
-        return -1;
 
     if (c->beta.nbits) {
+        if (cram_not_enough_bits(in, c->beta.nbits))
+            return -1;
+
 	for (i = 0, n = *out_size; i < n; i++)
 	    out[i] = get_bits_MSB(in, c->beta.nbits) - c->beta.offset;
     } else {

--- a/cram/cram_codecs.h
+++ b/cram/cram_codecs.h
@@ -159,7 +159,7 @@ cram_codec *cram_encoder_init(enum cram_encoding codec, cram_stats *st,
 
 static inline int cram_not_enough_bits(cram_block *blk, int nbits) {
     if (nbits < 0 ||
-	blk->byte >= blk->uncomp_size ||
+	(blk->byte >= blk->uncomp_size && nbits > 0) ||
 	(blk->uncomp_size - blk->byte <= INT32_MAX / 8 + 1 &&
 	 (blk->uncomp_size - blk->byte) * 8 + blk->bit - 7 < nbits)) {
         return 1;


### PR DESCRIPTION
Using the beta codec with nbits=0 is valid, but confuses
cram_not_enough_bits() as it's possible to have no input data in
this case so cram_not_enough_bits thinks it has run out.

Move the calls to cram_not_enough_bits inside checks that c->beta.nbits
is non-zero to avoid the problem.