### PR TITLE
Fix bcf_empty(), bcf_init(), bcf_destroy() definitions

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -238,6 +238,7 @@ typedef struct {
     #define vcf_parse1(s,h,v)   vcf_parse((s),(h),(v))
     #define bcf_clear1(v)       bcf_clear(v)
     #define vcf_format1(h,v,s)  vcf_format((h),(v),(s))
+    #define bcf_empty1(v)       bcf_empty(v)
 
     /**
      *  bcf_hdr_init() - create an empty BCF header.

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -275,7 +275,7 @@ static void bcf_sr_destroy1(bcf_sr_t *reader)
     if ( reader->itr ) tbx_itr_destroy(reader->itr);
     int j;
     for (j=0; j<reader->mbuffer; j++)
-        bcf_destroy1(reader->buffer[j]);
+        bcf_destroy(reader->buffer[j]);
     free(reader->buffer);
     free(reader->samples);
     free(reader->filter_ids);
@@ -473,7 +473,7 @@ static void _reader_fill_buffer(bcf_srs_t *files, bcf_sr_t *reader)
             reader->buffer = (bcf1_t**) realloc(reader->buffer, sizeof(bcf1_t*)*reader->mbuffer);
             for (i=8; i>0; i--)     // initialize
             {
-                reader->buffer[reader->mbuffer-i] = bcf_init1();
+                reader->buffer[reader->mbuffer-i] = bcf_init();
                 reader->buffer[reader->mbuffer-i]->max_unpack = files->max_unpack;
                 reader->buffer[reader->mbuffer-i]->pos = -1;    // for rare cases when VCF starts from 1
             }

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -33,7 +33,7 @@ void write_bcf(char *fname)
     // Init
     htsFile *fp    = hts_open(fname,"wb");
     bcf_hdr_t *hdr = bcf_hdr_init("w");
-    bcf1_t *rec    = bcf_init1();
+    bcf1_t *rec    = bcf_init();
 
     // Create VCF header
     kstring_t str = {0,0,0};
@@ -152,7 +152,7 @@ void write_bcf(char *fname)
 
     // Clean
     free(str.s);
-    bcf_destroy1(rec);
+    bcf_destroy(rec);
     bcf_hdr_destroy(hdr);
     int ret;
     if ( (ret=hts_close(fp)) )
@@ -166,7 +166,7 @@ void bcf_to_vcf(char *fname)
 {
     htsFile *fp    = hts_open(fname,"rb");
     bcf_hdr_t *hdr = bcf_hdr_read(fp);
-    bcf1_t *rec    = bcf_init1();
+    bcf1_t *rec    = bcf_init();
 
     char *gz_fname = (char*) malloc(strlen(fname)+4);
     snprintf(gz_fname,strlen(fname)+4,"%s.gz",fname);
@@ -194,7 +194,7 @@ void bcf_to_vcf(char *fname)
 
         bcf1_t *dup = bcf_dup(rec);     // force bcf1_sync call
         bcf_write1(out, hdr_out, dup);
-        bcf_destroy1(dup);
+        bcf_destroy(dup);
 
         bcf_update_alleles_str(hdr_out, rec, "G,A");
         int32_t tmpi = 99;
@@ -205,7 +205,7 @@ void bcf_to_vcf(char *fname)
         bcf_write1(out, hdr_out, rec);
     }
 
-    bcf_destroy1(rec);
+    bcf_destroy(rec);
     bcf_hdr_destroy(hdr);
     bcf_hdr_destroy(hdr_out);
     int ret;

--- a/vcf.c
+++ b/vcf.c
@@ -837,7 +837,7 @@ int bcf_hdr_write(htsFile *hfp, bcf_hdr_t *h)
  *** BCF site I/O ***
  ********************/
 
-bcf1_t *bcf_init1()
+bcf1_t *bcf_init()
 {
     bcf1_t *v;
     v = (bcf1_t*)calloc(1, sizeof(bcf1_t));
@@ -876,7 +876,7 @@ void bcf_clear(bcf1_t *v)
     if (v->d.m_id) v->d.id[0] = 0;
 }
 
-void bcf_empty1(bcf1_t *v)
+void bcf_empty(bcf1_t *v)
 {
     bcf_clear1(v);
     free(v->d.id);
@@ -886,9 +886,9 @@ void bcf_empty1(bcf1_t *v)
     free(v->shared.s); free(v->indiv.s);
 }
 
-void bcf_destroy1(bcf1_t *v)
+void bcf_destroy(bcf1_t *v)
 {
-    bcf_empty1(v);
+    bcf_empty(v);
     free(v);
 }
 
@@ -1190,7 +1190,7 @@ bcf1_t *bcf_copy(bcf1_t *dst, bcf1_t *src)
 }
 bcf1_t *bcf_dup(bcf1_t *src)
 {
-    bcf1_t *out = bcf_init1();
+    bcf1_t *out = bcf_init();
     return bcf_copy(out, src);
 }
 
@@ -2224,19 +2224,19 @@ hts_idx_t *bcf_index(htsFile *fp, int min_shift)
     max_len += 256;
     for (n_lvls = 0, s = 1<<min_shift; max_len > s; ++n_lvls, s <<= 3);
     idx = hts_idx_init(nids, HTS_FMT_CSI, bgzf_tell(fp->fp.bgzf), min_shift, n_lvls);
-    b = bcf_init1();
+    b = bcf_init();
     while (bcf_read1(fp,h, b) >= 0) {
         int ret;
         ret = hts_idx_push(idx, b->rid, b->pos, b->pos + b->rlen, bgzf_tell(fp->fp.bgzf), 1);
         if (ret < 0)
         {
-            bcf_destroy1(b);
+            bcf_destroy(b);
             hts_idx_destroy(idx);
             return NULL;
         }
     }
     hts_idx_finish(idx, bgzf_tell(fp->fp.bgzf));
-    bcf_destroy1(b);
+    bcf_destroy(b);
     bcf_hdr_destroy(h);
     return idx;
 }

--- a/vcf_sweep.c
+++ b/vcf_sweep.c
@@ -118,11 +118,10 @@ bcf_sweep_t *bcf_sweep_init(const char *fname)
     return sw;
 }
 
-void bcf_empty1(bcf1_t *v);
 void bcf_sweep_destroy(bcf_sweep_t *sw)
 {
     int i;
-    for (i=0; i<sw->mrec; i++) bcf_empty1(&sw->rec[i]);
+    for (i=0; i<sw->mrec; i++) bcf_empty(&sw->rec[i]);
     free(sw->idx);
     free(sw->rec);
     free(sw->lals);


### PR DESCRIPTION
vcf.h declares:

    bcf1_t *bcf_init(void);
    void bcf_empty(bcf1_t *v);
    void bcf_destroy(bcf1_t *v);

but vcf.c defines:

    bcf1_t *bcf_init1()
    void bcf_empty1(bcf1_t *v)
    void bcf_destroy1(bcf1_t *v)

So I've changed the vcf.c definitions to match the vcf.h declarations and added
the missing macro for bcf_empty().

I've also updated calls in htslib to init/empty/destroy to use the functions
rather than macros.

Note: I've got no idea how/why htslib compiled before, since `bcf_init()` was called (or called via macro `bcf_init1()` -> `bcf_init()`) but never declared anywhere. Can anyone explain?