### PR TITLE
Fix bcf_empty1() function declaration typo in vcf.h

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -261,7 +261,7 @@ typedef struct {
      *  Same as bcf_destroy() but frees only the memory allocated by bcf1_t,
      *  not the bcf1_t object itself.
      */
-    void bcf_empty(bcf1_t *v);
+    void bcf_empty1(bcf1_t *v);
 
     /**
      *  Make the bcf1_t object ready for next read. Intended mostly for

--- a/vcf_sweep.c
+++ b/vcf_sweep.c
@@ -118,7 +118,6 @@ bcf_sweep_t *bcf_sweep_init(const char *fname)
     return sw;
 }
 
-void bcf_empty1(bcf1_t *v);
 void bcf_sweep_destroy(bcf_sweep_t *sw)
 {
     int i;


### PR DESCRIPTION
vcf.h declares bcf_empty()
vcf.c defines bcf_empty1()

I've renamed the header declaration to bcf_empty1()