### PR TITLE
If no CC value set then use GCC, otherwise take the value from the env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-CC     = gcc
-AR     = ar
-RANLIB = ranlib
+CC     ?= gcc
+AR     ?= ar
+RANLIB ?= ranlib
 
 CPPFLAGS =
 # TODO: probably update cram code to make it compile cleanly with -Wc++-compat


### PR DESCRIPTION
Currently the Makefile sets CC to GCC even if a CC is set by the user.
This is now changed to set GCC if no CC is present in the user environment.
I think this was the intended behavior as the .travis.yml file wants to test compilation using both gcc and clang.

The same change is there for the AR and RANLIB setting.