### PR TITLE
vcfutils: add bcf_remove_alleles_set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ tbx.o tbx.pico: tbx.c config.h $(htslib_tbx_h) $(htslib_bgzf_h) $(htslib_khash_h
 faidx.o faidx.pico: faidx.c config.h $(htslib_bgzf_h) $(htslib_faidx_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kstring_h)
 synced_bcf_reader.o synced_bcf_reader.pico: synced_bcf_reader.c config.h $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) $(htslib_bgzf_h)
 vcf_sweep.o vcf_sweep.pico: vcf_sweep.c config.h $(htslib_vcf_sweep_h) $(htslib_bgzf_h)
-vcfutils.o vcfutils.pico: vcfutils.c config.h $(htslib_vcfutils_h)
+vcfutils.o vcfutils.pico: vcfutils.c config.h $(htslib_vcfutils_h) $(htslib_kbitset_h)
 kfunc.o kfunc.pico: kfunc.c $(htslib_kfunc_h)
 regidx.o regidx.pico: regidx.c config.h $(htslib_hts_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) $(htslib_regidx_h)
 md5.o md5.pico: md5.c config.h $(htslib_hts_h)

--- a/cram/sam_header.h
+++ b/cram/sam_header.h
@@ -321,6 +321,10 @@ int sam_hdr_add(SAM_hdr *sh, const char *type, ...);
  * varargs functions to call this while including their own additional
  * parameters; an example is in sam_hdr_add_PG().
  *
+ * Note: this function invokes va_arg at least once, making the value
+ * of ap indeterminate after the return.  The caller should call
+ * va_start/va_end before/after calling this function or use va_copy.
+ *
  * @return
  * Returns 0 on success;
  *        -1 on failure

--- a/htslib/vcfutils.h
+++ b/htslib/vcfutils.h
@@ -1,6 +1,6 @@
 /*  vcfutils.h -- allele-related utility functions.
 
-    Copyright (C) 2012, 2013 Genome Research Ltd.
+    Copyright (C) 2012, 2013, 2015 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>
 
@@ -31,6 +31,8 @@ DEALINGS IN THE SOFTWARE.  */
 extern "C" {
 #endif
 
+struct kbitset_t;
+
 /**
  *  bcf_trim_alleles() - remove ALT alleles unused in genotype fields
  *  @header:  for access to BCF_DT_ID dictionary
@@ -42,15 +44,27 @@ extern "C" {
  */
 int bcf_trim_alleles(const bcf_hdr_t *header, bcf1_t *line);
 
-
 /**
  *  bcf_remove_alleles() - remove ALT alleles according to bitmask @mask
  *  @header:  for access to BCF_DT_ID dictionary
  *  @line:    VCF line obtained from vcf_parse1
  *  @mask:    alleles to remove
+ * 
+ *  If you have more than 31 alleles, then the integer bit mask will
+ *  overflow, so use bcf_remove_alleles_set instead
  */
 void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int mask);
 
+/**
+ *  bcf_remove_alleles_set() - remove ALT alleles according to bitset @rm_set
+ *  @header:  for access to BCF_DT_ID dictionary
+ *  @line:    VCF line obtained from vcf_parse1
+ *  @rm_set:  pointer to kbitset_t object with bits set for allele
+ *            indexes to remove
+ *  
+ *  Number=A,R,G INFO and FORMAT fields will be updated accordingly.
+ */
+void bcf_remove_allele_set(const bcf_hdr_t *header, bcf1_t *line, const struct kbitset_t *rm_set);
 
 /**
  *  bcf_calc_ac() - calculate the number of REF and ALT alleles

--- a/vcfutils.c
+++ b/vcfutils.c
@@ -1,6 +1,6 @@
 /*  vcfutils.c -- allele-related utility functions.
 
-    Copyright (C) 2012-2014 Genome Research Ltd.
+    Copyright (C) 2012-2015 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>
 
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <config.h>
 
 #include "htslib/vcfutils.h"
+#include "htslib/kbitset.h"
 
 int bcf_calc_ac(const bcf_hdr_t *header, bcf1_t *line, int *ac, int which)
 {
@@ -198,18 +199,31 @@ int bcf_trim_alleles(const bcf_hdr_t *header, bcf1_t *line)
     }
     #undef BRANCH
 
-    int rm_als = 0, nrm = 0;
+    int nrm = 0;
+    kbitset_t *rm_set = kbs_init(line->n_allele);
     for (i=1; i<line->n_allele; i++)
     {
-        if ( !ac[i] ) { rm_als |= 1<<i; nrm++; }
+        if ( !ac[i] ) { kbs_insert(rm_set, i); nrm++; }
     }
     free(ac);
 
-    if ( nrm ) bcf_remove_alleles(header, line, rm_als);
+    if ( nrm ) bcf_remove_allele_set(header, line, rm_set);
+    kbs_destroy(rm_set);
     return nrm;
 }
 
 void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
+{
+    int i;
+    kbitset_t *rm_set = kbs_init(line->n_allele);
+    for (i=1; i<line->n_allele; i++)
+        if ( rm_mask & 1<<i ) kbs_insert(rm_set, i);
+
+    bcf_remove_allele_set(header, line, rm_set);
+    kbs_destroy(rm_set);
+}
+
+void bcf_remove_allele_set(const bcf_hdr_t *header, bcf1_t *line, const struct kbitset_t *rm_set)
 {
     int *map = (int*) calloc(line->n_allele, sizeof(int));
 
@@ -220,7 +234,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
     int nrm = 0, i,j;  // i: ori alleles, j: new alleles
     for (i=1, j=1; i<line->n_allele; i++)
     {
-        if ( rm_mask & 1<<i )
+        if ( kbs_exists(rm_set, i) )
         {
             // remove this allele
             line->d.allele[i] = NULL;
@@ -287,7 +301,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                 {
                     if ( !*se ) break;
                     while ( *se && *se!=',' ) se++;
-                    if ( rm_mask & 1<<(j+inc) )
+                    if ( kbs_exists(rm_set, j+inc) )
                     {
                         if ( *se ) se++;
                         ss = se;
@@ -310,7 +324,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                         if ( !*se ) break;
                         while ( *se && *se!=',' ) se++;
                         n++;
-                        if ( rm_mask & 1<<j || rm_mask & 1<<k )
+                        if ( kbs_exists(rm_set, j) || kbs_exists(rm_set, k) )
                         {
                             if ( *se ) se++;
                             ss = se;
@@ -361,7 +375,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                 for (j=0; j<ntop; j++) /* j:ori, k:new */ \
                 { \
                     if ( is_vector_end ) { memcpy(dat+k*size, dat+j*size, size); break; } \
-                    if ( rm_mask & 1<<(j+inc) ) continue; \
+                    if ( kbs_exists(rm_set, j+inc) ) continue; \
                     if ( j!=k ) memcpy(dat+k*size, dat+j*size, size); \
                     k++; \
                 } \
