### PR TITLE
CRAM indexing bug fix

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -615,8 +615,8 @@ static hts_itr_t *cram_itr_query(const hts_idx_t *idx, int tid, int beg, int end
     iter->bins.a = NULL;
     iter->readrec = readrec;
 
-    if (tid >= 0) {
-        cram_range r = { tid, beg+1, end };
+    if (tid >= 0 || tid == HTS_IDX_NOCOOR) {
+        cram_range r = { tid == HTS_IDX_NOCOOR ? -1 : tid, beg+1, end };
         if (cram_set_option(cidx->cram, CRAM_OPT_RANGE, &r) != 0) { free(iter); return NULL; }
         iter->curr_off = 0;
         // The following fields are not required by hts_itr_next(), but are


### PR DESCRIPTION
Bug fix for CRAM index querying when the query sequence has zero entries in the index.  It was accessing element -1 in a NULL array.

Also fixed the code so that searching on ref id -1 (unmapped data)
works.

Fixes samtools#454

Tricky to test exhaustively, but it passes our normal tests plus anything I can dream up on the command line.