### PR TITLE
Fix problems found by cppcheck listed in issue138

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -162,54 +162,36 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
     idx->end   = INT_MAX;
 
     idx_stack = calloc(++idx_stack_alloc, sizeof(*idx_stack));
+    if (!idx_stack) goto fail;
     idx_stack[idx_stack_ptr] = idx;
 
     if (!fn_idx) {
 	fn2 = hts_idx_getfn(fn, ".crai");
-	if (!fn2) {
-	    free(idx_stack);
-	    return -1;
-	}
+	if (!fn2) goto fail;
 	fn_idx = fn2;
     }
 
     if (!(fp = fopen(fn_idx, "r"))) {
 	perror(fn_idx);
-	free(idx_stack);
-	free(fn2);
-	return -1;
+        goto fail;
     }
 
     // Load the file into memory
     while ((len = fread(buf, 1, 65536, fp)) > 0)
 	kputsn(buf, len, &kstr);
     if (len < 0 || kstr.l < 2) {
-	if (kstr.s)
-	    free(kstr.s);
-	free(idx_stack);
-	free(fn2);
-	return -1;
+        fclose(fp);
+        goto fail;
     }
 
-    if (fclose(fp)) {
-	if (kstr.s)
-	    free(kstr.s);
-	free(idx_stack);
-	free(fn2);
-	return -1;
-    }
-	
+    if (fclose(fp)) goto fail;
 
     // Uncompress if required
     if (kstr.s[0] == 31 && (uc)kstr.s[1] == 139) {
 	size_t l;
 	char *s = zlib_mem_inflate(kstr.s, kstr.l, &l);
+	if (!s) goto fail;
 	free(kstr.s);
-	if (!s) {
-	    free(idx_stack);
-	    free(fn2);
-	    return -1;
-	}
 	kstr.s = s;
 	kstr.l = l;
 	kstr.m = l; // conservative estimate of the size allocated
@@ -220,42 +202,30 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
     // Parse it line at a time
     do {
 	/* 1.1 layout */
-	if (kget_int32(&kstr, &pos, &e.refid) == -1) {
-	    free(kstr.s); free(idx_stack); free(fn2); return -1;
-	}
-	if (kget_int32(&kstr, &pos, &e.start) == -1) {
-	    free(kstr.s); free(idx_stack); free(fn2); return -1;
-	}
-	if (kget_int32(&kstr, &pos, &e.end) == -1) {
-	    free(kstr.s); free(idx_stack); free(fn2); return -1;
-	}
-	if (kget_int64(&kstr, &pos, &e.offset) == -1) {
-	    free(kstr.s); free(idx_stack); free(fn2); return -1;
-	}
-	if (kget_int32(&kstr, &pos, &e.slice) == -1) {
-	    free(kstr.s); free(idx_stack); free(fn2); return -1;
-	}
-	if (kget_int32(&kstr, &pos, &e.len) == -1) {
-	    free(kstr.s); free(idx_stack); free(fn2); return -1;
-	}
+	if (kget_int32(&kstr, &pos, &e.refid) == -1) goto fail;
+	if (kget_int32(&kstr, &pos, &e.start) == -1) goto fail;
+	if (kget_int32(&kstr, &pos, &e.end) == -1) goto fail;
+	if (kget_int64(&kstr, &pos, &e.offset) == -1) goto fail;
+	if (kget_int32(&kstr, &pos, &e.slice) == -1) goto fail;
+	if (kget_int32(&kstr, &pos, &e.len) == -1) goto fail;
 
 	e.end += e.start-1;
 	//printf("%d/%d..%d\n", e.refid, e.start, e.end);
 
 	if (e.refid < -1) {
-	    free(kstr.s);
-	    free(idx_stack);
-	    free(fn2);
 	    fprintf(stderr, "Malformed index file, refid %d\n", e.refid);
-	    return -1;
+	    goto fail;
 	}
 
 	if (e.refid != idx->refid) {
 	    if (fd->index_sz < e.refid+2) {
+                cram_index *new_index;
 		size_t index_end = fd->index_sz * sizeof(*fd->index);
 		fd->index_sz = e.refid+2;
-		fd->index = realloc(fd->index,
+		new_index = realloc(fd->index,
 				    fd->index_sz * sizeof(*fd->index));
+                if (!new_index) goto fail;
+                fd->index = new_index;
 		memset(((char *)fd->index) + index_end, 0,
 		       fd->index_sz * sizeof(*fd->index) - index_end);
 	    }
@@ -274,8 +244,11 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
 
 	// Now contains, so append
 	if (idx->nslice+1 >= idx->nalloc) {
+            cram_index *new_e;
 	    idx->nalloc = idx->nalloc ? idx->nalloc*2 : 16;
-	    idx->e = realloc(idx->e, idx->nalloc * sizeof(*idx->e));
+	    new_e = realloc(idx->e, idx->nalloc * sizeof(*idx->e));
+            if (!new_e) goto fail;
+            idx->e = new_e;
 	}
 
 	e.nalloc = e.nslice = 0; e.e = NULL;
@@ -283,8 +256,11 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
 	idx = ep;
 
 	if (++idx_stack_ptr >= idx_stack_alloc) {
+            cram_index **new_stack;
 	    idx_stack_alloc *= 2;
-	    idx_stack = realloc(idx_stack, idx_stack_alloc*sizeof(*idx_stack));
+	    new_stack = realloc(idx_stack, idx_stack_alloc*sizeof(*idx_stack));
+            if (!new_stack) goto fail;
+            idx_stack = new_stack;
 	}
 	idx_stack[idx_stack_ptr] = idx;
 
@@ -300,6 +276,12 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
     // dump_index(fd);
 
     return 0;
+
+ fail:
+    free(idx_stack);
+    free(kstr.s);
+    free(fn2);
+    return -1;
 }
 
 static void cram_index_free_recurse(cram_index *e) {

--- a/cram/pooled_alloc.c
+++ b/cram/pooled_alloc.c
@@ -183,6 +183,8 @@ int main(void) {
 	pool_free(p, item);
     }
 
+    free(items);
+
     return 0;
 }
 #endif

--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -806,6 +806,7 @@ int main(int argc, char **argv) {
     if (optind < argc) {
 	if (!(outfp = fopen(argv[optind], "wb"))) {
 	    perror(argv[optind]);
+            fclose(infp);
 	    return 1;
 	}
 	optind++;
@@ -856,6 +857,8 @@ int main(int argc, char **argv) {
 	}
     }
 
+    if (infp  != stdin)  fclose(infp);
+    if (outfp != stdout) fclose(outfp);
     gettimeofday(&tv2, NULL);
 
     fprintf(stderr, "Took %ld microseconds, %5.1f MB/s\n",

--- a/cram/thread_pool.c
+++ b/cram/thread_pool.c
@@ -285,11 +285,10 @@ void t_results_queue_destroy(t_results_queue *q) {
     pthread_cond_destroy(&q->result_avail_c);
 
     memset(q, 0xbb, sizeof(*q));
-    free(q);
-
 #ifdef DEBUG
     fprintf(stderr, "Destroyed results queue %p\n", q);
 #endif
+    free(q);
 }
 
 /* ----------------------------------------------------------------------------
@@ -671,11 +670,10 @@ void t_pool_destroy(t_pool *p, int kill) {
 	free(p->t_stack);
 
     free(p->t);
-    free(p);
-
 #ifdef DEBUG
     fprintf(stderr, "Destroyed pool %p\n", p);
 #endif
+    free(p);
 }
 
 

--- a/cram/vlen.c
+++ b/cram/vlen.c
@@ -106,9 +106,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int flen(char *fmt, ...)
 {
     va_list args;
+    int res;
 
     va_start(args, fmt);
-    return vflen(fmt, args);
+    res = vflen(fmt, args);
+    va_end(args);
+    return res;
 }
 
 int vflen(char *fmt, va_list ap)
@@ -315,7 +318,9 @@ int vflen(char *fmt, va_list ap)
 	}
     }
 
+#if defined(HAVE_VA_COPY)
     va_end(ap);
+#endif
 
     return len+1; /* one for the null character */
 }

--- a/cram/zfio.c
+++ b/cram/zfio.c
@@ -154,7 +154,7 @@ zfp *zfopen(const char *path, const char *mode) {
 	printf("Failed on %s\n", path);
     } else {
 	sprintf(path2, "gzip > %.*s", 1000, path);
-	if (NULL != (zf->fp = popen(path2, "w")))
+	if (NULL != (zf->fp = popen(path2, "w"))) {
 	    return zf;
 	}
 	

--- a/vcf.c
+++ b/vcf.c
@@ -803,6 +803,7 @@ bcf_hdr_t *bcf_hdr_read(htsFile *hfp)
     if ( bgzf_read(fp, magic, 5)<0 )
     {
         fprintf(stderr,"[%s:%d %s] Failed to read the header (reading BCF in text mode?)\n", __FILE__,__LINE__,__FUNCTION__);
+        bcf_hdr_destroy(h);
         return NULL;
     }
     if (strncmp((char*)magic, "BCF\2\2", 5) != 0)
@@ -1288,6 +1289,7 @@ bcf_hdr_t *vcf_hdr_read(htsFile *fp)
     if ( !txt.s )
     {
         fprintf(stderr,"[%s:%d %s] Could not read the header\n", __FILE__,__LINE__,__FUNCTION__);
+        bcf_hdr_destroy(h);
         return NULL;
     }
     bcf_hdr_parse(h, txt.s);


### PR DESCRIPTION
Fix various problems, mostly memory leaks when cleaning up after errors.
Tidy up inconsistent use of va_end in a couple of cram functions.
Add some missing error checks.

Fixes #138
