### PR TITLE
Remove unnecessary bitmask

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -243,7 +243,7 @@ typedef struct {
  @param  i  The i-th position, 0-based
  @return    4-bit integer representing the base.
  */
-#define bam_seqi(s, i) ((s)[(i)>>1] >> ((~(i)&1)<<2) & 0xf)
+#define bam_seqi(s, i) ((s)[(i)>>1] >> (~(i)&1)<<2)
 
 /**************************
  *** Exported functions ***

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -243,7 +243,7 @@ typedef struct {
  @param  i  The i-th position, 0-based
  @return    4-bit integer representing the base.
  */
-#define bam_seqi(s, i) ((s)[(i)>>1] >> (~(i)&1)<<2)
+#define bam_seqi(s, i) ((s)[(i)>>1] >> ((~(i)&1)<<2))
 
 /**************************
  *** Exported functions ***


### PR DESCRIPTION
All integers return 0 or 1 from ((~i) &1). The bitmask never changes that value. It's not an expensive operation, but it is an unneeded one.