### PR TITLE
Provide updated compressBound() for bgzip blocks

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -108,6 +108,11 @@ static inline void packInt32(uint8_t *buffer, uint32_t value)
     buffer[3] = value >> 24;
 }
 
+static size_t bgzf_compressBound(size_t srclen)
+{
+    return compressBound(srclen) + 6; // bgzf adds six bytes to the header
+}
+
 static BGZF *bgzf_read_init(hFILE *hfpr)
 {
     BGZF *fp;
@@ -171,7 +176,7 @@ static BGZF *bgzf_write_init(const char *mode)
 BGZF *bgzf_open(const char *path, const char *mode)
 {
     BGZF *fp = 0;
-    assert(compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE);
+    assert(bgzf_compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE);
     if (strchr(mode, 'r')) {
         hFILE *fpr;
         if ((fpr = hopen(path, mode)) == 0) return 0;
@@ -193,7 +198,7 @@ BGZF *bgzf_open(const char *path, const char *mode)
 BGZF *bgzf_dopen(int fd, const char *mode)
 {
     BGZF *fp = 0;
-    assert(compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE);
+    assert(bgzf_compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE);
     if (strchr(mode, 'r')) {
         hFILE *fpr;
         if ((fpr = hdopen(fd, mode)) == 0) return 0;
@@ -215,7 +220,7 @@ BGZF *bgzf_dopen(int fd, const char *mode)
 BGZF *bgzf_hopen(hFILE *hfp, const char *mode)
 {
     BGZF *fp = NULL;
-    assert(compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE);
+    assert(bgzf_compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE);
     if (strchr(mode, 'r')) {
         fp = bgzf_read_init(hfp);
         if (fp == NULL) return NULL;

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -38,7 +38,7 @@
 extern "C" {
 #endif
 
-#define BGZF_BLOCK_SIZE     0xff00 // make sure compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE
+#define BGZF_BLOCK_SIZE     0xff00 // make sure bgzf_compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE
 #define BGZF_MAX_BLOCK_SIZE 0x10000
 
 #define BGZF_ERR_ZLIB   1


### PR DESCRIPTION
bgzip blocks have a higher bound on compressed size due to slightly larger headers. 
