### PR TITLE
Fix (some) signed one-bit bitfields

### DIFF
--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -47,7 +47,7 @@ struct bgzf_mtaux_t;
 typedef struct __bgzidx_t bgzidx_t;
 
 struct BGZF {
-    int errcode:16, is_write:2, is_be:2, compress_level:9, is_compressed:2, is_gzip:1;
+    unsigned int errcode:16, is_write:2, is_be:2, compress_level:9, is_compressed:2, is_gzip:1;
     int cache_size;
     int block_length, block_offset;
     int64_t block_address, uncompressed_address;

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -43,7 +43,7 @@ typedef struct hFILE {
     char *buffer, *begin, *end, *limit;
     const struct hFILE_backend *backend;
     off_t offset;
-    int at_eof:1;
+    unsigned int at_eof:1;
     int has_errno;
 } hFILE;
 


### PR DESCRIPTION
There are several places in the htslib tree where signed one-bit bitfields are defined. This triggers a lot of compile-time warnings on compilers that actually check for this (unfortunately it seems gcc is not one of them).

This pull request fixes the ones I've run into so far. I can extend this to cover the entire source tree if that is deemed necessary (though that could be a bit riskier than the current patch set).
