### PR TITLE
Cram reheader branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,8 @@ LIBHTS_OBJS = \
 	cram/string_alloc.o \
 	cram/thread_pool.o \
 	cram/vlen.o \
-	cram/zfio.o
+	cram/zfio.o \
+	cram/cram_external.o
 
 cram_h = cram/cram.h $(cram_samtools_h) $(cram_sam_header_h) $(cram_structs_h) $(cram_io_h) cram/cram_encode.h cram/cram_decode.h cram/cram_stats.h cram/cram_codecs.h cram/cram_index.h
 cram_io_h = cram/cram_io.h $(cram_misc_h)

--- a/cram/cram.h
+++ b/cram/cram.h
@@ -52,4 +52,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cram_codecs.h"
 #include "cram_index.h"
 
+// Validate against the external cram.h,
+//
+// This contains duplicated portions from cram_io.h and cram_structs.h,
+// so we want to ensure that the prototypes match.
+#include "htslib/cram.h"
+
 #endif

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2015 Genome Research Ltd.
+Author: James Bonfield <jkb@sanger.ac.uk>
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, 
+this list of conditions and the following disclaimer in the documentation 
+and/or other materials provided with the distribution.
+
+   3. Neither the names Genome Research Ltd and Wellcome Trust Sanger
+Institute nor the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY GENOME RESEARCH LTD AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL GENOME RESEARCH LTD OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*! \file
+ * External CRAM interface.
+ *
+ * Internally we're happy to use macros and to grub around in the cram
+ * structures.  This isn't very sustainable for an externally usable
+ * ABI though, so we have anonymous structs and accessor functions too
+ * to permit software such as samtools reheader to manipulate cram
+ * containers and blocks in a robust manner.
+ */
+
+#include "htslib/hfile.h"
+#include "cram/cram.h"
+
+/*
+ *-----------------------------------------------------------------------------
+ * cram_fd
+ */
+SAM_hdr *cram_fd_get_header(cram_fd *fd) { return fd->header; }
+void cram_fd_set_header(cram_fd *fd, SAM_hdr *hdr) { fd->header = hdr; }
+
+int cram_fd_get_version(cram_fd *fd) { return fd->version; }
+void cram_fd_set_version(cram_fd *fd, int vers) { fd->version = vers; }
+
+int cram_major_vers(cram_fd *fd) { return CRAM_MAJOR_VERS(fd->version); }
+int cram_mINOR_vers(cram_fd *fd) { return CRAM_MINOR_VERS(fd->version); }
+
+hFILE *cram_fd_get_fp(cram_fd *fd) { return fd->fp; }
+void cram_fd_set_fp(cram_fd *fd, hFILE *fp) { fd->fp = fp; }
+
+
+/*
+ *-----------------------------------------------------------------------------
+ * cram_container
+ */
+int32_t cram_container_get_length(cram_container *c) {
+    return c->length;
+}
+
+void cram_container_set_length(cram_container *c, int32_t length) {
+    c->length = length;
+}
+
+
+int32_t cram_container_get_num_blocks(cram_container *c) {
+    return c->num_blocks;
+}
+
+void cram_container_set_num_blocks(cram_container *c, int32_t num_blocks) {
+    c->num_blocks = num_blocks;
+}
+
+
+/* Returns the landmarks[] array and the number of elements
+ * in num_landmarks.
+ */
+int32_t *cram_container_get_landmarks(cram_container *c, int32_t *num_landmarks) {
+    *num_landmarks = c->num_landmarks;
+    return c->landmark;
+}
+
+/* Sets the landmarks[] array (pointer copy, not a memory dup) and
+ * num_landmarks value.
+ */
+void cram_container_set_landmarks(cram_container *c, int32_t num_landmarks,
+				  int32_t *landmarks) {
+    c->num_landmarks = num_landmarks;
+    c->landmark = landmarks;
+}
+
+
+/*
+ *-----------------------------------------------------------------------------
+ * cram_block
+ */
+int32_t cram_block_get_content_id(cram_block *b)  { return b->content_id; }
+int32_t cram_block_get_comp_size(cram_block *b)   { return b->comp_size; }
+int32_t cram_block_get_uncomp_size(cram_block *b) { return b->uncomp_size; }
+int32_t cram_block_get_crc32(cram_block *b)       { return b->crc32; }
+void *  cram_block_get_data(cram_block *b)        { return b->data; }
+
+void cram_block_set_content_id(cram_block *b, int32_t id) { b->content_id = id; }
+void cram_block_set_comp_size(cram_block *b, int32_t size) { b->comp_size = size; }
+void cram_block_set_uncomp_size(cram_block *b, int32_t size) { b->uncomp_size = size; }
+void cram_block_set_crc32(cram_block *b, int32_t crc) { b->crc32 = crc; }
+void cram_block_set_data(cram_block *b, void *data) { b->data = data; }
+
+int cram_block_append(cram_block *b, void *data, int size) {
+    BLOCK_APPEND(b, data, size);
+    return BLOCK_DATA(b) ? 0 : -1; // It'll do for now...
+}
+void cram_block_update_size(cram_block *b) { BLOCK_UPLEN(b); }
+
+// Offset is known as "size" internally, but it can be confusing.
+size_t cram_block_get_offset(cram_block *b) { return BLOCK_SIZE(b); }
+void cram_block_set_offset(cram_block *b, size_t offset) { BLOCK_SIZE(b) = offset; }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -994,6 +994,27 @@ cram_block *cram_read_block(cram_fd *fd) {
     return b;
 }
 
