### PR TITLE
Improved error checking and reporting for htslib (rebased)

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -161,9 +161,19 @@ static BGZF *bgzf_write_init(const char *mode)
         // gzip output
         fp->is_gzip = 1;
         fp->gz_stream = (z_stream*)calloc(1,sizeof(z_stream));
+        if (fp->gz_stream == NULL) {
+            if ( hts_verbose >= 1 ) fprintf(stderr, "[E::%s] calloc error initializing zlib output stream\n", __func__);
+            fp->errcode |= BGZF_ERR_ZLIB;
+            return NULL;
+        }
         fp->gz_stream->zalloc = NULL;
         fp->gz_stream->zfree  = NULL;
-        if ( deflateInit2(fp->gz_stream, fp->compress_level, Z_DEFLATED, 15|16, 8, Z_DEFAULT_STRATEGY)!=Z_OK ) return NULL;
+        int ret = deflateInit2(fp->gz_stream, fp->compress_level, Z_DEFLATED, 15|16, 8, Z_DEFAULT_STRATEGY);
+        if ( ret!=Z_OK ) {
+            if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflateInit2 ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+            fp->errcode |= BGZF_ERR_ZLIB;
+            return NULL;
+        }
     }
     return fp;
 }
@@ -182,6 +192,10 @@ BGZF *bgzf_open(const char *path, const char *mode)
         hFILE *fpw;
         if ((fpw = hopen(path, mode)) == 0) return 0;
         fp = bgzf_write_init(mode);
+        if (fp == NULL) {
+            if ( hts_verbose >= 2 ) fprintf(stderr, "[E::%s] bgzf_write_init error initializing zlib stream\n", __func__);
+            return 0;
+        }
         fp->fp = fpw;
     }
     else { errno = EINVAL; return 0; }
@@ -204,6 +218,10 @@ BGZF *bgzf_dopen(int fd, const char *mode)
         hFILE *fpw;
         if ((fpw = hdopen(fd, mode)) == 0) return 0;
         fp = bgzf_write_init(mode);
+        if (fp == NULL) {
+            if ( hts_verbose >= 2 ) fprintf(stderr, "[E::%s] bgzf_write_init error initializing zlib output stream\n", __func__);
+            return 0;
+        }
         fp->fp = fpw;
     }
     else { errno = EINVAL; return 0; }
@@ -221,6 +239,10 @@ BGZF *bgzf_hopen(hFILE *hfp, const char *mode)
         if (fp == NULL) return NULL;
     } else if (strchr(mode, 'w') || strchr(mode, 'a')) {
         fp = bgzf_write_init(mode);
+        if (fp == NULL) {
+            if ( hts_verbose >= 2 ) { fprintf(stderr, "[E::%s] bgzf_write_init error initializing zlib stream\n", __func__); }
+            return 0;
+        }
     }
     else { errno = EINVAL; return 0; }
 
@@ -241,9 +263,19 @@ static int bgzf_compress(void *_dst, int *dlen, void *src, int slen, int level)
     zs.avail_in = slen;
     zs.next_out = dst + BLOCK_HEADER_LENGTH;
     zs.avail_out = *dlen - BLOCK_HEADER_LENGTH - BLOCK_FOOTER_LENGTH;
-    if (deflateInit2(&zs, level, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) != Z_OK) return -1; // -15 to disable zlib header/footer
-    if (deflate(&zs, Z_FINISH) != Z_STREAM_END) return -1;
-    if (deflateEnd(&zs) != Z_OK) return -1;
+    int ret = deflateInit2(&zs, level, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY); // -15 to disable zlib header/footer
+    if ( ret!=Z_OK ) {
+        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflateInit2 ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        return -1;
+    }
+    if ((ret = deflate(&zs, Z_FINISH)) != Z_STREAM_END) {
+        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflate ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        return -1;
+    }
+    if ((ret = deflateEnd(&zs)) != Z_OK) {
+        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        return -1;
+    }
     *dlen = zs.total_out + BLOCK_HEADER_LENGTH + BLOCK_FOOTER_LENGTH;
     // write the header
     memcpy(dst, g_magic, BLOCK_HEADER_LENGTH); // the last two bytes are a place holder for the length of the block
@@ -264,7 +296,11 @@ static int bgzf_gzip_compress(BGZF *fp, void *_dst, int *dlen, void *src, int sl
     zs->avail_in  = slen;
     zs->next_out  = dst;
     zs->avail_out = *dlen;
-    if ( deflate(zs, flush) == Z_STREAM_ERROR ) return -1;
+    int ret = deflate(zs, flush);
+    if (ret == Z_STREAM_ERROR) {
+        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflate ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        return -1;
+    }
     *dlen = *dlen - zs->avail_out;
     return 0;
 }
@@ -281,6 +317,7 @@ static int deflate_block(BGZF *fp, int block_length)
 
     if ( ret != 0 )
     {
+        if ( hts_verbose >= 3 ) fprintf(stderr, "[E::%s] compression error %d\n", __func__, ret);
         fp->errcode |= BGZF_ERR_ZLIB;
         return -1;
     }
@@ -299,16 +336,22 @@ static int inflate_block(BGZF* fp, int block_length)
     zs.next_out = (Bytef*)fp->uncompressed_block;
     zs.avail_out = BGZF_MAX_BLOCK_SIZE;
 
