### PR TITLE
Work around an iRODS bug(?) regarding checksum and file updates.

### DIFF
--- a/hfile_irods.c
+++ b/hfile_irods.c
@@ -37,10 +37,13 @@ DEALINGS IN THE SOFTWARE.  */
 #include <dataObjFsync.h>
 #include <dataObjLseek.h>
 #include <dataObjClose.h>
+#include <dataObjChksum.h>
 
 typedef struct {
     hFILE base;
     int descriptor;
+    char name[MAX_NAME_LEN];
+    int flags;
 } hFILE_irods;
 
 static int status_errno(int status)
@@ -188,6 +191,27 @@ static int irods_close(hFILE *fpv)
     openedDataObjInp_t args;
     int ret;
 
+    if (fp->flags & (O_WRONLY|O_RDWR)) {
+        // Tested on iRODS 3.3.  iRODS doesn't automatically update
+        // the checksum before attempting to perform replication.
+        // This in turn causes the replication to fail repeatedly,
+        // making rcDataObjClose take an excessively long time.
+        //
+        // This is a workaround - we hope the data is auto-flushed(!)
+        // and forcibly request the checksum to be updated before
+        // closing.
+        dataObjInp_t chk_arg;
+        char *chksum = NULL;
+        memset(&chk_arg, 0, sizeof(chk_arg));
+        memcpy(chk_arg.objPath, fp->name, MAX_NAME_LEN);
+        addKeyVal(&chk_arg.condInput, FORCE_CHKSUM_KW, "");
+
+        ret = rcDataObjChksum(irods.conn, &chk_arg, &chksum);
+        if (ret < 0) set_errno(ret);
+        rmKeyVal(&chk_arg.condInput, FORCE_CHKSUM_KW);
+        free(chksum);
+    }
+
     memset(&args, 0, sizeof args);
     args.l1descInx = fp->descriptor;
 
@@ -223,9 +247,12 @@ hFILE *hopen_irods(const char *filename, const char *mode)
     ret = parseRodsPath(&path, &irods.env);
     if (ret < 0) goto error;
 
+    strncpy(fp->name, path.outPath, MAX_NAME_LEN-1);
+    fp->name[MAX_NAME_LEN-1] = '\0';
+
     memset(&args, 0, sizeof args);
     strcpy(args.objPath, path.outPath);
-    args.openFlags = hfile_oflags(mode);
+    fp->flags = args.openFlags = hfile_oflags(mode);
     if (args.openFlags & O_CREAT) {
         args.createMode = 0666;
         addKeyVal(&args.condInput, DEST_RESC_NAME_KW,irods.env.rodsDefResource);


### PR DESCRIPTION
NOTE: we want to let the iRODs team discuss this first before taking as-is, but it's here as a place to discuss the implications.

If we open, read/write and close a file then the irods close call takes an exceptionally long time possibly 10min+), apparently due to repeated attempts to create and verify a replica.

By forcibly recomputing the checksum prior to closing, the replication works and verifies so it exits much quicker.  Note that this _assumes_ that the writes have automatically flushed.  I am awaiting confirmation on this currently.

The background to the bug comes from samtools reheader -i on a CRAM file taking a long time.  Locally it is < 1sec.  iRODs with this fix: 0m30.647s.  iRODs without this fix: 14m49.635s.

Clearly this is something which the irods server ought to be handling transparently, so I think it is a bug at their end.  However even if/when it is fixed we would need a way of working around it as not every irods install will incorporate the bug fix.  At the very least, this code ought to be left in as an in-source comment to aid future cases of people scratching their heads over why close is so slow.
