### PR TITLE
Switch some bcf1_t members to 'unsigned int'

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -193,9 +193,9 @@ typedef struct {
     line must be formatted in vcf_format.
  */
 typedef struct {
-    int32_t rid;  // CHROM
-    int32_t pos;  // POS
-    int32_t rlen; // length of REF
+    uint32_t rid;  // CHROM
+    uint32_t pos;  // POS
+    uint32_t rlen; // length of REF
     float qual;   // QUAL
     uint32_t n_info:16, n_allele:16;
     uint32_t n_fmt:8, n_sample:24;


### PR DESCRIPTION
I think these variables could be unsigned, this came up while comparing with positions from another library.