### PR TITLE
Fixed for handling of BCF string dictionaries

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -102,10 +102,11 @@ typedef struct {
     const bcf_idinfo_t *val;
 } bcf_idpair_t;
 
+// Note that bcf_hdr_t structs must always be created via bcf_hdr_init()
 typedef struct {
-    int32_t n[3];
+    int32_t n[3];           // n:the size of the dictionary block in use, (allocated size, m, is below to preserve ABI)
     bcf_idpair_t *id[3];
-    void *dict[3]; // ID dictionary, contig dict and sample dict
+    void *dict[3];          // ID dictionary, contig dict and sample dict
     char **samples;
     bcf_hrec_t **hrec;
     int nhrec, dirty;
@@ -113,6 +114,7 @@ typedef struct {
     int nsamples_ori;           // for bcf_hdr_set_samples()
     uint8_t *keep_samples;
     kstring_t mem;
+    int32_t m[3];          // m: allocated size of the dictionary block in use (see n above)
 } bcf_hdr_t;
 
 extern uint8_t bcf_type_shift[];


### PR DESCRIPTION
Gaps in IDX blocks were causing incorrect tags on output.

Fixes samtools/bcftools#317.