### PR TITLE
change bgzf_*open to set binary mode in windows

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -417,6 +417,10 @@ hFILE *hdopen(int fd, const char *mode)
     hFILE_fd *fp = (hFILE_fd*) hfile_init(sizeof (hFILE_fd), mode, blksize(fd));
     if (fp == NULL) return NULL;
 
+#ifdef _WIN32
+    /* htslib policy is to open everything in binary mode */
+    _setmode(fd, _O_BINARY);
+#endif
     fp->fd = fd;
     fp->is_socket = (strchr(mode, 's') != NULL);
     fp->base.backend = &fd_backend;
@@ -426,7 +430,6 @@ hFILE *hdopen(int fd, const char *mode)
 static hFILE *hopen_fd_stdinout(const char *mode)
 {
     int fd = (strchr(mode, 'r') != NULL)? STDIN_FILENO : STDOUT_FILENO;
-    // TODO Set binary mode (for Windows)
     return hdopen(fd, mode);
 }
 


### PR DESCRIPTION
Always set binary mode on the BGZF* file descriptor for
all bgzf_*open calls on windows. Note the occurance of
'b' in the mode string is ignored, because this file
type must be binary mode to work correctly on windows.

This design will correct all bgzf file pointers (stdin/stdout,
other cases of pre-specified fd...)  instead of just
those using bgzf_open with the current O_BINARY define
in hfile_oflags.