### PR TITLE
Function bcf_hdr_parse_line now ignores trailing spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ BUILT_TEST_PROGRAMS = \
 	test/test-regidx \
 	test/test_view \
 	test/test-vcf-api \
+	test/test-vcf-hdr \
 	test/test-vcf-sweep
 
 all: lib-static lib-shared $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS)
@@ -312,6 +313,9 @@ test/test_view: test/test_view.o libhts.a
 test/test-vcf-api: test/test-vcf-api.o libhts.a
 	$(CC) -pthread $(LDFLAGS) -o $@ test/test-vcf-api.o libhts.a $(LDLIBS) -lz
 
+test/test-vcf-hdr: test/test-vcf-hdr.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/test-vcf-hdr.o libhts.a $(LDLIBS) -lz
+
 test/test-vcf-sweep: test/test-vcf-sweep.o libhts.a
 	$(CC) -pthread $(LDFLAGS) -o $@ test/test-vcf-sweep.o libhts.a $(LDLIBS) -lz
 
@@ -321,6 +325,7 @@ test/sam.o: test/sam.c $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h)
 test/test-regidx.o: test/test-regidx.c $(htslib_regidx_h)
 test/test_view.o: test/test_view.c $(cram_h) $(htslib_sam_h)
 test/test-vcf-api.o: test/test-vcf-api.c $(htslib_hts_h) $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_kseq_h)
+test/test-vcf-hdr.o: test/test-vcf-hdr.c $(htslib_hts_h) $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_kseq_h)
 test/test-vcf-sweep.o: test/test-vcf-sweep.c $(htslib_vcf_sweep_h)
 
 

--- a/test/test-vcf-hdr-in.vcf
+++ b/test/test-vcf-hdr-in.vcf
@@ -1,0 +1,25 @@
+##fileformat=VCFv4.1
+##fileDate=20150126
+##reference=hs37d5
+##phasing=partial
+##FILTER=<ID=INDEL_SPECIFIC_FILTERS,Description="QD < 2.0 || ReadPosRankSum < -20.0 || InbreedingCoeff < -0.8 || FS > 200.0">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FILTER=<ID=VQSRTrancheSNP99.00to99.90,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -6.6778 <= x < -0.6832">
+##FILTER=<ID=VQSRTrancheSNP99.90to100.00+,Description="Truth sensitivity tranche level for SNP model at VQS Lod < -36469.5723">
+##INFO=<ID=TRAILING,Number=.,Type=Integer,Description="This line contains trailing spaces for testing purposes">               
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GATK,Number=1,Type=String,Description="Genotype as called by GATK. Always a diploid call. All other genotype stats based on this genotype.">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype after Personalis post-processing to match detected chromosome counts.">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001
+1	12065947	PTV001	C	T,A	29	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:19
+1	109817590	PTV002	G	T	77	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:20
+1	153791300	PTV003	CTG	C	81	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:21
+1	156104666	PTV004	TTGAGAGCCGGCTGGCGGAT	TCC	30	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:22
+1	156108541	PTV005	G	GG	31	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:23
+1	161279695	PTV006	T	C,A	32	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:24
+1	169519049	PTV007	T	.	35	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:24
+1	226125468	PTV097	G	A	99	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:109
+16	2103394	PTV056	C	T	68	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:72
+4	31789170	PTV021	G	.	77	PASS	.	GT:GATK:AD:DP:GQ	0/1:0/1:3,2:5:38

--- a/test/test-vcf-hdr.c
+++ b/test/test-vcf-hdr.c
@@ -1,0 +1,65 @@
+/*  test/test-vcf-api.c -- VCF test harness.
+
+    Copyright (C) 2015 EMBL - European Bioinformatics Institute
+
+    Author: Cristina Yenyxe Gonzalez Garcia <cyenyxe@ebi.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <stdio.h>
+#include <htslib/hts.h>
+#include <htslib/vcf.h>
+
+
+int main(int argc, char **argv)
+{
+    char *in_fname = argc>1 ? argv[1] : "test/test-vcf-hdr-in.vcf";
+    
+    // Parse header with trailing spaces
+    htsFile *file = hts_open(in_fname, "r");
+    bcf_hdr_t *header = bcf_hdr_read(file);
+        
+    if (header->nhrec != 15)
+    {
+        fprintf(stderr, "The header contains %d lines, 15 were expected\n", header->nhrec);
+        hts_close(file);
+        exit(1);
+    }
+    
+    // Write results
+    char *out_fname = "test/test-vcf-hdr.out.new";
+    htsFile *out = hts_open(out_fname, "wu");
+    vcf_hdr_write(out, header);
+    
+    int ret;
+    if (ret = hts_close(out))
+    {
+        fprintf(stderr, "hts_close(%s): non-zero status %d\n", out_fname, ret);
+        exit(ret);
+    }
+    
+    if (ret = hts_close(file))
+    {
+        fprintf(stderr, "hts_close(%s): non-zero status %d\n", in_fname, ret);
+        exit(ret);
+    }
+    
+    return 0;
+}
+

--- a/test/test-vcf-hdr.out
+++ b/test/test-vcf-hdr.out
@@ -1,0 +1,16 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##fileDate=20150126
+##reference=hs37d5
+##phasing=partial
+##FILTER=<ID=INDEL_SPECIFIC_FILTERS,Description="QD < 2.0 || ReadPosRankSum < -20.0 || InbreedingCoeff < -0.8 || FS > 200.0">
+##FILTER=<ID=LowQual,Description="Low quality">
+##FILTER=<ID=VQSRTrancheSNP99.00to99.90,Description="Truth sensitivity tranche level for SNP model at VQS Lod: -6.6778 <= x < -0.6832">
+##FILTER=<ID=VQSRTrancheSNP99.90to100.00+,Description="Truth sensitivity tranche level for SNP model at VQS Lod < -36469.5723">
+##INFO=<ID=TRAILING,Number=.,Type=Integer,Description="This line contains trailing spaces for testing purposes">
+##FORMAT=<ID=AD,Number=.,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GATK,Number=1,Type=String,Description="Genotype as called by GATK. Always a diploid call. All other genotype stats based on this genotype.">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype after Personalis post-processing to match detected chromosome counts.">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001

--- a/vcf.c
+++ b/vcf.c
@@ -347,6 +347,10 @@ bcf_hrec_t *bcf_hdr_parse_line(const bcf_hdr_t *h, const char *line, int *len)
         if ( quoted ) q++;
         if ( *q=='>' ) { nopen--; q++; }
     }
+    
+    // Skip trailing spaces
+    while ( *q && *q==' ') { q++; }
+    
     *len = q-line+1;
     return hrec;
 }


### PR DESCRIPTION
Making the function bcf_header_parse ignore trailing spaces fixes issue #248.

A test file is included, but I haven't been able to integrate it with the rest of the VCF test suite (test/test.pl). For some reason, it won't copy the input file into the temporary folder.