-    if (inflateInit2(&zs, -15) != Z_OK) {
+    int ret = inflateInit2(&zs, -15);
+    if (ret != Z_OK) {
+        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflateInit2 ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
         fp->errcode |= BGZF_ERR_ZLIB;
         return -1;
     }
-    if (inflate(&zs, Z_FINISH) != Z_STREAM_END) {
-        inflateEnd(&zs);
+    if ((ret = inflate(&zs, Z_FINISH)) != Z_STREAM_END) {
+        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflate ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        if ((ret = inflateEnd(&zs)) != Z_OK) {
+            if ( hts_verbose >= 2 ) { fprintf(stderr, "[E::%s] inflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        }
         fp->errcode |= BGZF_ERR_ZLIB;
         return -1;
     }
-    if (inflateEnd(&zs) != Z_OK) {
+    if ((ret = inflateEnd(&zs)) != Z_OK) {
+        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
         fp->errcode |= BGZF_ERR_ZLIB;
         return -1;
     }
@@ -334,7 +377,11 @@ static int inflate_gzip_block(BGZF *fp, int cached)
             fp->gz_stream->avail_out = BGZF_MAX_BLOCK_SIZE - fp->block_offset;
             ret = inflate(fp->gz_stream, Z_NO_FLUSH);
             if ( ret==Z_BUF_ERROR ) continue;   // non-critical error
-            if ( ret<0 ) return -1;
+            if ( ret<0 ) {
+                if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflate ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+                fp->errcode |= BGZF_ERR_ZLIB;
+                return -1;
+            }
             unsigned int have = BGZF_MAX_BLOCK_SIZE - fp->gz_stream->avail_out;
             if ( have ) return have;
         }
@@ -505,6 +552,7 @@ int bgzf_read_block(BGZF *fp)
         int ret = inflateInit2(fp->gz_stream, -15);
         if (ret != Z_OK)
         {
+            if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflateInit2 ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
             fp->errcode |= BGZF_ERR_ZLIB;
             return -1;
         }
@@ -532,7 +580,11 @@ int bgzf_read_block(BGZF *fp)
         return -1;
     }
     size += count;
-    if ((count = inflate_block(fp, block_length)) < 0) return -1;
+    if ((count = inflate_block(fp, block_length)) < 0) {
+        if ( hts_verbose >= 2 ) fprintf(stderr, "[E::%s] inflate_block error %d\n", __func__, count);
+        fp->errcode |= BGZF_ERR_ZLIB;
+        return -1;
+    }
     if (fp->block_length != 0) fp->block_offset = 0; // Do not reset offset if this read follows a seek.
     fp->block_address = block_address;
     fp->block_length = count;
@@ -555,7 +607,12 @@ ssize_t bgzf_read(BGZF *fp, void *data, size_t length)
         int copy_length, available = fp->block_length - fp->block_offset;
         uint8_t *buffer;
         if (available <= 0) {
-            if (bgzf_read_block(fp) != 0) return -1;
+            int ret = bgzf_read_block(fp);
+            if (ret != 0) {
+                if ( hts_verbose >= 2 ) fprintf(stderr, "[E::%s] bgzf_read_block error %d after %d of %d bytes\n", __func__, ret, bytes_read, length);
+                fp->errcode |= BGZF_ERR_ZLIB;
+                return -1;
+            }
             available = fp->block_length - fp->block_offset;
             if (available <= 0) break;
         }
@@ -612,8 +669,12 @@ static int worker_aux(worker_t *w)
     w->errcode = 0;
     for (i = w->i; i < w->mt->curr; i += w->mt->n_threads) {
         int clen = BGZF_MAX_BLOCK_SIZE;
-        if (bgzf_compress(w->buf, &clen, w->mt->blk[i], w->mt->len[i], w->compress_level) != 0)
+        int ret = bgzf_compress(w->buf, &clen, w->mt->blk[i], w->mt->len[i], w->compress_level);
+        if (ret != 0) {
+            if ( hts_verbose >= 2 ) fprintf(stderr, "[E::%s] bgzf_compress error %d\n", __func__, ret);
             w->errcode |= BGZF_ERR_ZLIB;
+            abort(); // return -1; // FIXME: mt_worker() and mt_flush_queue() don't test return value
+        }
         memcpy(w->mt->blk[i], w->buf, clen);
         w->mt->len[i] = clen;
     }
@@ -750,8 +811,12 @@ int bgzf_flush(BGZF *fp)
             fp->idx->ublock_addr += fp->block_offset;
         }
         int block_length = deflate_block(fp, fp->block_offset);
-        if (block_length < 0) return -1;
+        if (block_length < 0) {
+            if ( hts_verbose >= 3 ) fprintf(stderr, "[E::%s] deflate_block error %d\n", __func__, block_length);
+            abort(); // return -1; // FIXME: lazy_flush() does not check return value
+        }
         if (hwrite(fp->fp, fp->compressed_block, block_length) != block_length) {
+            if ( hts_verbose >= 1 ) fprintf(stderr, "[E::%s] hwrite error (wrong size)\n", __func__);
             fp->errcode |= BGZF_ERR_IO; // possibly truncated file
             return -1;
         }
@@ -802,8 +867,13 @@ int bgzf_close(BGZF* fp)
         if (bgzf_flush(fp) != 0) return -1;
         fp->compress_level = -1;
         block_length = deflate_block(fp, 0); // write an empty block
+        if (block_length < 0) {
+            if ( hts_verbose >= 3 ) fprintf(stderr, "[E::%s] deflate_block error %d\n", __func__, block_length);
+            abort(); // return -1; FIXME: hts_close() does not test return value)
+        }
         if (hwrite(fp->fp, fp->compressed_block, block_length) < 0
             || hflush(fp->fp) != 0) {
+            if ( hts_verbose >= 1 ) fprintf(stderr, "[E::%s] file write error\n", __func__);
             fp->errcode |= BGZF_ERR_IO;
             return -1;
         }
@@ -813,8 +883,21 @@ int bgzf_close(BGZF* fp)
     }
     if ( fp->is_gzip )
     {
-        if (!fp->is_write) (void)inflateEnd(fp->gz_stream);
-        else (void)deflateEnd(fp->gz_stream);
+        if (!fp->is_write) {
+            ret = inflateEnd(fp->gz_stream);
+            if (ret != Z_OK) {
+                if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+                fp->errcode |= BGZF_ERR_ZLIB;
+                // return -1; // don't bother, closing anyway
+            }
+        } else {
+            ret = deflateEnd(fp->gz_stream);
+            if (ret != Z_OK) {
+                if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+                fp->errcode |= BGZF_ERR_ZLIB;
+                // return -1; // don't bother, closing anyway
+            }
+        }
         free(fp->gz_stream);
     }
     ret = hclose(fp->fp);
@@ -1121,5 +1204,40 @@ int bgzf_useek(BGZF *fp, long uoffset, int where)
 long bgzf_utell(BGZF *fp)
 {
     return fp->uncompressed_address;    // currently maintained only when reading
+}
+
+int bgzf_zerr(int errnum, FILE *fpOutput)
+{
+    // gzerror OF((gzFile file, int *errnum)
+    switch (errnum) {
+    case Z_ERRNO:
+        if (ferror(stdin))
+            fputs("zlib: error reading stdin", fpOutput);
+        else if (ferror(stdout))
+            fputs("zlib: error writing stdout", fpOutput);
+        else
+            fputs("zlib: file system error", fpOutput);
+        break;
+    case Z_STREAM_ERROR:
+        fputs("zlib error: invalid parameter/compression level, or inconsistent stream state", fpOutput);
+        break;
+    case Z_DATA_ERROR:
+        fputs("zlib error: invalid or incomplete IO", fpOutput);
+        break;
+    case Z_MEM_ERROR:
+        fputs("zlib error: out of memory", fpOutput);
+        break;
+    case Z_BUF_ERROR:
+        fputs("progress temporarily not possible, or in() / out() returned an error", fpOutput);
+        break;
+    case Z_VERSION_ERROR:
+        fputs("zlib version mismatch!", fpOutput);
+        break;
+    case Z_OK: // 0: maybe gzgets error Z_NULL
+    default:
+        fprintf(fpOutput, "zlib error: [%d] unknown", errnum);
+        return -1;
+    }
+    return 0;
 }
 

--- a/bgzf.c
+++ b/bgzf.c
@@ -528,24 +528,25 @@ int bgzf_read_block(BGZF *fp)
         }
         if ( header[3] & 0x8 ) // FLG.FNAME
         {
-            while ( nskip<count && cblock[nskip] ) nskip++;
+            while ( nskip<BGZF_BLOCK_SIZE && cblock[nskip] ) nskip++;
+            if ( nskip==BGZF_BLOCK_SIZE )
+            {
+                fp->errcode |= BGZF_ERR_HEADER;
+                return -1;
+            }
             nskip++;
         }
         if ( header[3] & 0x10 ) // FLG.FCOMMENT
         {
-            while ( nskip<count && cblock[nskip] ) nskip++;
+            while ( nskip<BGZF_BLOCK_SIZE && cblock[nskip] ) nskip++;
+            if ( nskip==BGZF_BLOCK_SIZE )
+            {
+                fp->errcode |= BGZF_ERR_HEADER;
+                return -1;
+            }
             nskip++;
         }
         if ( header[3] & 0x2 ) nskip += 2;  //  FLG.FHCRC
-
-        /* FIXME: Should handle this better.  There's no reason why
-           someone shouldn't include a massively long comment in their
-           gzip stream. */
-        if ( nskip >= count )
-        {
-            fp->errcode |= BGZF_ERR_HEADER;
-            return -1;
-        }
 
         fp->is_gzip = 1;
         fp->gz_stream = (z_stream*) calloc(1,sizeof(z_stream));

--- a/bgzf.c
+++ b/bgzf.c
@@ -88,6 +88,7 @@ struct __bgzidx_t
 
 void bgzf_index_destroy(BGZF *fp);
 int bgzf_index_add_block(BGZF *fp);
+static const char * bgzf_zerr(int errnum);
 
 static inline void packInt16(uint8_t *buffer, uint16_t value)
 {
@@ -144,6 +145,7 @@ static BGZF *bgzf_write_init(const char *mode)
 {
     BGZF *fp;
     fp = (BGZF*)calloc(1, sizeof(BGZF));
+    if (fp == NULL) goto mem_fail;
     fp->is_write = 1;
     int compress_level = mode2level(mode);
     if ( compress_level==-2 )
@@ -152,8 +154,12 @@ static BGZF *bgzf_write_init(const char *mode)
         return fp;
     }
     fp->is_compressed = 1;
+
     fp->uncompressed_block = malloc(BGZF_MAX_BLOCK_SIZE);
+    if (fp->uncompressed_block == NULL) goto mem_fail;
     fp->compressed_block = malloc(BGZF_MAX_BLOCK_SIZE);
+    if (fp->compressed_block == NULL) goto mem_fail;
+
     fp->compress_level = compress_level < 0? Z_DEFAULT_COMPRESSION : compress_level; // Z_DEFAULT_COMPRESSION==-1
     if (fp->compress_level > 9) fp->compress_level = Z_DEFAULT_COMPRESSION;
     if ( strchr(mode,'g') )
@@ -161,21 +167,33 @@ static BGZF *bgzf_write_init(const char *mode)
         // gzip output
         fp->is_gzip = 1;
         fp->gz_stream = (z_stream*)calloc(1,sizeof(z_stream));
-        if (fp->gz_stream == NULL) {
-            if ( hts_verbose >= 1 ) fprintf(stderr, "[E::%s] calloc error initializing zlib output stream\n", __func__);
-            fp->errcode |= BGZF_ERR_ZLIB;
-            return NULL;
-        }
+        if (fp->gz_stream == NULL) goto mem_fail;
         fp->gz_stream->zalloc = NULL;
         fp->gz_stream->zfree  = NULL;
+
         int ret = deflateInit2(fp->gz_stream, fp->compress_level, Z_DEFLATED, 15|16, 8, Z_DEFAULT_STRATEGY);
         if ( ret!=Z_OK ) {
-            if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflateInit2 ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
-            fp->errcode |= BGZF_ERR_ZLIB;
-            return NULL;
+            if ( hts_verbose >= 1 ) {
+                fprintf(stderr, "[E::%s] deflateInit2 failed: %s\n",
+                        __func__, bgzf_zerr(ret));
+            }
+            goto fail;
         }
     }
     return fp;
+
+ mem_fail:
+    if ( hts_verbose >= 1 ) {
+        fprintf(stderr, "[E::%s] %s\n", __func__, strerror(errno));
+    }
+ fail:
+    if (fp != NULL) {
+        free(fp->uncompressed_block);
+        free(fp->compressed_block);
+        free(fp->gz_stream);
+        free(fp);
+    }
+    return NULL;
 }
 
 BGZF *bgzf_open(const char *path, const char *mode)
