### PR TITLE
Cigar P support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ lib*.so.*
 /tabix
 /test/fieldarith
 /test/hfile
+/test/pileup
 /test/sam
 /test/test-regidx
 /test/test-vcf-api

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ BUILT_PROGRAMS = \
 BUILT_TEST_PROGRAMS = \
 	test/fieldarith \
 	test/hfile \
+	test/pileup \
 	test/sam \
 	test/test-regidx \
 	test/test_view \
@@ -298,6 +299,9 @@ test/fieldarith: test/fieldarith.o libhts.a
 test/hfile: test/hfile.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/hfile.o libhts.a $(LDLIBS) -lz
 
+test/pileup: test/pileup.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/pileup.o libhts.a $(LDLIBS) -lz
+
 test/sam: test/sam.o libhts.a
 	$(CC) -pthread $(LDFLAGS) -o $@ test/sam.o libhts.a $(LDLIBS) -lz
 
@@ -315,6 +319,7 @@ test/test-vcf-sweep: test/test-vcf-sweep.o libhts.a
 
 test/fieldarith.o: test/fieldarith.c $(htslib_sam_h)
 test/hfile.o: test/hfile.c $(htslib_hfile_h) $(htslib_hts_defs_h)
+test/pileup.o: test/pileup.c $(htslib_sam_h)
 test/sam.o: test/sam.c $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h)
 test/test-regidx.o: test/test-regidx.c $(htslib_regidx_h)
 test/test_view.o: test/test_view.c $(cram_h) $(htslib_sam_h)

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -355,10 +355,11 @@ typedef struct {
  @field  indel      indel length; 0 for no indel, positive for ins and negative for del
  @field  level      the level of the read in the "viewer" mode
  @field  is_del     1 iff the base on the padded read is a deletion
- @field  is_head    ???
- @field  is_tail    ???
- @field  is_refskip ???
- @field  aux        ???
+ @field  is_head    1 iff this is the first base in the query sequence
+ @field  is_tail    1 iff this is the last base in the query sequence
+ @field  is_refskip 1 iff the base on the padded read is part of CIGAR N op
+ @field  aux        (used by bcf_call_gap_prep())
+ @field  cigar_ind  index of the CIGAR operator that has just been processed
 
  @discussion See also bam_plbuf_push() and bam_lplbuf_push(). The
  difference between the two functions is that the former does not
@@ -371,6 +372,7 @@ typedef struct {
     int32_t qpos;
     int indel, level;
     uint32_t is_del:1, is_head:1, is_tail:1, is_refskip:1, aux:28;
+    int cigar_ind;
 } bam_pileup1_t;
 
 typedef int (*bam_plp_auto_f)(void *data, bam1_t *b);
@@ -408,6 +410,15 @@ typedef struct __bam_mplp_t *bam_mplp_t;
     void bam_mplp_destroy(bam_mplp_t iter);
     void bam_mplp_set_maxcnt(bam_mplp_t iter, int maxcnt);
     int bam_mplp_auto(bam_mplp_t iter, int *_tid, int *_pos, int *n_plp, const bam_pileup1_t **plp);
+
+    /*
+     * Fills out the kstring with the padded insertion sequence for the current
+     * location in 'p'.  If this is not an insertion site, the string is blank.
+     *
+     * Returns the length of insertion string on success;
+     *        -1 on failure.
+     */
+    int bam_plp_insertion(const bam_pileup1_t *p, kstring_t *ins);
 
 #endif // ~!defined(BAM_NO_PILEUP)
 

--- a/test/pileup.c
+++ b/test/pileup.c
@@ -1,0 +1,103 @@
+/*  test/pileup.c -- simple pileup tester
+
+    Copyright (C) 2014 Genome Research Ltd.
+
+    Author: James Bonfield <jkb@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <stdio.h>
+#include "htslib/sam.h"
+
+#define MIN(a,b) ((a)<(b)?(a):(b))
+
+typedef struct ptest_t {
+    samFile *fp;
+    bam_hdr_t *fp_hdr;
+} ptest_t;
+
+static int readaln(void *data, bam1_t *b) {
+    ptest_t *g = (ptest_t*)data;
+    int ret;
+
+    while (1) {
+	ret = sam_read1(g->fp, g->fp_hdr, b);
+	if (ret < 0) break;
+	if ( b->core.flag & (BAM_FUNMAP | BAM_FSECONDARY | BAM_FQCFAIL | BAM_FDUP) ) continue;
+	break;
+    }
+
+    return ret;
+}
+
+int main(int argc, char **argv) {
+    bam_plp_t plp;
+    const bam_pileup1_t *p;
+    int tid, pos, n;
+    ptest_t g;
+
+    if (argc != 2) {
+	fprintf(stderr, "Usage: pileup foo.bam\n");
+	return 1;
+    }
+
+    g.fp = sam_open(argv[1], "r");
+    g.fp_hdr = sam_hdr_read(g.fp);
+
+    plp = bam_plp_init(readaln, &g);
+    while ((p = bam_plp_auto(plp, &tid, &pos, &n)) != 0) {
+	int i;
+
+        if (tid < 0) break;
+
+	printf("%2d\t%6d\t", tid, pos+1);
+
+	for (i = 0; i < n; i++, p++) {
+            uint8_t *seq = bam_get_seq(p->b);
+	    if (p->is_head)
+		putchar('^'), putchar('!'+MIN(p->b->core.qual,93));
+
+	    if (p->is_del)
+		putchar('*');
+	    else
+		putchar(seq_nt16_str[bam_seqi(seq, p->qpos)]);
+
+	    if (p->indel > 0) {
+		int j;
+		printf("%+d(", p->indel);
+		for (j = 1; j<=p->indel; j++)
+		    putchar(seq_nt16_str[bam_seqi(seq, p->qpos+j-p->is_del)]);
+		putchar(')');
+	    }
+	    if (p->indel < 0) {
+		printf("%+d(?)", p->indel);
+	    }
+	    if (p->is_tail)
+		putchar('$');
+	}
+
+	putchar('\n');
+    }
+    bam_plp_destroy(plp);
+
+    bam_hdr_destroy(g.fp_hdr);
+    sam_close(g.fp);
+
+    return 0;
+}


### PR DESCRIPTION
Rebased and updated version of @jkbonfield's PR #157, which:

> Adds a bam_plp_insertion() function that queries the cigar string to cope with multiple I and P operators, producing an aligned insertion sequence.

However the addition of `cigar_ind` is a binary compatibility issue.  We may be able to fix this by completely reworking the API addition, or…
