### PR TITLE
allow bcf_index_build2 to index both bcf and vcf

### DIFF
--- a/htslib/tbx.h
+++ b/htslib/tbx.h
@@ -66,6 +66,7 @@ extern tbx_conf_t tbx_conf_gff, tbx_conf_bed, tbx_conf_psltbl, tbx_conf_sam, tbx
     BGZF *hts_get_bgzfp(htsFile *fp);
     int tbx_readrec(BGZF *fp, void *tbxv, void *sv, int *tid, int *beg, int *end);
 
+    tbx_t *tbx_index(BGZF *fp, int min_shift, const tbx_conf_t *conf);
     int tbx_index_build(const char *fn, int min_shift, const tbx_conf_t *conf);
     int tbx_index_build2(const char *fn, const char *fnidx, int min_shift, const tbx_conf_t *conf);
     tbx_t *tbx_index_load(const char *fn);

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -765,7 +765,34 @@ typedef struct {
     #define bcf_index_seqnames(idx, hdr, nptr) hts_idx_seqnames((idx),(nptr),(hts_id2name_f)(bcf_hdr_id2name),(hdr))
 
     hts_idx_t *bcf_index_load2(const char *fn, const char *fnidx);
+
+    /**
+     *  bcf_index_build() - Generate and save an index file
+     *  @fn:         Input VCF/BCF filename
+     *  @min_shift:  Positive to generate CSI, or 0 to generate TBI
+     *
+     *  Returns 0 if successful, or negative if an error occurred.
+     *
+     *  List of error codes:
+     *      -1 .. indexing failed
+     *      -2 .. opening @fn failed
+     *      -3 .. format not indexable
+     */
     int bcf_index_build(const char *fn, int min_shift);
+
+    /**
+     *  bcf_index_build2() - Generate and save an index to a specific file
+     *  @fn:         Input VCF/BCF filename
+     *  @fnidx:      Output filename, or NULL to add .csi/.tbi to @fn
+     *  @min_shift:  Positive to generate CSI, or 0 to generate TBI
+     *
+     *  Returns 0 if successful, or negative if an error occurred.
+     *
+     *  List of error codes:
+     *      -1 .. indexing failed
+     *      -2 .. opening @fn failed
+     *      -3 .. format not indexable
+     */
     int bcf_index_build2(const char *fn, const char *fnidx, int min_shift);
 
 /*******************


### PR DESCRIPTION
This is to allow VCF/BCF indexing via streamed input and is a
pre-requisite for adressing samtools/bcftools#373

* distinguish negative return values as in sam_index_build2()
* expose tbx_index() via tbx.h
* add documentation for bcf_index_build() and bcf_index_build2()