### PR TITLE
Use -lpthread instead of -pthread when only linking; Fixes clang warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,13 +270,13 @@ cram/zfio.o cram/zfio.pico: cram/zfio.c config.h cram/os.h cram/zfio.h
 
 
 bgzip: bgzip.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ bgzip.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ bgzip.o libhts.a $(LDLIBS) -lpthread -lz
 
 htsfile: htsfile.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ htsfile.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ htsfile.o libhts.a $(LDLIBS) -lpthread -lz
 
 tabix: tabix.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ tabix.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ tabix.o libhts.a $(LDLIBS) -lpthread -lz
 
 bgzip.o: bgzip.c config.h $(htslib_bgzf_h) $(htslib_hts_h)
 htsfile.o: htsfile.c config.h $(htslib_hfile_h) $(htslib_hts_h) $(htslib_sam_h) $(htslib_vcf_h)
@@ -294,25 +294,25 @@ check test: $(BUILT_TEST_PROGRAMS)
 	cd test && ./test.pl
 
 test/fieldarith: test/fieldarith.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ test/fieldarith.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ test/fieldarith.o libhts.a $(LDLIBS) -lpthread -lz
 
 test/hfile: test/hfile.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ test/hfile.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ test/hfile.o libhts.a $(LDLIBS) -lpthread -lz
 
 test/sam: test/sam.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ test/sam.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ test/sam.o libhts.a $(LDLIBS) -lpthread -lz
 
 test/test-regidx: test/test-regidx.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ test/test-regidx.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ test/test-regidx.o libhts.a $(LDLIBS) -lpthread -lz
 
 test/test_view: test/test_view.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ test/test_view.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ test/test_view.o libhts.a $(LDLIBS) -lpthread -lz
 
 test/test-vcf-api: test/test-vcf-api.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ test/test-vcf-api.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ test/test-vcf-api.o libhts.a $(LDLIBS) -lpthread -lz
 
 test/test-vcf-sweep: test/test-vcf-sweep.o libhts.a
-	$(CC) -lpthread $(LDFLAGS) -o $@ test/test-vcf-sweep.o libhts.a $(LDLIBS) -lz
+	$(CC) $(LDFLAGS) -o $@ test/test-vcf-sweep.o libhts.a $(LDLIBS) -lpthread -lz
 
 test/fieldarith.o: test/fieldarith.c $(htslib_sam_h)
 test/hfile.o: test/hfile.c $(htslib_hfile_h) $(htslib_hts_defs_h)

--- a/Makefile
+++ b/Makefile
@@ -270,13 +270,13 @@ cram/zfio.o cram/zfio.pico: cram/zfio.c config.h cram/os.h cram/zfio.h
 
 
 bgzip: bgzip.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ bgzip.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ bgzip.o libhts.a $(LDLIBS) -lz
 
 htsfile: htsfile.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ htsfile.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ htsfile.o libhts.a $(LDLIBS) -lz
 
 tabix: tabix.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ tabix.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ tabix.o libhts.a $(LDLIBS) -lz
 
 bgzip.o: bgzip.c config.h $(htslib_bgzf_h) $(htslib_hts_h)
 htsfile.o: htsfile.c config.h $(htslib_hfile_h) $(htslib_hts_h) $(htslib_sam_h) $(htslib_vcf_h)
@@ -294,25 +294,25 @@ check test: $(BUILT_TEST_PROGRAMS)
 	cd test && ./test.pl
 
 test/fieldarith: test/fieldarith.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ test/fieldarith.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ test/fieldarith.o libhts.a $(LDLIBS) -lz
 
 test/hfile: test/hfile.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ test/hfile.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ test/hfile.o libhts.a $(LDLIBS) -lz
 
 test/sam: test/sam.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ test/sam.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ test/sam.o libhts.a $(LDLIBS) -lz
 
 test/test-regidx: test/test-regidx.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ test/test-regidx.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ test/test-regidx.o libhts.a $(LDLIBS) -lz
 
 test/test_view: test/test_view.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ test/test_view.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ test/test_view.o libhts.a $(LDLIBS) -lz
 
 test/test-vcf-api: test/test-vcf-api.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ test/test-vcf-api.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ test/test-vcf-api.o libhts.a $(LDLIBS) -lz
 
 test/test-vcf-sweep: test/test-vcf-sweep.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ test/test-vcf-sweep.o libhts.a $(LDLIBS) -lz
+	$(CC) -lpthread $(LDFLAGS) -o $@ test/test-vcf-sweep.o libhts.a $(LDLIBS) -lz
 
 test/fieldarith.o: test/fieldarith.c $(htslib_sam_h)
 test/hfile.o: test/hfile.c $(htslib_hfile_h) $(htslib_hts_defs_h)


### PR DESCRIPTION
`-pthread` is equivalent to `-D_REENTRANT=1 -D__USE_REENTRANT=1` when compiling and `-lpthread` when linking, although the exact behaviour may be plaform specific. 

Clang gives a warning if `-pthread` is used when only linking `.o` and `.a` files:

```
clang: warning: argument unused during compilation: '-pthread'
```

This is fixed by using `-lpthread` instead if a compiler call is only linking. 
