### PR TITLE
Correct dst and ndst size bug in bcf_get_format_values (vcf.c).

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -3350,10 +3350,10 @@ int bcf_get_format_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, v
         return n;
     }
 
-    // Make sure the buffer is big enough
+    // Make sure the buffer has the right size
     int nsmpl = bcf_hdr_nsamples(hdr);
     int size1 = type==BCF_HT_INT ? sizeof(int32_t) : sizeof(float);
-    if ( *ndst < fmt->n*nsmpl )
+    if ( *ndst != fmt->n*nsmpl )
     {
         *ndst = fmt->n*nsmpl;
         *dst  = realloc(*dst, *ndst*size1);


### PR DESCRIPTION
Make dst and ndst size adjustment in bcf_get_format_values also work, when the required size decreases from one parsed line to the next.
So far, dst buffer size and ndst were only upwards adjusted. If a buffer
size smaller than a previous one was needed, only the values at the
start of dst were updated, old values in later positions of dst were
carried over and ndst was kept at the larger value.