### PR TITLE
Support for quoted contig names

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -289,6 +289,7 @@ bcf_hrec_t *bcf_hdr_parse_line(const bcf_hdr_t *h, const char *line, int *len)
     // structured line, e.g.
     // ##INFO=<ID=PV1,Number=1,Type=Float,Description="P-value for baseQ bias">
     // ##PEDIGREE=<Name_0=G0-ID,Name_1=G1-ID,Name_3=GN-ID>
+    // ##contig=<ID="CrazyContigName,1",length=249250621>
     int nopen = 1;
     while ( *q && *q!='\n' && nopen )
     {
@@ -386,7 +387,16 @@ int bcf_hdr_register_hrec(bcf_hdr_t *hdr, bcf_hrec_t *hrec)
 
         i = bcf_hrec_find_key(hrec,"ID");
         if ( i<0 ) return 0;
-        str = strdup(hrec->vals[i]);
+        if ( hrec->vals[i][0]=='"' )
+        {
+            int len = strlen(hrec->vals[i]);
+            assert( hrec->vals[i][len-1]=='"' );
+            hrec->vals[i][len-1] = 0;
+            str = strdup(hrec->vals[i]+1);
+            hrec->vals[i][len-1] = '"';
+        }
+        else
+            str = strdup(hrec->vals[i]);
 
         // Register in the dictionary
         vdict_t *d = (vdict_t*)hdr->dict[BCF_DT_CTG];
@@ -1298,18 +1308,24 @@ bcf_hdr_t *vcf_hdr_read(htsFile *fp)
     {
         int i, n, need_sync = 0;
         const char **names = tbx_seqnames(idx, &n);
+        kstring_t tmp = {0,0,0};
         for (i=0; i<n; i++)
         {
             bcf_hrec_t *hrec = bcf_hdr_get_hrec(h, BCF_HL_CTG, "ID", (char*) names[i], NULL);
             if ( hrec ) continue;
+            tmp.l = 0;
+            kputc('"',&tmp);
+            kputs(names[i],&tmp);
+            kputc('"',&tmp);
             hrec = (bcf_hrec_t*) calloc(1,sizeof(bcf_hrec_t));
             hrec->key = strdup("contig");
             bcf_hrec_add_key(hrec, "ID", strlen("ID"));
-            bcf_hrec_set_val(hrec, hrec->nkeys-1, (char*) names[i], strlen(names[i]), 0);
+            bcf_hrec_set_val(hrec, hrec->nkeys-1, tmp.s, tmp.l, 0);
             bcf_hdr_add_hrec(h, hrec);
             need_sync = 1;
         }
         free(names);
+        free(tmp.s);
         tbx_destroy(idx);
         if ( need_sync )
             bcf_hdr_sync(h);
@@ -1813,7 +1829,7 @@ int vcf_parse(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v)
                 if (hts_verbose >= 2) fprintf(stderr, "[W::%s] contig '%s' is not defined in the header. (Quick workaround: index the file with tabix.)\n", __func__, p);
                 kstring_t tmp = {0,0,0};
                 int l;
-                ksprintf(&tmp, "##contig=<ID=%s>", p);
+                ksprintf(&tmp, "##contig=<ID=\"%s\">", p);
                 bcf_hrec_t *hrec = bcf_hdr_parse_line(h,tmp.s,&l);
                 free(tmp.s);
                 if ( bcf_hdr_add_hrec((bcf_hdr_t*)h, hrec) ) bcf_hdr_sync((bcf_hdr_t*)h);


### PR DESCRIPTION
Support for quoted contig names, such as `##contig=<ID="CrazyContigName,1">`
- fixes a parsing problem when comma in the contig name (closes samtools/bcftools#266)
- when injecting contigs in the header from the index, use quoted contig IDs
- some bcftools test output files will need to be updated if this is pulled in
- there are places in at least bcftools/vcfconvert.c and samtools/bam_plcmd.c
  where contig header lines are created. These should also be changed to have quoted IDs
- still and issue is what happens if there is a `"` in the contig name
