### PR TITLE
Updated support for s3 urls.

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -5,8 +5,17 @@
    This template file can be updated with autoheader, but do so carefully
    as autoheader adds #defines such as PACKAGE_* that we don't want.  */
 
+/* Define if you have the Common Crypto library. */
+#undef HAVE_COMMONCRYPTO
+
+/* Define to 1 if you have the `gmtime_r' function. */
+#undef HAVE_GMTIME_R
+
 /* Define to 1 if iRODS file access is enabled. */
 #undef HAVE_IRODS
+
+/* Define to 1 if you have the `crypto' library (-lcrypto). */
+#undef HAVE_LIBCRYPTO
 
 /* Define if libcurl file access is enabled. */
 #undef HAVE_LIBCURL

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,8 @@ redistribute it.  There is NO WARRANTY, to the extent permitted by law.])
 AC_PROG_CC
 AC_PROG_RANLIB
 
+need_crypto=no
+
 AC_ARG_WITH([irods],
   [AS_HELP_STRING([[--with-irods[=DIR]]],
                   [use RodsAPIs library (in DIR) to support iRODS URLs])],
@@ -55,6 +57,7 @@ AC_ARG_ENABLE([libcurl],
 
 dnl FIXME This pulls in dozens of standard header checks
 AC_FUNC_MMAP
+AC_CHECK_FUNCS(gmtime_r)
 
 save_LIBS=$LIBS
 zlib_devel=ok
@@ -121,8 +124,15 @@ is installed.
 Either configure with --disable-libcurl or resolve this error to build HTSlib.])
        ;;
      esac])
+  need_crypto=yes
 fi
 AC_SUBST([libcurl])
+
+if test $need_crypto != no; then
+  AC_CHECK_LIB([crypto], [HMAC])
+  AC_CHECK_FUNC([CCHmac], [AC_DEFINE([HAVE_COMMONCRYPTO], 1,
+        [Define if you have the Common Crypto library.])])
+fi
 
 AC_CONFIG_FILES(config.mk)
 AC_OUTPUT

--- a/hfile.c
+++ b/hfile.c
@@ -570,9 +570,17 @@ hFILE *hopen(const char *fname, const char *mode)
 int hisremote(const char *fname)
 {
     // FIXME Make a new backend entry to return this
-    if (strncmp(fname, "http://", 7) == 0 ||
-        strncmp(fname, "https://", 8) == 0 ||
-        strncmp(fname, "ftp://", 6) == 0) return 1;
+    if (strncmp(fname, "file://", 7) == 0) return 0;
+#ifdef HAVE_LIBCURL
+    else if (strncmp(fname, "http://", 7) == 0 ||
+             strncmp(fname, "https://", 8) == 0 ||
+             strncmp(fname, "s3://", 5) == 0 ||
+             strncmp(fname, "s3+http://", 10) == 0 ||
+             strncmp(fname, "s3+https://", 11) == 0 ||
+             strncmp(fname, "ftp://", 6) == 0) return 1;
+#endif
+    else if (strncmp(fname, "http://", 7) == 0 ||
+             strncmp(fname, "ftp://", 6) == 0) return 1;
 #ifdef HAVE_IRODS
     else if (strncmp(fname, "irods:", 6) == 0) return 1;
 #endif

--- a/hfile.c
+++ b/hfile.c
@@ -552,6 +552,9 @@ hFILE *hopen(const char *fname, const char *mode)
 #ifdef HAVE_LIBCURL
     else if (strncmp(fname, "http://", 7) == 0 ||
              strncmp(fname, "https://", 8) == 0 ||
+             strncmp(fname, "s3://", 5) == 0 ||
+             strncmp(fname, "s3+http://", 10) == 0 ||
+             strncmp(fname, "s3+https://", 11) == 0 ||
              strncmp(fname, "ftp://", 6) == 0) return hopen_libcurl(fname,mode);
 #endif
     else if (strncmp(fname, "http://", 7) == 0 ||

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -124,6 +124,9 @@ static int easy_errno(CURL *easy, CURLcode err)
     case CURLE_OPERATION_TIMEDOUT:
         return ETIMEDOUT;
 
+    case CURLE_RANGE_ERROR:
+        return ESPIPE;
+
     case CURLE_SSL_CONNECT_ERROR:
         // TODO return SSL error buffer messages
         return ECONNABORTED;

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -651,6 +651,8 @@ static int is_dns_compliant(const char *s0, const char *slim)
     int has_nondigit = 0, len = 0;
     const char *s;
 
+    if (*s0 == '-' || slim[-1] == '-') return 0;
+
     for (s = s0; s < slim; len++, s++)
         if (islower(*s) || *s == '-') has_nondigit = 1;
         else if (isdigit(*s)) ;


### PR DESCRIPTION
Added parsing for additional file types for hisremote.

Added code to incorporate an 'AWS_SESSION_TOKEN' environmental variable. Added this token as a CononicalizedAmzHeader to the signature message and a header incorporating the token. The token is used for granting temporary access.

Changed the request style from virtual hosted to path. The bucket I was accessing had a name that was [not DNS compliant] (http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html). 