### PR TITLE
bug for 8-bit arrays

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -1056,7 +1056,7 @@ int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str)
             int32_t n;
             memcpy(&n, s, 4);
             s += 4; // no point to the start of the array
-            if (s + n >= b->data + b->l_data)
+            if (s + n > b->data + b->l_data)
                 return -1;
             kputsn("B:", 2, str); kputc(sub_type, str); // write the typing
             for (i = 0; i < n; ++i) { // FIXME: for better performance, put the loop after "if"


### PR DESCRIPTION
Reported by Derek Barnett of Pacific Biosciences:

> There was (& still is) an off-by-one error in htslib's handling of 8-bit array
> tags. The change in htslib that triggered it was recent-ish, and I don't know
> how many people are using 8-bit arrays, instead of strings. And the kicker is
> that it *only* appears if that tag is the last one on the record. Hence why it
> may not have been noticed yet.