@@ -192,10 +210,7 @@ BGZF *bgzf_open(const char *path, const char *mode)
         hFILE *fpw;
         if ((fpw = hopen(path, mode)) == 0) return 0;
         fp = bgzf_write_init(mode);
-        if (fp == NULL) {
-            if ( hts_verbose >= 2 ) fprintf(stderr, "[E::%s] bgzf_write_init error initializing zlib stream\n", __func__);
-            return 0;
-        }
+        if (fp == NULL) return NULL;
         fp->fp = fpw;
     }
     else { errno = EINVAL; return 0; }
@@ -218,10 +233,7 @@ BGZF *bgzf_dopen(int fd, const char *mode)
         hFILE *fpw;
         if ((fpw = hdopen(fd, mode)) == 0) return 0;
         fp = bgzf_write_init(mode);
-        if (fp == NULL) {
-            if ( hts_verbose >= 2 ) fprintf(stderr, "[E::%s] bgzf_write_init error initializing zlib output stream\n", __func__);
-            return 0;
-        }
+        if (fp == NULL) return NULL;
         fp->fp = fpw;
     }
     else { errno = EINVAL; return 0; }
@@ -239,10 +251,7 @@ BGZF *bgzf_hopen(hFILE *hfp, const char *mode)
         if (fp == NULL) return NULL;
     } else if (strchr(mode, 'w') || strchr(mode, 'a')) {
         fp = bgzf_write_init(mode);
-        if (fp == NULL) {
-            if ( hts_verbose >= 2 ) { fprintf(stderr, "[E::%s] bgzf_write_init error initializing zlib stream\n", __func__); }
-            return 0;
-        }
+        if (fp == NULL) return NULL;
     }
     else { errno = EINVAL; return 0; }
 
@@ -265,15 +274,24 @@ static int bgzf_compress(void *_dst, int *dlen, void *src, int slen, int level)
     zs.avail_out = *dlen - BLOCK_HEADER_LENGTH - BLOCK_FOOTER_LENGTH;
     int ret = deflateInit2(&zs, level, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY); // -15 to disable zlib header/footer
     if ( ret!=Z_OK ) {
-        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflateInit2 ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        if ( hts_verbose >= 1 ) {
+            fprintf(stderr, "[E::%s] deflateInit2 failed: %s\n",
+                    __func__, bgzf_zerr(ret));
+        }
         return -1;
     }
     if ((ret = deflate(&zs, Z_FINISH)) != Z_STREAM_END) {
-        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflate ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        if ( hts_verbose >= 1 ) {
+            fprintf(stderr, "[E::%s] deflate failed: %s\n",
+                    __func__, bgzf_zerr(ret));
+        }
         return -1;
     }
     if ((ret = deflateEnd(&zs)) != Z_OK) {
-        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        if ( hts_verbose >= 1 ) {
+            fprintf(stderr, "[E::%s] deflateEnd failed: %s\n",
+                    __func__, bgzf_zerr(ret));
+        }
         return -1;
     }
     *dlen = zs.total_out + BLOCK_HEADER_LENGTH + BLOCK_FOOTER_LENGTH;
