### PR TITLE
Export bgzf_compress() in bgzf.h

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -229,7 +229,7 @@ BGZF *bgzf_hopen(hFILE *hfp, const char *mode)
     return fp;
 }
 
-static int bgzf_compress(void *_dst, int *dlen, void *src, int slen, int level)
+int bgzf_compress(void *_dst, int *dlen, void *src, int slen, int level)
 {
     uint32_t crc;
     z_stream zs;

--- a/bgzf.c
+++ b/bgzf.c
@@ -229,7 +229,7 @@ BGZF *bgzf_hopen(hFILE *hfp, const char *mode)
     return fp;
 }
 
-int bgzf_compress(void *_dst, int *dlen, void *src, int slen, int level)
+int bgzf_compress(void *_dst, unsigned int *dlen, void *src, unsigned int slen, int level)
 {
     uint32_t crc;
     z_stream zs;
@@ -255,7 +255,8 @@ int bgzf_compress(void *_dst, int *dlen, void *src, int slen, int level)
     return 0;
 }
 
-static int bgzf_gzip_compress(BGZF *fp, void *_dst, int *dlen, void *src, int slen, int level)
+static int bgzf_gzip_compress(BGZF *fp, void *_dst, unsigned int *dlen,
+                              void *src, unsigned int slen, int level)
 {
     uint8_t *dst = (uint8_t*)_dst;
     z_stream *zs = fp->gz_stream;
@@ -272,7 +273,7 @@ static int bgzf_gzip_compress(BGZF *fp, void *_dst, int *dlen, void *src, int sl
 // Deflate the block in fp->uncompressed_block into fp->compressed_block. Also adds an extra field that stores the compressed block length.
 static int deflate_block(BGZF *fp, int block_length)
 {
-    int comp_size = BGZF_MAX_BLOCK_SIZE;
+    unsigned int comp_size = BGZF_MAX_BLOCK_SIZE;
     int ret;
     if ( !fp->is_gzip )
         ret = bgzf_compress(fp->compressed_block, &comp_size, fp->uncompressed_block, block_length, fp->compress_level);
@@ -611,7 +612,7 @@ static int worker_aux(worker_t *w)
     if (stop) return 1; // to quit the thread
     w->errcode = 0;
     for (i = w->i; i < w->mt->curr; i += w->mt->n_threads) {
-        int clen = BGZF_MAX_BLOCK_SIZE;
+        unsigned int clen = BGZF_MAX_BLOCK_SIZE;
         if (bgzf_compress(w->buf, &clen, w->mt->blk[i], w->mt->len[i], w->compress_level) != 0)
             w->errcode |= BGZF_ERR_ZLIB;
         memcpy(w->mt->blk[i], w->buf, clen);

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -254,6 +254,17 @@ typedef struct __kstring_t {
      */
     int bgzf_mt(BGZF *fp, int n_threads, int n_sub_blks);
 
+    /**
+     * Generate a bgzf block
+     *
+     * @param dst    output buffer, must be at least BGZF_MAX_BLOCK_SIZE bytes
+     * @param dstlen pointer to address to store number of bytes in dst
+     * @param src    buffer to compress
+     * @param srclen number of bytes to compress, must be <= BGZF_BLOCK_SIZE
+     * @param level  compression level used by deflate()
+     * @return       zero on success, non-zero on error
+     */
+    int bgzf_compress(void *dst, int *dlen, void *src, int slen, int level);
 
     /*******************
      * bgzidx routines *

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -264,7 +264,7 @@ typedef struct __kstring_t {
      * @param level  compression level used by deflate()
      * @return       zero on success, non-zero on error
      */
-    int bgzf_compress(void *dst, int *dlen, void *src, int slen, int level);
+    int bgzf_compress(void *dst, unsigned int *dlen, void *src, unsigned int slen, int level);
 
     /*******************
      * bgzidx routines *


### PR DESCRIPTION
I'd like to write bgzf files in a current project. Access to the bgzf block compress function without having to use BGZF file handles would be very useful.
