### PR TITLE
Enable multithreaded compression in bgzip

### DIFF
--- a/bgzip.c
+++ b/bgzip.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
         {"help",0,0,'h'},
         {"offset",1,0,'b'},
         {"stdout",0,0,'c'},
-        {"threads",0,0,'@'},
+        {"threads",1,0,'@'},
         {"decompress",0,0,'d'},
         {"force",0,0,'f'},
         {"index",0,0,'i'},


### PR DESCRIPTION
I noticed that there is support for multithreaded bgzip compression in `htslib` but this wasn't being surfaced to the user in the `bgzip` executable. I added it with the same command line flag `-@` to match the same as the multithreaded compression on `samtools sort`.