@@ -298,7 +316,10 @@ static int bgzf_gzip_compress(BGZF *fp, void *_dst, int *dlen, void *src, int sl
     zs->avail_out = *dlen;
     int ret = deflate(zs, flush);
     if (ret == Z_STREAM_ERROR) {
-        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflate ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        if ( hts_verbose >= 1 ) {
+            fprintf(stderr, "[E::%s] deflate failed: %s\n",
+                    __func__, bgzf_zerr(ret));
+        }
         return -1;
     }
     *dlen = *dlen - zs->avail_out;
@@ -317,7 +338,9 @@ static int deflate_block(BGZF *fp, int block_length)
 
     if ( ret != 0 )
     {
-        if ( hts_verbose >= 3 ) fprintf(stderr, "[E::%s] compression error %d\n", __func__, ret);
+        if ( hts_verbose >= 3 ) {
+            fprintf(stderr, "[E::%s] compression error %d\n", __func__, ret);
+        }
         fp->errcode |= BGZF_ERR_ZLIB;
         return -1;
     }
@@ -338,20 +361,32 @@ static int inflate_block(BGZF* fp, int block_length)
 
     int ret = inflateInit2(&zs, -15);
     if (ret != Z_OK) {
-        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflateInit2 ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        if ( hts_verbose >= 1 ) {
+            fprintf(stderr, "[E::%s] inflateInit2 failed: %s\n",
+                    __func__, bgzf_zerr(ret));
+        }
         fp->errcode |= BGZF_ERR_ZLIB;
         return -1;
     }
     if ((ret = inflate(&zs, Z_FINISH)) != Z_STREAM_END) {
-        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflate ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        if ( hts_verbose >= 1 ) {
+            fprintf(stderr, "[E::%s] inflate failed: %s\n",
+                    __func__, bgzf_zerr(ret));
+        }
         if ((ret = inflateEnd(&zs)) != Z_OK) {
-            if ( hts_verbose >= 2 ) { fprintf(stderr, "[E::%s] inflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+            if ( hts_verbose >= 2 ) {
+                fprintf(stderr, "[E::%s] inflateEnd failed: %s\n",
+                        __func__, bgzf_zerr(ret));
+            }
         }
         fp->errcode |= BGZF_ERR_ZLIB;
         return -1;
     }
     if ((ret = inflateEnd(&zs)) != Z_OK) {
-        if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+        if ( hts_verbose >= 1 ) {
+            fprintf(stderr, "[E::%s] inflateEnd failed: %s\n",
+                    __func__, bgzf_zerr(ret));
+        }
         fp->errcode |= BGZF_ERR_ZLIB;
         return -1;
     }
@@ -378,7 +413,10 @@ static int inflate_gzip_block(BGZF *fp, int cached)
             ret = inflate(fp->gz_stream, Z_NO_FLUSH);
             if ( ret==Z_BUF_ERROR ) continue;   // non-critical error
             if ( ret<0 ) {
-                if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflate ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+                if ( hts_verbose >= 1 ) {
+                    fprintf(stderr, "[E::%s] inflate failed: %s\n",
+                            __func__, bgzf_zerr(ret));
+                }
                 fp->errcode |= BGZF_ERR_ZLIB;
                 return -1;
             }
@@ -558,7 +596,10 @@ int bgzf_read_block(BGZF *fp)
         int ret = inflateInit2(fp->gz_stream, -15);
         if (ret != Z_OK)
         {
-            if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflateInit2 ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+            if ( hts_verbose >= 1 ) {
+                fprintf(stderr, "[E::%s] inflateInit2 failed: %s",
+                        __func__, bgzf_zerr(ret));
+            }
             fp->errcode |= BGZF_ERR_ZLIB;
             return -1;
         }
@@ -615,7 +656,9 @@ ssize_t bgzf_read(BGZF *fp, void *data, size_t length)
         if (available <= 0) {
             int ret = bgzf_read_block(fp);
             if (ret != 0) {
-                if ( hts_verbose >= 2 ) fprintf(stderr, "[E::%s] bgzf_read_block error %d after %d of %d bytes\n", __func__, ret, bytes_read, length);
+                if ( hts_verbose >= 2 ) {
+                    fprintf(stderr, "[E::%s] bgzf_read_block error %d after %zd of %zu bytes\n", __func__, ret, bytes_read, length);
+                }
                 fp->errcode |= BGZF_ERR_ZLIB;
                 return -1;
             }
@@ -901,14 +944,20 @@ int bgzf_close(BGZF* fp)
         if (!fp->is_write) {
             ret = inflateEnd(fp->gz_stream);
             if (ret != Z_OK) {
-                if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] inflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+                if ( hts_verbose >= 1 ) {
+                    fprintf(stderr, "[E::%s] inflateEnd failed: %s\n",
+                            __func__, bgzf_zerr(ret));
+                }
                 fp->errcode |= BGZF_ERR_ZLIB;
                 // return -1; // don't bother, closing anyway
             }
         } else {
             ret = deflateEnd(fp->gz_stream);
             if (ret != Z_OK) {
-                if ( hts_verbose >= 1 ) { fprintf(stderr, "[E::%s] deflateEnd ", __func__); bgzf_zerr(ret, stderr); fputc('\n', stderr); }
+                if ( hts_verbose >= 1 ) {
+                    fprintf(stderr, "[E::%s] deflateEnd failed: %s\n",
+                            __func__, bgzf_zerr(ret));
+                }
                 fp->errcode |= BGZF_ERR_ZLIB;
                 // return -1; // don't bother, closing anyway
             }
@@ -1152,14 +1201,22 @@ int bgzf_index_load(BGZF *fp, const char *bname, const char *suffix)
 
     FILE *idx = fopen(tmp?tmp:bname,"rb");
     if ( tmp ) free(tmp);
-    if ( !idx ) return -1;
+    if ( !idx ) {
+        if (hts_verbose > 1) {
+            fprintf(stderr, "[E::%s] Error opening %s%s : %s\n",
+                    __func__, bname, suffix ? suffix : "", strerror(errno));
+        }
+        return -1;
+    }
 
     fp->idx = (bgzidx_t*) calloc(1,sizeof(bgzidx_t));
+    if (fp->idx == NULL) goto fail;
     uint64_t x;
-    if ( fread(&x, 1, sizeof(x), idx) != sizeof(x) ) return -1;
+    if ( fread(&x, 1, sizeof(x), idx) != sizeof(x) ) goto fail;
 
     fp->idx->noffs = fp->idx->moffs = 1 + (fp->is_be ? ed_swap_8(x) : x);
     fp->idx->offs  = (bgzidx1_t*) malloc(fp->idx->moffs*sizeof(bgzidx1_t));
+    if (fp->idx->offs == NULL) goto fail;
     fp->idx->offs[0].caddr = fp->idx->offs[0].uaddr = 0;
 
     int i;
@@ -1171,7 +1228,7 @@ int bgzf_index_load(BGZF *fp, const char *bname, const char *suffix)
             ret += fread(&x, 1, sizeof(x), idx); fp->idx->offs[i].caddr = ed_swap_8(x);
             ret += fread(&x, 1, sizeof(x), idx); fp->idx->offs[i].uaddr = ed_swap_8(x);
         }
-        if ( ret != sizeof(x)*2*(fp->idx->noffs-1) ) return -1;
+        if ( ret != sizeof(x)*2*(fp->idx->noffs-1) ) goto fail;
     }
     else
     {
@@ -1181,11 +1238,24 @@ int bgzf_index_load(BGZF *fp, const char *bname, const char *suffix)
             ret += fread(&x, 1, sizeof(x), idx); fp->idx->offs[i].caddr = x;
             ret += fread(&x, 1, sizeof(x), idx); fp->idx->offs[i].uaddr = x;
         }
-        if ( ret != sizeof(x)*2*(fp->idx->noffs-1) ) return -1;
+        if ( ret != sizeof(x)*2*(fp->idx->noffs-1) ) goto fail;
     }
