### PR TITLE
Add prefix based on libdir in pkg-config

### DIFF
--- a/htslib.pc.in
+++ b/htslib.pc.in
@@ -1,5 +1,6 @@
 includedir=@includedir@
 libdir=@libdir@
+prefix: ${libdir}
 
 Name: htslib
 Description: C library for high-throughput sequencing data formats


### PR DESCRIPTION
For easy referencing from Makefiles, for example:

```
HTS_LIB=`pkg-config --variable=prefix htslib`
```

Instead of going for hardcoded, relative and manually pre-downloaded libraries:

https://github.com/ryanlayer/gqt/blob/master/src/Makefile#L3

@ryanlayer