+
+/*
+ * Computes the size of a cram block, including the block
+ * header itself.
+ */
+uint32_t cram_block_size(cram_block *b) {
+    unsigned char dat[100], *cp = dat;;
+    uint32_t sz;
+
+    *cp++ = b->method;
+    *cp++ = b->content_type;
+    cp += itf8_put(cp, b->content_id);
+    cp += itf8_put(cp, b->comp_size);
+    cp += itf8_put(cp, b->uncomp_size);
+
+    sz = cp-dat + 4;
+    sz += b->method == RAW ? b->uncomp_size : b->comp_size;
+
+    return sz;
+}
+
 /*
  * Writes a CRAM block.
  * Returns 0 on success
@@ -1218,6 +1239,8 @@ static char *cram_compress_by_method(char *in, size_t in_size,
  * The logic here is that sometimes Z_RLE does a better job than Z_FILTERED
  * or Z_DEFAULT_STRATEGY on quality data. If so, we'd rather use it as it is
  * significantly faster.
+ *
+ * Method and level -1 implies defaults, as specified in cram_fd.
  */
 int cram_compress_block(cram_fd *fd, cram_block *b, cram_metrics *metrics,
 			int method, int level) {
@@ -1226,6 +1249,17 @@ int cram_compress_block(cram_fd *fd, cram_block *b, cram_metrics *metrics,
     size_t comp_size = 0;
     int strat;
 
+    if (method == -1) {
+	method = 1<<GZIP;
+	if (fd->use_bz2)
+	    method |= 1<<BZIP2;
+	if (fd->use_lzma)
+	    method |= 1<<LZMA;
+    }
+
+    if (level == -1)
+	level = fd->level;
+    
     //fprintf(stderr, "IN: block %d, sz %d\n", b->content_id, b->uncomp_size);
 
     if (method == RAW || level == 0 || b->uncomp_size == 0) {
@@ -2946,6 +2980,75 @@ cram_container *cram_read_container(cram_fd *fd) {
     return c;
 }
 
+
+/* MAXIMUM storage size needed for the container. */
+int cram_container_size(cram_container *c) {
+    return 55 + 5*c->num_landmarks;
+}
+
+
+/*
+ * Stores the container structure in dat and returns *size as the
+ * number of bytes written to dat[].  The input size of dat is also
+ * held in *size and should be initialised to cram_container_size(c).
+ *
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_store_container(cram_fd *fd, cram_container *c, char *dat, int *size)
+{
+    char *cp = dat;
+    int i;
+    
+    // Check the input buffer is large enough according to our stated
+    // requirements. (NOTE: it may actually take less.)
+    if (cram_container_size(c) > *size)
+        return -1;
+
+    if (CRAM_MAJOR_VERS(fd->version) == 1) {
+	cp += itf8_put(cp, c->length);
+    } else {
+	*(int32_t *)cp = le_int4(c->length);
+	cp += 4;
+    }
+    if (c->multi_seq) {
+	cp += itf8_put(cp, -2);
+	cp += itf8_put(cp, 0);
+	cp += itf8_put(cp, 0);
+    } else {
+	cp += itf8_put(cp, c->ref_seq_id);
+	cp += itf8_put(cp, c->ref_seq_start);
+	cp += itf8_put(cp, c->ref_seq_span);
+    }
+    cp += itf8_put(cp, c->num_records);
+    if (CRAM_MAJOR_VERS(fd->version) == 2) {
+	cp += itf8_put(cp, c->record_counter);
+	cp += ltf8_put(cp, c->num_bases);
+    } else if (CRAM_MAJOR_VERS(fd->version) >= 3) {
+	cp += ltf8_put(cp, c->record_counter);
+	cp += ltf8_put(cp, c->num_bases);
+    }
+
+    cp += itf8_put(cp, c->num_blocks);
+    cp += itf8_put(cp, c->num_landmarks);
+    for (i = 0; i < c->num_landmarks; i++)
+	cp += itf8_put(cp, c->landmark[i]);
+
+    if (CRAM_MAJOR_VERS(fd->version) >= 3) {
+	c->crc32 = crc32(0L, (uc *)dat, cp-dat);
+	cp[0] =  c->crc32        & 0xff;
+	cp[1] = (c->crc32 >>  8) & 0xff;
+	cp[2] = (c->crc32 >> 16) & 0xff;
+	cp[3] = (c->crc32 >> 24) & 0xff;
+	cp += 4;
+    }
+
+    *size = cp-dat; // actual used size
+
+    return 0;
+}
+
+
 /*
  * Writes a container structure.
  *
@@ -3753,14 +3856,8 @@ int cram_write_SAM_hdr(cram_fd *fd, SAM_hdr *hdr) {
 	BLOCK_UPLEN(b);
 
 	// Compress header block if V3.0 and above
-	if (CRAM_MAJOR_VERS(fd->version) >= 3 && fd->level > 0) {
-	    int method = 1<<GZIP;
-	    if (fd->use_bz2)
-		method |= 1<<BZIP2;
-	    if (fd->use_lzma)
-		method |= 1<<LZMA;
-	    cram_compress_block(fd, b, NULL, method, fd->level);
-	} 
+	if (CRAM_MAJOR_VERS(fd->version) >= 3)
+	    cram_compress_block(fd, b, NULL, -1, -1);
 
 	if (blank_block) {
 	    c->length = b->comp_size + 2 + 4*is_cram_3 +

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -662,7 +662,7 @@ int int32_encode(cram_fd *fd, int32_t val) {
 }
 
 /* As int32_decoded/encode, but from/to blocks instead of cram_fd */
-int int32_get(cram_block *b, int32_t *val) {
+int int32_get_blk(cram_block *b, int32_t *val) {
     if (b->uncomp_size - BLOCK_SIZE(b) < 4)
 	return -1;
 
@@ -676,7 +676,7 @@ int int32_get(cram_block *b, int32_t *val) {
 }
 
 /* As int32_decoded/encode, but from/to blocks instead of cram_fd */
-int int32_put(cram_block *b, int32_t val) {
+int int32_put_blk(cram_block *b, int32_t val) {
     unsigned char cp[4];
     cp[0] = ( val      & 0xff);
     cp[1] = ((val>>8)  & 0xff);
@@ -3572,7 +3572,7 @@ SAM_hdr *cram_read_SAM_hdr(cram_fd *fd) {
 	    itf8_size(b->comp_size);
 
 	/* Extract header from 1st block */
-	if (-1 == int32_get(b, &header_len) ||
+	if (-1 == int32_get_blk(b, &header_len) ||
             header_len < 0 || /* Spec. says signed...  why? */
 	    b->uncomp_size - 4 < header_len) {
 	    cram_free_container(c);
@@ -3668,7 +3668,7 @@ int cram_write_SAM_hdr(cram_fd *fd, SAM_hdr *hdr) {
 	    return -1;
     }
 
-    /* 1.0 requires and UNKNOWN read-group */
+    /* 1.0 requires an UNKNOWN read-group */
     if (CRAM_MAJOR_VERS(fd->version) == 1) {
 	if (!sam_hdr_find_rg(hdr, "UNKNOWN"))
 	    if (sam_hdr_add(hdr, "RG",
@@ -3748,7 +3748,7 @@ int cram_write_SAM_hdr(cram_fd *fd, SAM_hdr *hdr) {
 	    return -1;
 	}
 
-	int32_put(b, header_len);
+	int32_put_blk(b, header_len);
 	BLOCK_APPEND(b, sam_hdr_str(hdr), header_len);
 	BLOCK_UPLEN(b);
 

--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -142,6 +142,22 @@ static inline int safe_itf8_get(const char *cp, const char *endp,
  */
 int itf8_put_blk(cram_block *blk, int val);
 
+/*! Pulls a literal 32-bit value from a block.
+ *
+ * @returns the number of bytes decoded;
+ *         -1 on failure.
+ */
+int int32_get_blk(cram_block *b, int32_t *val);
+
+/*! Pushes a literal 32-bit value onto the end of a block.
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure.
+ */
+int int32_put_blk(cram_block *blk, int32_t val);
+
+
 /**@}*/
 /**@{ ----------------------------------------------------------------------
  * CRAM blocks - the dynamically growable data block. We have code to

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -88,7 +88,7 @@ struct hFILE;
 
 #define MAX_STAT_VAL 1024
 //#define MAX_STAT_VAL 16
-typedef struct {
+typedef struct cram_stats {
     int freqs[MAX_STAT_VAL];
     khash_t(m_i2i) *h;
     int nsamp; // total number of values added
@@ -176,7 +176,7 @@ enum cram_DS_ID {
 };
 
 /* "File Definition Structure" */
-typedef struct {
+typedef struct cram_file_def {
     char    magic[4];
     uint8_t major_version;
     uint8_t minor_version;
@@ -246,7 +246,7 @@ typedef struct {
 } cram_metrics;
 
 /* Block */
-typedef struct {
+typedef struct cram_block {
     enum cram_block_method  method, orig_method;
     enum cram_content_type  content_type;
     int32_t  content_id;
@@ -316,7 +316,7 @@ typedef struct cram_map {
 } cram_map;
 
 /* Mapped or unmapped slice header block */
-typedef struct {
+typedef struct cram_block_slice_hdr {
     enum cram_content_type content_type;
     int32_t ref_seq_id;     /* if content_type == MAPPED_SLICE */
     int32_t ref_seq_start;  /* if content_type == MAPPED_SLICE */
@@ -341,7 +341,7 @@ struct ref_entry;
  *
  * OR... are landmarks the start/end points of slices?
  */
-typedef struct {
+typedef struct cram_container {
     int32_t  length;
     int32_t  ref_seq_id;
     int32_t  ref_seq_start;
@@ -394,7 +394,7 @@ typedef struct {
 /*
  * A single cram record
  */
-typedef struct {
+typedef struct cram_record {
     struct cram_slice *s; // Filled out by cram_decode only
 
     int32_t ref_id;       // fixed for all recs in slice?
@@ -448,7 +448,7 @@ typedef struct {
  * A feature is a base difference, used for the sequence reference encoding.
  * (We generate these internally when writing CRAM.)
  */
-typedef struct {
+typedef struct cram_feature {
     union {
 	struct {
 	    int pos;

--- a/cram/sam_header.c
+++ b/cram/sam_header.c
@@ -446,14 +446,13 @@ int sam_hdr_vadd(SAM_hdr *sh, const char *type, va_list ap, ...) {
 	return -1;
     if (-1 == (k = kh_put(sam_hdr, sh->h, type_i, &new)))
 	return -1;
-    kh_val(sh->h, k) = h_type;
 
     // Form the ring, either with self or other lines of this type
     if (!new) {
 	SAM_hdr_type *t = kh_val(sh->h, k), *p;
 	p = t->prev;
 	    
-	assert(p->next = t);
+	assert(p->next == t);
 	p->next = h_type;
 	h_type->prev = p;
 
@@ -461,6 +460,7 @@ int sam_hdr_vadd(SAM_hdr *sh, const char *type, va_list ap, ...) {
 	h_type->next = t;
 	h_type->order = p->order + 1;
     } else {
+	kh_val(sh->h, k) = h_type;
 	h_type->prev = h_type->next = h_type;
 	h_type->order = 0;
     }
@@ -1168,7 +1168,7 @@ const char *sam_hdr_PG_ID(SAM_hdr *sh, const char *name) {
     do {
 	sprintf(sh->ID_buf, "%.1000s.%d", name, sh->ID_cnt++);
 	k = kh_get(m_s2i, sh->pg_hash, sh->ID_buf);
-    } while (k == kh_end(sh->pg_hash));
+    } while (k != kh_end(sh->pg_hash));
 
     return sh->ID_buf;
 }

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -1,0 +1,433 @@
+/*
+Copyright (c) 2015 Genome Research Ltd.
+Author: James Bonfield <jkb@sanger.ac.uk>
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice, 
+this list of conditions and the following disclaimer in the documentation 
+and/or other materials provided with the distribution.
+
+   3. Neither the names Genome Research Ltd and Wellcome Trust Sanger
+Institute nor the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY GENOME RESEARCH LTD AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL GENOME RESEARCH LTD OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/*! \file
+ * CRAM interface.
+ *
+ * Consider using the higher level hts_*() API for programs that wish to
+ * be file format agnostic (see htslib/hts.h).
+ *
+ * This API should be used for CRAM specific code. The specifics of the
+ * public API are implemented in cram_io.h, cram_encode.h and cram_decode.h
+ * although these should not be included directly (use this file instead).
+ */
+
+#ifndef _CRAM_EXTERNAL_H_
+#define _CRAM_EXTERNAL_H_
+
+#ifndef _CRAM_STRUCTS_H_
+enum cram_block_method {
+    ERROR    = -1,
+    RAW      = 0,
+    GZIP     = 1,
+    BZIP2    = 2,
+    LZMA     = 3,
+    RANS     = 4,  // Generic; either order
+    RANS0    = 4,
+    RANS1    = 10, // Not externalised; stored as RANS (generic)
+    GZIP_RLE = 11, // NB: not externalised in CRAM
+};
+
+enum cram_content_type {
+    CT_ERROR           = -1,
+    FILE_HEADER        = 0,
+    COMPRESSION_HEADER = 1,
+    MAPPED_SLICE       = 2,
+    UNMAPPED_SLICE     = 3, // CRAM V1.0 only
+    EXTERNAL           = 4,
+    CORE               = 5,
+};
+
+// Opaque data types, see cram_structs for the fully fledged versions.
+typedef struct SAM_hdr SAM_hdr;
+typedef struct cram_file_def cram_file_def;
+typedef struct cram_fd cram_fd;
+typedef struct cram_container cram_container;
+typedef struct cram_block cram_block;
+typedef struct cram_slice cram_slice;
+typedef struct cram_metrics cram_metrics;
+typedef struct cram_block_slice_hdr cram_block_slice_hdr;
+typedef struct cram_block_compression_hdr cram_block_compression_hdr;
+typedef struct refs_t refs_t; // need this?
+
+struct hFILE;
+#endif
+
+// Accessor functions
+
+/*
+ *-----------------------------------------------------------------------------
+ * cram_fd
+ */
+SAM_hdr *cram_fd_get_header(cram_fd *fd);
+void cram_fd_set_header(cram_fd *fd, SAM_hdr *hdr);
+
+int cram_fd_get_version(cram_fd *fd);
+void cram_fd_set_version(cram_fd *fd, int vers);
+
+int cram_major_vers(cram_fd *fd);
+int cram_mINOR_vers(cram_fd *fd);
+
+struct hFILE *cram_fd_get_fp(cram_fd *fd);
+void cram_fd_set_fp(cram_fd *fd, struct hFILE *fp);
+
+
+/*
+ *-----------------------------------------------------------------------------
+ * cram_container
+ */
+int32_t cram_container_get_length(cram_container *c);
+void cram_container_set_length(cram_container *c, int32_t length);
+int32_t cram_container_get_num_blocks(cram_container *c);
+void cram_container_set_num_blocks(cram_container *c, int32_t num_blocks);
+int32_t *cram_container_get_landmarks(cram_container *c, int32_t *num_landmarks);
+void cram_container_set_landmarks(cram_container *c, int32_t num_landmarks,
+				  int32_t *landmarks);
+
+
+/*
+ *-----------------------------------------------------------------------------
+ * cram_block
+ */
+int32_t cram_block_get_content_id(cram_block *b);
+int32_t cram_block_get_comp_size(cram_block *b);
+int32_t cram_block_get_uncomp_size(cram_block *b);
+int32_t cram_block_get_crc32(cram_block *b);
+void *  cram_block_get_data(cram_block *b);
+
+void cram_block_set_content_id(cram_block *b, int32_t id);
+void cram_block_set_comp_size(cram_block *b, int32_t size);
+void cram_block_set_uncomp_size(cram_block *b, int32_t size);
+void cram_block_set_crc32(cram_block *b, int32_t crc);
+void cram_block_set_data(cram_block *b, void *data);
+
+int cram_block_append(cram_block *b, void *data, int size);
+void cram_block_update_size(cram_block *b);
+
+// Offset is known as "size" internally, but it can be confusing.
+size_t cram_block_get_offset(cram_block *b);
+void cram_block_set_offset(cram_block *b, size_t offset);
+
+/*
+ * Computes the size of a cram block, including the block
+ * header itself.
+ */
+uint32_t cram_block_size(cram_block *b);
+
+/*
+ *-----------------------------------------------------------------------------
+ * SAM_hdr
+ */
+
+/*! Tokenises a SAM header into a hash table.
+ *
+ * Also extracts a few bits on specific data types, such as @RG lines.
+ *
+ * @return
+ * Returns a SAM_hdr struct on success (free with sam_hdr_free());
+ *         NULL on failure
+ */
+SAM_hdr *sam_hdr_parse_(const char *hdr, int len);
+
+
+/*
+ *-----------------------------------------------------------------------------
+ * cram_io basics
+ */
+
+/**@{ ----------------------------------------------------------------------
+ * CRAM blocks - the dynamically growable data block. We have code to
+ * create, update, (un)compress and read/write.
+ *
+ * These are derived from the deflate_interlaced.c blocks, but with the
+ * CRAM extension of content types and IDs.
+ */
+
+/*! Allocates a new cram_block structure with a specified content_type and
+ * id.
+ *
+ * @return
+ * Returns block pointer on success;
+ *         NULL on failure
+ */
+cram_block *cram_new_block(enum cram_content_type content_type,
+			   int content_id);
+
+/*! Reads a block from a cram file.
+ *
+ * @return
+ * Returns cram_block pointer on success;
+ *         NULL on failure
+ */
+cram_block *cram_read_block(cram_fd *fd);
+
+/*! Writes a CRAM block.
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_write_block(cram_fd *fd, cram_block *b);
+
+/*! Frees a CRAM block, deallocating internal data too.
+ */
+void cram_free_block(cram_block *b);
+
+/*! Uncompresses a CRAM block, if compressed.
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_uncompress_block(cram_block *b);
+
+/*! Compresses a block.
+ *
+ * Compresses a block using one of two different zlib strategies. If we only
+ * want one choice set strat2 to be -1.
+ *
+ * The logic here is that sometimes Z_RLE does a better job than Z_FILTERED
+ * or Z_DEFAULT_STRATEGY on quality data. If so, we'd rather use it as it is
+ * significantly faster.
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_compress_block(cram_fd *fd, cram_block *b, cram_metrics *metrics,
+			int method, int level);
+
+/**@}*/
+/**@{ ----------------------------------------------------------------------
+ * Containers
+ */
+
+/*! Creates a new container, specifying the maximum number of slices
+ * and records permitted.
+ *
+ * @return
+ * Returns cram_container ptr on success;
+ *         NULL on failure
+ */
+cram_container *cram_new_container(int nrec, int nslice);
+void cram_free_container(cram_container *c);
+
+/*! Reads a container header.
+ *
+ * @return
+ * Returns cram_container on success;
+ *         NULL on failure or no container left (fd->err == 0).
+ */
+cram_container *cram_read_container(cram_fd *fd);
+
+/*! Writes a container structure.
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_write_container(cram_fd *fd, cram_container *h);
+
+/*
+ * Stores the container structure in dat and returns *size as the
+ * number of bytes written to dat[].  The input size of dat is also
+ * held in *size and should be initialised to cram_container_size(c).
+ *
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_store_container(cram_fd *fd, cram_container *c, char *dat, int *size);
+
+int cram_container_size(cram_container *c);
+
+/**@}*/
+/**@{ ----------------------------------------------------------------------
+ * The top-level cram opening, closing and option handling
+ */
+
+/*! Opens a CRAM file for read (mode "rb") or write ("wb").
+ *
+ * The filename may be "-" to indicate stdin or stdout.
+ *
+ * @return
+ * Returns file handle on success;
+ *         NULL on failure.
+ */
+cram_fd *cram_open(const char *filename, const char *mode);
+
+/*! Opens an existing stream for reading or writing.
+ *
+ * @return
+ * Returns file handle on success;
+ *         NULL on failure.
+ */
+cram_fd *cram_dopen(struct hFILE *fp, const char *filename, const char *mode);
+
+/*! Closes a CRAM file.
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_close(cram_fd *fd);
+
+/*
+ * Seek within a CRAM file.
+ *
+ * Returns 0 on success
+ *        -1 on failure
+ */
+int cram_seek(cram_fd *fd, off_t offset, int whence);
+
+/*
+ * Flushes a CRAM file.
+ * Useful for when writing to stdout without wishing to close the stream.
+ *
+ * Returns 0 on success
+ *        -1 on failure
+ */
+int cram_flush(cram_fd *fd);
+
+/*! Checks for end of file on a cram_fd stream.
+ *
+ * @return
+ * Returns 0 if not at end of file
+ *         1 if we hit an expected EOF (end of range or EOF block)
+ *         2 for other EOF (end of stream without EOF block)
+ */
+int cram_eof(cram_fd *fd);
+
+/*! Sets options on the cram_fd.
+ *
+ * See CRAM_OPT_* definitions in cram_structs.h.
+ * Use this immediately after opening.
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_set_option(cram_fd *fd, enum cram_option opt, ...);
+
+/*! Sets options on the cram_fd.
+ *
+ * See CRAM_OPT_* definitions in cram_structs.h.
+ * Use this immediately after opening.
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_set_voption(cram_fd *fd, enum cram_option opt, va_list args);
+
+/*!
+ * Attaches a header to a cram_fd.
+ *
+ * This should be used when creating a new cram_fd for writing where
+ * we have an SAM_hdr already constructed (eg from a file we've read
+ * in).
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int cram_set_header(cram_fd *fd, SAM_hdr *hdr);
+
+
+/* As int32_decoded/encode, but from/to blocks instead of cram_fd */
+int int32_put_blk(cram_block *b, int32_t val);
+
+/**@}*/
+/**@{ -------------------------------------------------------------------*/
+/*! Deallocates all storage used by a SAM_hdr struct.
+ *
+ * This also decrements the header reference count. If after decrementing 
+ * it is still non-zero then the header is assumed to be in use by another
+ * caller and the free is not done.
+ *
+ * This is a synonym for sam_hdr_dec_ref().
+ */
+void sam_hdr_free(SAM_hdr *hdr);
+
+/*! Returns the current length of the SAM_hdr in text form.
+ *
+ * Call sam_hdr_rebuild() first if editing has taken place.
+ */
+int sam_hdr_length(SAM_hdr *hdr);
+
+/*! Returns the string form of the SAM_hdr.
+ *
+ * Call sam_hdr_rebuild() first if editing has taken place.
+ */
+char *sam_hdr_str(SAM_hdr *hdr);
+
+/*! Appends a formatted line to an existing SAM header.
+ *
+ * Line is a full SAM header record, eg "@SQ\tSN:foo\tLN:100", with
+ * optional new-line. If it contains more than 1 line then multiple lines
+ * will be added in order.
+ *
+ * Len is the length of the text data, or 0 if unknown (in which case
+ * it should be null terminated).
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+
+/*! Add an @PG line.
+ *
+ * If we wish complete control over this use sam_hdr_add() directly. This
+ * function uses that, but attempts to do a lot of tedious house work for
+ * you too.
+ *
+ * - It will generate a suitable ID if the supplied one clashes.
+ * - It will generate multiple @PG records if we have multiple PG chains.
+ *
+ * Call it as per sam_hdr_add() with a series of key,value pairs ending
+ * in NULL.
+ *
+ * @return
+ * Returns 0 on success;
+ *        -1 on failure
+ */
+int sam_hdr_add_PG(SAM_hdr *sh, const char *name, ...);
+
+/*!
+ * A function to help with construction of CL tags in @PG records.
+ * Takes an argc, argv pair and returns a single space-separated string.
+ * This string should be deallocated by the calling function.
+ * 
+ * @return
+ * Returns malloced char * on success;
+ *         NULL on failure
+ */
+char *stringify_argv(int argc, char *argv[]);
+/**@}*/
+#endif


### PR DESCRIPTION
Needed for the Samtools reheader branch.

The changes fix a bug uncovered by using a function we haven't needed so far (io_lib's Scramble used it, but not Samtools).  Also exported a couple more CRAM functions.