-    fclose(idx);
+    if (fclose(idx) != 0) goto fail;
     return 0;
 
+ fail:
+    if (hts_verbose > 1)
+    {
+        fprintf(stderr, "[E::%s] Error reading %s%s : %s\n",
+                __func__, bname, suffix ? suffix : "", strerror(errno));
+    }
+    fclose(idx);
+    if (fp->idx) {
+        free(fp->idx->offs);
+        free(fp->idx);
+        fp->idx = NULL;
+    }
+    return -1;
 }
 
 int bgzf_useek(BGZF *fp, long uoffset, int where)
@@ -1250,38 +1320,27 @@ long bgzf_utell(BGZF *fp)
     return fp->uncompressed_address;    // currently maintained only when reading
 }
 
-int bgzf_zerr(int errnum, FILE *fpOutput)
+static const char * bgzf_zerr(int errnum)
 {
+    static char buffer[32];
     // gzerror OF((gzFile file, int *errnum)
     switch (errnum) {
     case Z_ERRNO:
-        if (ferror(stdin))
-            fputs("zlib: error reading stdin", fpOutput);
-        else if (ferror(stdout))
-            fputs("zlib: error writing stdout", fpOutput);
-        else
-            fputs("zlib: file system error", fpOutput);
-        break;
+        return strerror(errno);
     case Z_STREAM_ERROR:
-        fputs("zlib error: invalid parameter/compression level, or inconsistent stream state", fpOutput);
-        break;
+        return "invalid parameter/compression level, or inconsistent stream state";
     case Z_DATA_ERROR:
-        fputs("zlib error: invalid or incomplete IO", fpOutput);
-        break;
+        return "invalid or incomplete IO";
     case Z_MEM_ERROR:
-        fputs("zlib error: out of memory", fpOutput);
-        break;
+        return "out of memory";
     case Z_BUF_ERROR:
-        fputs("progress temporarily not possible, or in() / out() returned an error", fpOutput);
-        break;
+        return "progress temporarily not possible, or in() / out() returned an error";
     case Z_VERSION_ERROR:
-        fputs("zlib version mismatch!", fpOutput);
-        break;
+        return "zlib version mismatch";
     case Z_OK: // 0: maybe gzgets error Z_NULL
     default:
-        fprintf(fpOutput, "zlib error: [%d] unknown", errnum);
-        return -1;
+        snprintf(buffer, sizeof(buffer), "[%d] unknown", errnum);
+        return buffer;  // FIXME: Not thread-safe.
     }
-    return 0;
 }
 

--- a/bgzf.c
+++ b/bgzf.c
@@ -1169,8 +1169,11 @@ int bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix)
     }
     if (fclose(idx) < 0)
     {
-        fprintf(stderr, "[E::%s] Error on closing %s%s : %s\n",
-                __func__, bname, suffix ? suffix : "", strerror(errno));
+        if (hts_verbose > 1)
+        {
+            fprintf(stderr, "[E::%s] Error on closing %s%s : %s\n",
+                    __func__, bname, suffix ? suffix : "", strerror(errno));
+        }
         return -1;
     }
     return 0;

--- a/bgzf.c
+++ b/bgzf.c
@@ -474,7 +474,12 @@ int bgzf_read_block(BGZF *fp)
     if ( !fp->is_compressed )
     {
         count = hread(fp->fp, fp->uncompressed_block, BGZF_MAX_BLOCK_SIZE);
-        if ( count==0 )
+        if ( count < 0 )  // Error
+        {
+            fp->errcode |= BGZF_ERR_IO;
+            return -1;
+        }
+        if ( count==0 )   // EOF
         {
             fp->block_length = 0;
             return 0;
@@ -1077,7 +1082,14 @@ int bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix)
 
     FILE *idx = fopen(tmp?tmp:bname,"wb");
     if ( tmp ) free(tmp);
-    if ( !idx ) return -1;
+    if ( !idx ) {
+        if (hts_verbose > 1)
+        {
+            fprintf(stderr, "[E::%s] Error opening %s%s : %s\n",
+                    __func__, bname, suffix ? suffix : "", strerror(errno));
+        }
+        return -1;
+    }
 
     // Note that the index contains one extra record when indexing files opened
     // for reading. The terminating record is not present when opened for writing.
@@ -1087,25 +1099,41 @@ int bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix)
     if ( fp->is_be )
     {
         uint64_t x = fp->idx->noffs - 1;
-        fwrite(ed_swap_8p(&x), 1, sizeof(x), idx);
+        if (fwrite(ed_swap_8p(&x), 1, sizeof(x), idx) < sizeof(x)) goto fail;
         for (i=1; i<fp->idx->noffs; i++)
         {
-            x = fp->idx->offs[i].caddr; fwrite(ed_swap_8p(&x), 1, sizeof(x), idx);
-            x = fp->idx->offs[i].uaddr; fwrite(ed_swap_8p(&x), 1, sizeof(x), idx);
+            x = fp->idx->offs[i].caddr;
+            if (fwrite(ed_swap_8p(&x), 1, sizeof(x), idx) < sizeof(x)) goto fail;
+            x = fp->idx->offs[i].uaddr;
+            if (fwrite(ed_swap_8p(&x), 1, sizeof(x), idx) < sizeof(x)) goto fail;
         }
     }
     else
     {
         uint64_t x = fp->idx->noffs - 1;
-        fwrite(&x, 1, sizeof(x), idx);
+        if (fwrite(&x, 1, sizeof(x), idx) < sizeof(x)) goto fail;
         for (i=1; i<fp->idx->noffs; i++)
         {
-            fwrite(&fp->idx->offs[i].caddr, 1, sizeof(fp->idx->offs[i].caddr), idx);
-            fwrite(&fp->idx->offs[i].uaddr, 1, sizeof(fp->idx->offs[i].uaddr), idx);
+            if (fwrite(&fp->idx->offs[i].caddr, 1, sizeof(fp->idx->offs[i].caddr), idx) < sizeof(fp->idx->offs[i].caddr)) goto fail;
+            if (fwrite(&fp->idx->offs[i].uaddr, 1, sizeof(fp->idx->offs[i].uaddr), idx) < sizeof(fp->idx->offs[i].uaddr)) goto fail;
         }
     }
