### PR TITLE
Fixed a CRAM encoding assertion failure on repeated templates.

### DIFF
--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -808,6 +808,11 @@ enum cram_fields {
 #define CRAM_FLAG_DETACHED             (1<<1)
 #define CRAM_FLAG_MATE_DOWNSTREAM      (1<<2)
 #define CRAM_FLAG_NO_SEQ               (1<<3)
+#define CRAM_FLAG_MASK                 ((1<<4)-1)
+
+/* Internal only */
+#define CRAM_FLAG_STATS_ADDED          (1<<30)
+
 
 #ifdef __cplusplus
 }

--- a/test/xx#repeated.sam
+++ b/test/xx#repeated.sam
@@ -1,0 +1,7 @@
+@SQ	SN:xx	LN:20
+S	67	xx	1	1	10M	=	11	20	AAAAAAAAAA	**********
+S	131	xx	11	1	10M	=	1	-20	TTTTTTTTTT	**********
+S	67	xx	1	1	10M	=	11	20	AAAAAAAAAA	**********
+S	131	xx	11	1	10M	=	1	-20	TTTTTTTTTT	**********
+S	67	xx	1	1	10M	=	11	20	AAAAAAAAAA	**********
+S	131	xx	11	1	10M	=	1	-20	TTTTTTTTTT	**********


### PR DESCRIPTION
Passes all the tests and doesn't seem to change output in normal behaviour, but PR for review if anyone wishes prior to merge.

If we have a complex template where more than 2 reads exist and we
have valid pnext/tlen fields between each successive pairs, the code
was erroneously removing the statistics for the tlen(etc) values
multiple times instead of just once.  Test data included.