@@ -389,7 +403,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                     { \
                         l_ori++; \
                         if ( is_vector_end ) { memcpy(dat+l_new*size, dat+l_ori*size, size); break; } \
-                        if ( rm_mask & 1<<j || rm_mask & 1<<k ) continue; \
+                        if ( kbs_exists(rm_set, j) || kbs_exists(rm_set, k) ) continue; \
                         if ( l_ori!=l_new ) memcpy(dat+l_new*size, dat+l_ori*size, size); \
                         l_new++; \
                     } \
@@ -486,7 +500,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                     {
                         if ( ptr>=se || !*ptr) break;
                         while ( ptr<se && *ptr && *ptr!=',' ) ptr++;
-                        if ( rm_mask & 1<<(k_src+inc) )
+                        if ( kbs_exists(rm_set, k_src+inc) )
                         {
                             ss = ++ptr;
                             continue;
@@ -526,7 +540,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                             {
                                 if ( ptr>=se || !*ptr ) break;
                                 while ( ptr<se && *ptr && *ptr!=',' ) ptr++;
-                                if ( rm_mask & 1<<ia || rm_mask & 1<<ib )
+                                if ( kbs_exists(rm_set, ia) || kbs_exists(rm_set, ib) )
                                 {
                                     ss = ++ptr;
                                     continue;
@@ -545,7 +559,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                         {
                             if ( ptr>=se || !*ptr ) break;
                             while ( ptr<se && *ptr && *ptr!=',' ) ptr++;
-                            if ( rm_mask & 1<<k_src )
+                            if ( kbs_exists(rm_set, k_src) )
                             {
                                 ss = ++ptr;
                                 continue;
@@ -600,7 +614,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                     for (k_src=0; k_src<nori; k_src++) \
                     { \
                         if ( is_vector_end ) { memcpy(ptr_dst+k_dst, ptr_src+k_src, size); break; } \
-                        if ( rm_mask & 1<<(k_src+inc) ) continue; \
+                        if ( kbs_exists(rm_set, k_src+inc) ) continue; \
                         memcpy(ptr_dst+k_dst, ptr_src+k_src, size); \
                         k_dst++; \
                     } \
@@ -632,7 +646,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                     { \
                         for (k_src=0; k_src<nR_ori; k_src++) \
                         { \
-                            if ( rm_mask & 1<<k_src ) continue; \
+                            if ( kbs_exists(rm_set, k_src) ) continue; \
                             memcpy(ptr_dst+k_dst, ptr_src+k_src, size); \
                             k_dst++; \
                         } \
@@ -647,7 +661,7 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
                             { \
                                 k_src++; \
                                 if ( is_vector_end ) { memcpy(ptr_dst+k_dst, ptr_src+k_src, size); ia = nR_ori; break; }  \
-                                if ( rm_mask & 1<<ia || rm_mask & 1<<ib ) continue; \
+                                if ( kbs_exists(rm_set, ia) || kbs_exists(rm_set, ib) ) continue; \
                                 memcpy(ptr_dst+k_dst, ptr_src+k_src, size); \
                                 k_dst++; \
                             } \


### PR DESCRIPTION
* new bcf_remove_alleles_set function to the new kbitset.h api to indicated alleles
  to be removed. This avoids overflowing the old integer bitmask in bcf_remove_alleles
  when there are more than 31 alleles
* bcf_remove_alleles updated to use the new bcf_remove_alleles_set
* Fixes samtools/bcftools#319