### PR TITLE
Avoid unnecessary warning on unknown sort order

### DIFF
--- a/cram/sam_header.c
+++ b/cram/sam_header.c
@@ -774,7 +774,7 @@ static enum sam_sort_order sam_hdr_parse_sort_order(SAM_hdr *hdr) {
 		    so = ORDER_NAME;
 		else if (strcmp(tag->str+3, "coordinate") == 0)
 		    so = ORDER_COORD;
-		else
+		else if (strcmp(tag->str+3, "unknown") != 0)
 		    fprintf(stderr, "Unknown sort order field: %s\n",
 			    tag->str+3);
 	    }


### PR DESCRIPTION
A sort order of "unknown" is not an unknown sort order, it's a perfectly reasonable sort order defined in the BAM specification. This change will avoid unnecessary warnings in our log files when using samtools.