-    fclose(idx);
+    if (fclose(idx) < 0)
+    {
+        fprintf(stderr, "[E::%s] Error on closing %s%s : %s\n",
+                __func__, bname, suffix ? suffix : "", strerror(errno));
+        return -1;
+    }
     return 0;
+
+ fail:
+    if (hts_verbose > 1)
+    {
+        fprintf(stderr, "[E::%s] Error writing to %s%s : %s\n",
+                __func__, bname, suffix ? suffix : "", strerror(errno));
+    }
+    fclose(idx);
+    return -1;
 }
 
 
@@ -1172,7 +1200,10 @@ int bgzf_useek(BGZF *fp, long uoffset, int where)
         fp->block_length = 0;  // indicates current block has not been loaded
         fp->block_address = uoffset;
         fp->block_offset = 0;
-        bgzf_read_block(fp);
+        if (bgzf_read_block(fp) < 0) {
+            fp->errcode |= BGZF_ERR_IO;
+            return -1;
+        }
         fp->uncompressed_address = uoffset;
         return 0;
     }
@@ -1201,7 +1232,10 @@ int bgzf_useek(BGZF *fp, long uoffset, int where)
     fp->block_length = 0;  // indicates current block has not been loaded
     fp->block_address = fp->idx->offs[i].caddr;
     fp->block_offset = 0;
-    if ( bgzf_read_block(fp) < 0 ) return -1;
+    if ( bgzf_read_block(fp) < 0 ) {
+        fp->errcode |= BGZF_ERR_IO;
+        return -1;
+    }
     if ( uoffset - fp->idx->offs[i].uaddr > 0 )
     {
         fp->block_offset = uoffset - fp->idx->offs[i].uaddr;

--- a/bgzip.c
+++ b/bgzip.c
@@ -177,8 +177,13 @@ int main(int argc, char **argv)
         // f_dst will be closed here
         if ( index )
         {
-            if ( index_fname ) bgzf_index_dump(fp, index_fname, NULL);
-            else bgzf_index_dump(fp, argv[optind], ".gz.gzi");
+            if (index_fname) {
+                if (bgzf_index_dump(fp, index_fname, NULL) < 0)
+                    error("Could not write index to '%s'\n", index_fname);
+            } else {
+                if (bgzf_index_dump(fp, argv[optind], ".gz.gzi") < 0)
+                    error("Could not write index to '%s.gz.gzi'", argv[optind]);
+            }
         }
         if (bgzf_close(fp) < 0) error("Close failed: Error %d", fp->errcode);
         if (argc > optind && !pstdout) unlink(argv[optind]);
@@ -207,10 +212,13 @@ int main(int argc, char **argv)
         free(buffer);
         if ( ret<0 ) error("Is the file gzipped or bgzipped? The latter is required for indexing.\n");
 
-        if ( index_fname )
-            bgzf_index_dump(fp, index_fname, NULL);
-        else
-            bgzf_index_dump(fp, argv[optind], ".gzi");
+        if ( index_fname ) {
+            if (bgzf_index_dump(fp, index_fname, NULL) < 0)
+                error("Could not write index to '%s'\n", index_fname);
+        } else {
+            if (bgzf_index_dump(fp, argv[optind], ".gzi") < 0)
+                error("Could not write index to '%s.gzi'\n", argv[optind]);
+        }
 
         if ( bgzf_close(fp)<0 ) error("Close failed: Error %d\n",fp->errcode);
         return 0;

--- a/hts.c
+++ b/hts.c
@@ -1479,39 +1479,45 @@ int hts_idx_save(const hts_idx_t *idx, const char *fn, int fmt)
 
 int hts_idx_save_as(const hts_idx_t *idx, const char *fn, const char *fnidx, int fmt)
 {
+    BGZF *fp = NULL;
+    FILE *f = NULL;
     if (fnidx == NULL) return hts_idx_save(idx, fn, fmt);
 
     if (fmt == HTS_FMT_CSI) {
-        BGZF *fp;
         uint32_t x[3];
         int is_be, i;
         is_be = ed_is_big();
         fp = bgzf_open(fnidx, "w");
         if (fp == NULL) return -1;
-        bgzf_write(fp, "CSI\1", 4);
+        if (bgzf_write(fp, "CSI\1", 4) < 0) goto fail;
         x[0] = idx->min_shift; x[1] = idx->n_lvls; x[2] = idx->l_meta;
         if (is_be) {
             for (i = 0; i < 3; ++i)
-                bgzf_write(fp, ed_swap_4p(&x[i]), 4);
-        } else bgzf_write(fp, &x, 12);
-        if (idx->l_meta) bgzf_write(fp, idx->meta, idx->l_meta);
+                if (bgzf_write(fp, ed_swap_4p(&x[i]), 4) < 0) goto fail;
+        } else {
+            if (bgzf_write(fp, &x, 12) < 0) goto fail;
+        }
+        if (idx->l_meta) {
+            if (bgzf_write(fp, idx->meta, idx->l_meta) < 0) goto fail;
+        }
         hts_idx_save_core(idx, fp, HTS_FMT_CSI);
-        bgzf_close(fp);
     } else if (fmt == HTS_FMT_TBI) {
-        BGZF *fp = bgzf_open(fnidx, "w");
+        fp = bgzf_open(fnidx, "w");
         if (fp == NULL) return -1;
-        bgzf_write(fp, "TBI\1", 4);
+        if (bgzf_write(fp, "TBI\1", 4) < 0) goto fail;
         hts_idx_save_core(idx, fp, HTS_FMT_TBI);
-        bgzf_close(fp);
     } else if (fmt == HTS_FMT_BAI) {
-        FILE *fp = fopen(fnidx, "w");
-        if (fp == NULL) return -1;
-        fwrite("BAI\1", 1, 4, fp);
-        hts_idx_save_core(idx, fp, HTS_FMT_BAI);
-        fclose(fp);
+        f = fopen(fnidx, "w");
+        if (f == NULL) return -1;
+        if (fwrite("BAI\1", 1, 4, f) != 4) goto fail;
+        hts_idx_save_core(idx, f, HTS_FMT_BAI);
     } else abort();
 
-    return 0;
+    return fp ? bgzf_close(fp) : fclose(f);
+ fail:
+    if (fp) bgzf_close(fp);
+    if (f)  fclose(f);
+    return -1;
 }
 
 static int hts_idx_load_core(hts_idx_t *idx, BGZF *fp, int fmt)
