### PR TITLE
Cram reheader 2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ test/fieldarith: test/fieldarith.o libhts.a
 	$(CC) -pthread $(LDFLAGS) -o $@ test/fieldarith.o libhts.a $(LDLIBS) -lz
 
 test/hfile: test/hfile.o libhts.a
-	$(CC) $(LDFLAGS) -o $@ test/hfile.o libhts.a $(LDLIBS) -lz
+	$(CC) -pthread $(LDFLAGS) -o $@ test/hfile.o libhts.a $(LDLIBS) -lz
 
 test/sam: test/sam.o libhts.a
 	$(CC) -pthread $(LDFLAGS) -o $@ test/sam.o libhts.a $(LDLIBS) -lz

--- a/hfile.c
+++ b/hfile.c
@@ -42,7 +42,7 @@ DEALINGS IN THE SOFTWARE.  */
    const hFILE_backend *backend;  // Methods to refill/flush I/O buffer
 
    off_t offset;     // Offset within the stream of buffer position 0
-   int at_eof:1;     // For reading, whether EOF has been seen
+   unsigned at_eof:1;// For reading, whether EOF has been seen
    int has_errno;    // Error number from the last failure on this stream
 
 For reading, begin is the first unread character in the buffer and end is the
@@ -318,7 +318,7 @@ void hclose_abruptly(hFILE *fp)
 typedef struct {
     hFILE base;
     int fd;
-    int is_socket:1;
+    unsigned is_socket:1;
 } hFILE_fd;
 
 static ssize_t fd_read(hFILE *fpv, void *buffer, size_t nbytes)

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -51,7 +51,9 @@ struct bgzf_mtaux_t;
 typedef struct __bgzidx_t bgzidx_t;
 
 struct BGZF {
-    int errcode:16, is_write:2, is_be:2, compress_level:9, is_compressed:2, is_gzip:1;
+    unsigned errcode:16, is_write:2, is_be:2;
+    signed compress_level:9;
+    unsigned is_compressed:2, is_gzip:1;
     int cache_size;
     int block_length, block_offset;
     int64_t block_address, uncompressed_address;

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -43,7 +43,7 @@ typedef struct hFILE {
     char *buffer, *begin, *end, *limit;
     const struct hFILE_backend *backend;
     off_t offset;
-    int at_eof:1;
+    unsigned at_eof:1;
     int has_errno;
 } hFILE;
 


### PR DESCRIPTION
NOTE: contains the merge of output-fmt-option and appropriate fixes to get this working with the reheader code.