### PR TITLE
allow 0-length fasta label

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -90,8 +90,9 @@ faidx_t *fai_build_core(BGZF *bgzf)
     int64_t len;
 
     idx = (faidx_t*)calloc(1, sizeof(faidx_t));
+    name = (char *)calloc(1, sizeof(char));
     idx->hash = kh_init(s);
-    name = 0; l_name = m_name = 0;
+    l_name = m_name = 0;
     len = line_len = line_blen = -1; state = 0; l1 = l2 = -1; offset = 0;
     while ( (c=bgzf_getc(bgzf))>=0 ) {
         if (c == '\n') { // an empty line

--- a/faidx.c
+++ b/faidx.c
@@ -121,6 +121,7 @@ faidx_t *fai_build_core(BGZF *bgzf)
                 return 0;
             }
             if (c != '\n') while ( (c=bgzf_getc(bgzf))>=0 && c != '\n');
+            if (name.l == 0) kputc('\0', &name);
             state = 1; len = 0;
             offset = bgzf_utell(bgzf);
         } else {
@@ -147,7 +148,7 @@ faidx_t *fai_build_core(BGZF *bgzf)
             }
         }
     }
-    if ( name.l )
+    if ( len>=0 )
         fai_insert_index(idx, name.s, len, line_len, line_blen, offset);
     free(name.s);
     return idx;


### PR DESCRIPTION
A fasta file with no sequence name segfaults during index creation.

    ~/src/samtools$ cat > noname.fa
    >
    ATCG
    ^D
    ~/src/samtools$ ./samtools faidx noname.fa
    Segmentation fault (core dumped)

because the null terminator is written to a null pointer. The patch allocates enough space for the terminating null. An alternative (if sequence names are supposed to be required) would be to exit more gracefully.