@@ -1927,7 +1933,7 @@ int hts_itr_next(BGZF *fp, hts_itr_t *iter, void *r, void *data)
     if (iter == NULL || iter->finished) return -1;
     if (iter->read_rest) {
         if (iter->curr_off) { // seek to the start
-            bgzf_seek(fp, iter->curr_off, SEEK_SET);
+            if (bgzf_seek(fp, iter->curr_off, SEEK_SET) < 0) return -1;
             iter->curr_off = 0; // only seek once
         }
         ret = iter->readrec(fp, data, r, &tid, &beg, &end);
@@ -1942,7 +1948,7 @@ int hts_itr_next(BGZF *fp, hts_itr_t *iter, void *r, void *data)
         if (iter->curr_off == 0 || iter->curr_off >= iter->off[iter->i].v) { // then jump to the next chunk
             if (iter->i == iter->n_off - 1) { ret = -1; break; } // no more chunks
             if (iter->i < 0 || iter->off[iter->i].v != iter->off[iter->i+1].u) { // not adjacent chunks; then seek
-                bgzf_seek(fp, iter->off[iter->i+1].u, SEEK_SET);
+                if (bgzf_seek(fp, iter->off[iter->i+1].u, SEEK_SET) < 0) return -1;
                 iter->curr_off = bgzf_tell(fp);
             }
             ++iter->i;

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -310,6 +310,16 @@ typedef struct __kstring_t {
      */
     int bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix);
 
+    /**
+     * Append zlib or i/o error details to a file.
+     *
+     * @param errnum      zlib return value
+     * @param fpOutput    output file handle, typically stderr 
+     *
+     * Returns 0 on success and -1 for unknown ret value.
+     */
+    int bgzf_zerr(int errnum, FILE *fpOutput);
+
 #ifdef __cplusplus
 }
 #endif

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -34,6 +34,8 @@
 #include <zlib.h>
 #include <sys/types.h>
 
+#include <htslib/hts_defs.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -125,7 +127,7 @@ typedef struct __kstring_t {
      * @param length size of data to read
      * @return       number of bytes actually read; 0 on end-of-file and -1 on error
      */
-    ssize_t bgzf_read(BGZF *fp, void *data, size_t length);
+    ssize_t bgzf_read(BGZF *fp, void *data, size_t length) HTS_RESULT_USED;
 
     /**
      * Write _length_ bytes from _data_ to the file.  If no I/O errors occur,
@@ -136,7 +138,7 @@ typedef struct __kstring_t {
      * @param length size of data to write
      * @return       number of bytes written (i.e., _length_); negative on error
      */
-    ssize_t bgzf_write(BGZF *fp, const void *data, size_t length);
+    ssize_t bgzf_write(BGZF *fp, const void *data, size_t length) HTS_RESULT_USED;
 
     /**
      * Read up to _length_ bytes directly from the underlying stream without
@@ -148,7 +150,7 @@ typedef struct __kstring_t {
      * @param length number of raw bytes to read
      * @return       number of bytes actually read; 0 on end-of-file and -1 on error
      */
-    ssize_t bgzf_raw_read(BGZF *fp, void *data, size_t length);
+    ssize_t bgzf_raw_read(BGZF *fp, void *data, size_t length) HTS_RESULT_USED;
 
     /**
      * Write _length_ bytes directly to the underlying stream without
@@ -160,12 +162,15 @@ typedef struct __kstring_t {
      * @param length number of raw bytes to write
      * @return       number of bytes actually written; -1 on error
      */
-    ssize_t bgzf_raw_write(BGZF *fp, const void *data, size_t length);
+    ssize_t bgzf_raw_write(BGZF *fp, const void *data, size_t length) HTS_RESULT_USED;
 
     /**
      * Write the data in the buffer to the file.
+     * 
+     * @param fp     BGZF file handle
+     * @return       0 on success and -1 on error
      */
-    int bgzf_flush(BGZF *fp);
+    int bgzf_flush(BGZF *fp) HTS_RESULT_USED;
 
     /**
      * Return a virtual file pointer to the current location in the file.
@@ -183,7 +188,7 @@ typedef struct __kstring_t {
      * @param whence must be SEEK_SET
      * @return       0 on success and -1 on error
      */
-    int64_t bgzf_seek(BGZF *fp, int64_t pos, int whence);
+    int64_t bgzf_seek(BGZF *fp, int64_t pos, int whence) HTS_RESULT_USED;
 
     /**
      * Check if the BGZF end-of-file (EOF) marker is present
@@ -220,7 +225,7 @@ typedef struct __kstring_t {
      * Flush the file if the remaining buffer size is smaller than _size_
      * @return      0 if flushing succeeded or was not needed; negative on error
      */
-    int bgzf_flush_try(BGZF *fp, ssize_t size);
+    int bgzf_flush_try(BGZF *fp, ssize_t size) HTS_RESULT_USED;
 
     /**
      * Read one byte from a BGZF file. It is faster than bgzf_read()
@@ -242,7 +247,7 @@ typedef struct __kstring_t {
     /**
      * Read the next BGZF block.
      */
-    int bgzf_read_block(BGZF *fp);
+    int bgzf_read_block(BGZF *fp) HTS_RESULT_USED;
 
     /**
      * Enable multi-threading (only effective on writing and when the
@@ -252,7 +257,7 @@ typedef struct __kstring_t {
      * @param n_threads   #threads used for writing
      * @param n_sub_blks  #blocks processed by each thread; a value 64-256 is recommended
      */
-    int bgzf_mt(BGZF *fp, int n_threads, int n_sub_blks);
+    int bgzf_mt(BGZF *fp, int n_threads, int n_sub_blks) HTS_RESULT_USED;
 
 
     /*******************
@@ -268,7 +273,7 @@ typedef struct __kstring_t {
      *
      *  Returns 0 on success and -1 on error.
      */
-    int bgzf_useek(BGZF *fp, long uoffset, int where);
+    int bgzf_useek(BGZF *fp, long uoffset, int where) HTS_RESULT_USED;
 
     /**
      *  Position in uncompressed BGZF
@@ -308,7 +313,8 @@ typedef struct __kstring_t {
      *
      * Returns 0 on success and -1 on error.
      */
-    int bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix);
+    int bgzf_index_dump(BGZF *fp,
+                        const char *bname, const char *suffix) HTS_RESULT_USED;
 
     /**
      * Append zlib or i/o error details to a file.

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -316,16 +316,6 @@ typedef struct __kstring_t {
     int bgzf_index_dump(BGZF *fp,
                         const char *bname, const char *suffix) HTS_RESULT_USED;
 
-    /**
-     * Append zlib or i/o error details to a file.
-     *
-     * @param errnum      zlib return value
-     * @param fpOutput    output file handle, typically stderr 
-     *
-     * Returns 0 on success and -1 for unknown ret value.
-     */
-    int bgzf_zerr(int errnum, FILE *fpOutput);
-
 #ifdef __cplusplus
 }
 #endif

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -60,7 +60,7 @@ typedef struct __faidx_t faidx_t;
       @return     0 on success; or -1 on failure
       @discussion File "fn.fai" will be generated.
      */
-    int fai_build(const char *fn);
+    int fai_build(const char *fn) HTS_RESULT_USED;
 
     /*!
       @abstract    Destroy a faidx_t struct.

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -29,6 +29,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stddef.h>
 #include <stdint.h>
 
+#include <htslib/hts_defs.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -445,7 +447,7 @@ typedef struct {
     @param fmt  One of the HTS_FMT_* index formats
     @return  0 if successful, or negative if an error occurred.
 */
-int hts_idx_save(const hts_idx_t *idx, const char *fn, int fmt);
+int hts_idx_save(const hts_idx_t *idx, const char *fn, int fmt) HTS_RESULT_USED;
 
 /// Save an index to a specific file
 /** @param idx    Index to be written
@@ -454,7 +456,7 @@ int hts_idx_save(const hts_idx_t *idx, const char *fn, int fmt);
     @param fmt    One of the HTS_FMT_* index formats
     @return  0 if successful, or negative if an error occurred.
 */
-int hts_idx_save_as(const hts_idx_t *idx, const char *fn, const char *fnidx, int fmt);
+int hts_idx_save_as(const hts_idx_t *idx, const char *fn, const char *fnidx, int fmt) HTS_RESULT_USED;
 
 /// Load an index file
 /** @param fn   BAM/BCF/etc filename, to which .bai/.csi/etc will be added or
@@ -511,7 +513,7 @@ const char *hts_parse_reg(const char *str, int *beg, int *end);
     typedef hts_itr_t *hts_itr_query_func(const hts_idx_t *idx, int tid, int beg, int end, hts_readrec_func *readrec);
 
     hts_itr_t *hts_itr_querys(const hts_idx_t *idx, const char *reg, hts_name2id_f getid, void *hdr, hts_itr_query_func *itr_query, hts_readrec_func *readrec);
-    int hts_itr_next(BGZF *fp, hts_itr_t *iter, void *r, void *data);
+    int hts_itr_next(BGZF *fp, hts_itr_t *iter, void *r, void *data) HTS_RESULT_USED;
     const char **hts_idx_seqnames(const hts_idx_t *idx, int *n, hts_id2name_f getid, void *hdr); // free only the array, not the values
 
     /**

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -255,15 +255,15 @@ typedef struct {
 
     bam_hdr_t *bam_hdr_init(void);
     bam_hdr_t *bam_hdr_read(BGZF *fp);
-    int bam_hdr_write(BGZF *fp, const bam_hdr_t *h);
+    int bam_hdr_write(BGZF *fp, const bam_hdr_t *h) HTS_RESULT_USED;
     void bam_hdr_destroy(bam_hdr_t *h);
     int bam_name2id(bam_hdr_t *h, const char *ref);
     bam_hdr_t* bam_hdr_dup(const bam_hdr_t *h0);
 
     bam1_t *bam_init1(void);
     void bam_destroy1(bam1_t *b);
-    int bam_read1(BGZF *fp, bam1_t *b);
-    int bam_write1(BGZF *fp, const bam1_t *b);
+    int bam_read1(BGZF *fp, bam1_t *b) HTS_RESULT_USED;
+    int bam_write1(BGZF *fp, const bam1_t *b) HTS_RESULT_USED;
     bam1_t *bam_copy1(bam1_t *bdst, const bam1_t *bsrc);
     bam1_t *bam_dup1(const bam1_t *bsrc);
 
@@ -322,7 +322,7 @@ hts_idx_t *sam_index_load2(htsFile *fp, const char *fn, const char *fnidx);
     @param min_shift Positive to generate CSI, or 0 to generate BAI
     @return  0 if successful, or negative if an error occurred.
 */
-int sam_index_build(const char *fn, int min_shift);
+int sam_index_build(const char *fn, int min_shift) HTS_RESULT_USED;
 
 /// Generate and save an index to a specific file
 /** @param fn        Input BAM/CRAM/etc filename
@@ -330,7 +330,7 @@ int sam_index_build(const char *fn, int min_shift);
     @param min_shift Positive to generate CSI, or 0 to generate BAI
     @return  0 if successful, or negative if an error occurred.
 */
-int sam_index_build2(const char *fn, const char *fnidx, int min_shift);
+int sam_index_build2(const char *fn, const char *fnidx, int min_shift) HTS_RESULT_USED;
 
     #define sam_itr_destroy(iter) hts_itr_destroy(iter)
     hts_itr_t *sam_itr_queryi(const hts_idx_t *idx, int tid, int beg, int end);
@@ -357,12 +357,12 @@ int sam_index_build2(const char *fn, const char *fnidx, int min_shift);
     typedef htsFile samFile;
     bam_hdr_t *sam_hdr_parse(int l_text, const char *text);
     bam_hdr_t *sam_hdr_read(samFile *fp);
-    int sam_hdr_write(samFile *fp, const bam_hdr_t *h);
+    int sam_hdr_write(samFile *fp, const bam_hdr_t *h) HTS_RESULT_USED;
 
-    int sam_parse1(kstring_t *s, bam_hdr_t *h, bam1_t *b);
-    int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str);
-    int sam_read1(samFile *fp, bam_hdr_t *h, bam1_t *b);
-    int sam_write1(samFile *fp, const bam_hdr_t *h, const bam1_t *b);
+    int sam_parse1(kstring_t *s, bam_hdr_t *h, bam1_t *b) HTS_RESULT_USED;
+    int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str) HTS_RESULT_USED;
+    int sam_read1(samFile *fp, bam_hdr_t *h, bam1_t *b) HTS_RESULT_USED;
+    int sam_write1(samFile *fp, const bam_hdr_t *h, const bam1_t *b) HTS_RESULT_USED;
 
     /*************************************
      *** Manipulating auxiliary fields ***

--- a/sam.c
+++ b/sam.c
@@ -779,7 +779,7 @@ int sam_hdr_write(htsFile *fp, const bam_hdr_t *h)
         fp->format.format = bam;
         /* fall-through */
     case bam:
-        bam_hdr_write(fp->fp.bgzf, h);
+        if (bam_hdr_write(fp->fp.bgzf, h) < 0) return -1;
         break;
 
     case cram: {


### PR DESCRIPTION
This is a rebased version of #242, which was an updated version of pull request #211.

The error message printing is simplified a bit by making bgzf_zerr return strings instead of writing to a file descriptor itself. That means the error reporting can be done with a single printf instead of a printf, a call to bgzf_err and a puts.

Removed calls to abort(). Instead function prototypes have had HTS_RESULT_USED added to them (where useful) so that gcc warns when the return value is not being checked. This has been done in bgzf.h, sam.h, hts.h and faidx.h. Fixes for all of the warnings are included, apart from some that should be sorted by other pull requests. At the same time, a few other cases of missing error checks have been fixed.

The error handling code in a few functions has been improved so that they shouldn't leak memory or keep file handles open when they return due to detecting an error.
