### PR TITLE
Removed use of CRAM "CORE" block while encoding.

### DIFF
--- a/cram/cram_stats.c
+++ b/cram/cram_stats.c
@@ -116,25 +116,6 @@ void cram_stats_dump(cram_stats *st) {
     }
 }
 
-#if 1
-/* Returns the number of bits set in val; it the highest bit used */
-static int nbits(int v) {
-    static const int MultiplyDeBruijnBitPosition[32] = {
-	1, 10, 2, 11, 14, 22, 3, 30, 12, 15, 17, 19, 23, 26, 4, 31,
-	9, 13, 21, 29, 16, 18, 25, 8, 20, 28, 24, 7, 27, 6, 5, 32
-    };
-
-    v |= v >> 1; // first up to set all bits 1 after the first 1 */
-    v |= v >> 2;
-    v |= v >> 4;
-    v |= v >> 8;
-    v |= v >> 16;
-
-    // DeBruijn magic to find top bit
-    return MultiplyDeBruijnBitPosition[(uint32_t)(v * 0x07C4ACDDU) >> 27];
-}
-#endif
-
 /*
  * Computes entropy from integer frequencies for various encoding methods and
  * picks the best encoding.
@@ -145,10 +126,8 @@ static int nbits(int v) {
  * Returns the best codec to use.
  */
 enum cram_encoding cram_stats_encoding(cram_fd *fd, cram_stats *st) {
-    enum cram_encoding best_encoding = E_NULL;
-    int best_size = INT_MAX, bits;
-    int nvals, i, ntot = 0, max_val = 0, min_val = INT_MAX, k;
-    int *vals = NULL, *freqs = NULL, vals_alloc = 0, *codes;
+    int nvals, i, ntot = 0, max_val = 0, min_val = INT_MAX;
+    int *vals = NULL, *freqs = NULL, vals_alloc = 0;
 
     //cram_stats_dump(st);
 
@@ -201,244 +180,14 @@ enum cram_encoding cram_stats_encoding(cram_fd *fd, cram_stats *st) {
     st->nvals = nvals;
     assert(ntot == st->nsamp);
 
-    if (nvals <= 1) {
-	free(vals);
-	free(freqs);
-	return E_HUFFMAN;
-    }
-
-    if (fd->verbose > 1)
-	fprintf(stderr, "Range = %d..%d, nvals=%d, ntot=%d\n",
-		min_val, max_val, nvals, ntot);
-
-    /* Theoretical entropy */
-//    if (fd->verbose > 1) {
-//	double dbits = 0;
-//	for (i = 0; i < nvals; i++) {
-//	    dbits += freqs[i] * log((double)freqs[i]/ntot);
-//	}
-//	dbits /= -log(2);
-//	if (fd->verbose > 1)
-//	    fprintf(stderr, "Entropy = %f\n", dbits);
-//    }
-
-    if (nvals > 1 && ntot > 256) {
-#if 0
-	/*
-	 * CRUDE huffman estimator. Round to closest and round up from 0
-	 * to 1 bit.
-	 *
-	 * With and without ITF8 incase we have a few discrete values but with
-	 * large magnitude.
-	 *
-	 * Note rans0/arith0 and Z_HUFFMAN_ONLY vs internal huffman can be
-	 * compared in this way, but order-1 (eg rans1) or maybe LZ77 modes
-	 * may detect the correlation of high bytes to low bytes in multi-
-	 * byte values. So this predictor breaks down.
-	 */
-	double dbits = 0;  // entropy + ~huffman
-	double dbitsH = 0;
-	double dbitsE = 0; // external entropy + ~huffman
-	double dbitsEH = 0;
-	int F[256] = {0}, n = 0;
-	double e = 0; // accumulated error bits
-	for (i = 0; i < nvals; i++) {
-	    double x; int X;
-	    unsigned int v = vals[i];
-
-	    //Better encoding would cope with sign.
-	    //v = ABS(vals[i])*2+(vals[i]<0);
-
-	    if (!(v & ~0x7f)) {
-		F[v]             += freqs[i], n+=freqs[i];
-	    } else if (!(v & ~0x3fff)) {
-		F[(v>>8) |0x80] += freqs[i];
-		F[ v     &0xff] += freqs[i], n+=2*freqs[i];
-	    } else if (!(v & ~0x1fffff)) {
-		F[(v>>16)|0xc0] += freqs[i];
-		F[(v>>8 )&0xff] += freqs[i];
-		F[ v     &0xff] += freqs[i], n+=3*freqs[i];
-	    } else if (!(v & ~0x0fffffff)) {
-		F[(v>>24)|0xe0] += freqs[i];
-		F[(v>>16)&0xff] += freqs[i];
-		F[(v>>8 )&0xff] += freqs[i];
-		F[ v     &0xff] += freqs[i], n+=4*freqs[i];
-	    } else {
-		F[(v>>28)|0xf0] += freqs[i];
-		F[(v>>20)&0xff] += freqs[i];
-		F[(v>>12)&0xff] += freqs[i];
-		F[(v>>4 )&0xff] += freqs[i];
-		F[ v     &0x0f] += freqs[i], n+=5*freqs[i];
-	    }
-
-	    x = -log((double)freqs[i]/ntot)/.69314718055994530941;
-	    X = x+0.5;
-	    if ((int)(x+((double)e/freqs[i])+.5)>X) {
-		X++;
-	    } else if ((int)(x+((double)e/freqs[i])+.5)<X) {
-		X--;
-	    }
-	    e-=freqs[i]*(X-x);
-	    X += (X==0);
-
-	    //fprintf(stderr, "Val %d = %d x %d (ent %f, %d) e %f\n", i, v, freqs[i], x, X, e);
-
-	    dbits  += freqs[i] * x;
-	    dbitsH += freqs[i] * X;
-	}
-
-	for (i = 0; i < 256; i++) {
-	    if (F[i]) {
-		double x = -log((double)F[i]/n)/.69314718055994530941;
-		int X = x+0.5;
-		X += (X==0);
-		dbitsE  += F[i] * x;
-		dbitsEH += F[i] * X;
-
-		//fprintf(stderr, "Val %d = %d x %d (e %f, %d)\n", i, i, F[i], x, X);
-	    }
-	}
-
-	//fprintf(stderr, "CORE Entropy = %f, %f\n", dbits/8, dbitsH/8);
-	//fprintf(stderr, "Ext. Entropy = %f, %f\n", dbitsE/8, dbitsEH/8);
-
-	if (dbitsE < 1000 || dbitsE / dbits > 1.1) {
-	    //fprintf(stderr, "=> %d < 200 ? E_HUFFMAN : E_BETA\n", nvals);
-	    free(vals); free(freqs);
-	    return nvals < 200 ? E_HUFFMAN : E_BETA;
-	}
-#endif
-	free(vals); free(freqs);
-	return E_EXTERNAL;
-    }
-
-    /*
-     * Avoid complex stats for now, just do heuristic of HUFFMAN for small
-     * alphabets and BETA for anything large.
-     */
-    free(vals); free(freqs);
-    return nvals < 200 ? E_HUFFMAN : E_BETA;
-    //return E_HUFFMAN;
-    //return E_EXTERNAL;
-
-
-    /* We only support huffman now anyway... */
-    //free(vals); free(freqs); return E_HUFFMAN;
-
-    /* Beta */
-    bits = nbits(max_val - min_val) * ntot;
-    if (fd->verbose > 1)
-	fprintf(stderr, "BETA    = %d\n", bits);
-    if (best_size > bits)
-	best_size = bits, best_encoding = E_BETA;
-
-#if 0
-    /* Unary */
-    if (min_val >= 0) {
-	for (bits = i = 0; i < nvals; i++)
-	    bits += freqs[i]*(vals[i]+1);
-	if (fd->verbose > 1)
-	    fprintf(stderr, "UNARY   = %d\n", bits);
-	if (best_size > bits)
-	    best_size = bits, best_encoding = E_NULL; //E_UNARY;
-    }
-
-    /* Gamma */
-    for (bits = i = 0; i < nvals; i++)
-	bits += ((nbits(vals[i]-min_val+1)-1) + nbits(vals[i]-min_val+1)) * freqs[i];
-    if (fd->verbose > 1)
-	fprintf(stderr, "GAMMA   = %d\n", bits);
-    if (best_size > bits)
-	best_size = bits, best_encoding = E_GAMMA;
-
-    /* Subexponential */
-    for (k = 0; k < 10; k++) {
-	for (bits = i = 0; i < nvals; i++) {
-	    if (vals[i]-min_val < (1<<k))
-		bits += (1 + k)*freqs[i];
-	    else
-		bits += (nbits(vals[i]-min_val)*2-k)*freqs[i];
-	}
-
-	if (fd->verbose > 1)
-	    fprintf(stderr, "SUBEXP%d = %d\n", k, bits);
-	if (best_size > bits)
-	    best_size = bits, best_encoding = E_SUBEXP;
-    }
-#endif
-
-    /* byte array len */
-
-    /* byte array stop */
-
-    /* External? Guesswork! */
-
-    /* Huffman */
-//    qsort(freqs, nvals, sizeof(freqs[0]), sort_freqs);
-//    for (i = 0; i < nvals; i++) {
-//	fprintf(stderr, "%d = %d\n", i, freqs[i]);
-//	vals[i] = 0;
-//    }
-
-    /* Grow freqs to 2*freqs, to store sums */
-    /* Vals holds link data */
-    freqs = realloc(freqs, 2*nvals*sizeof(*freqs));
-    codes = calloc(2*nvals, sizeof(*codes));
-    if (!freqs || !codes)
-	return E_HUFFMAN; // Cannot do much else atm
-
-    /* Inefficient, use pointers to form chain so we can insert and maintain
-     * a sorted list? This is currently O(nvals^2) complexity.
-     */
-    for (;;) {
-	int low1 = INT_MAX, low2 = INT_MAX;
-	int ind1 = 0, ind2 = 0;
-	for (i = 0; i < nvals; i++) {
-	    if (freqs[i] < 0)
-		continue;
-	    if (low1 > freqs[i]) 
-		low2 = low1, ind2 = ind1, low1 = freqs[i], ind1 = i;
-	    else if (low2 > freqs[i])
-		low2 = freqs[i], ind2 = i;
-	}
-	if (low2 == INT_MAX)
-	    break;
-
-	//fprintf(stderr, "Merge ind %d (%d), %d (%d) = %d+%d, => %d=%d\n",
-	//	ind1, vals[ind1], ind2, vals[ind2], low1, low2,
-	//	nvals, low1+low2);
-
-	freqs[nvals] = low1 + low2;
-	codes[ind1] = nvals;
-	codes[ind2] = nvals;
-	freqs[ind1] *= -1;
-	freqs[ind2] *= -1;
-	nvals++;
-    }
-    nvals = nvals/2+1;
-
-    for (i = 0; i < nvals; i++) {
-	int code_len = 0;
-	for (k = codes[i]; k; k = codes[k])
-	    code_len++;
-	codes[i] = code_len;
-	freqs[i] *= -1;
-	//fprintf(stderr, "%d / %d => %d\n", vals[i], freqs[i], codes[i]);
-    }
-
-    for (bits = i = 0; i < nvals; i++) {
-	bits += freqs[i] * codes[i];
-    }
-    if (fd->verbose > 1)
-	fprintf(stderr, "HUFFMAN = %d\n", bits);
-    if (best_size >= bits)
-	best_size = bits, best_encoding = E_HUFFMAN;
-    free(codes);
-
     free(vals);
     free(freqs);
 
-    return best_encoding;
+    /*
+     * Simple policy that everything is external unless it can be
+     * encoded using zero bits as a unary item huffman table.
+     */
+    return nvals <= 1 ? E_HUFFMAN : E_EXTERNAL;
 }
 
 void cram_stats_free(cram_stats *st) {

--- a/hfile.c
+++ b/hfile.c
@@ -577,8 +577,6 @@ static hFILE *hopen_mem(const char *data, const char *mode)
  * Plugin and hopen() backend dispatcher *
  *****************************************/
 
-#include <ctype.h>
-
 #include "hts_internal.h"
 #include "htslib/khash.h"
 
@@ -717,8 +715,8 @@ static const struct hFILE_scheme_handler *find_scheme_handler(const char *s)
     int i;
 
     for (i = 0; i < sizeof scheme; i++)
-        if (isalnum(s[i]) || s[i] == '+' || s[i] == '-' || s[i] == '.')
-            scheme[i] = tolower(s[i]);
+        if (isalnum_c(s[i]) || s[i] == '+' || s[i] == '-' || s[i] == '.')
+            scheme[i] = tolower_c(s[i]);
         else if (s[i] == ':') break;
         else return NULL;
 

--- a/hts.c
+++ b/hts.c
@@ -26,7 +26,6 @@ DEALINGS IN THE SOFTWARE.  */
 #include <config.h>
 
 #include <zlib.h>
-#include <ctype.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -1848,24 +1847,24 @@ long long hts_parse_decimal(const char *str, char **strend, int flags)
     char sign = '+', esign = '+';
     const char *s;
 
-    while (isspace(*str)) str++;
+    while (isspace_c(*str)) str++;
     s = str;
 
     if (*s == '+' || *s == '-') sign = *s++;
     while (*s)
-        if (isdigit(*s)) n = push_digit(n, *s++);
+        if (isdigit_c(*s)) n = push_digit(n, *s++);
         else if (*s == ',' && (flags & HTS_PARSE_THOUSANDS_SEP)) s++;
         else break;
 
     if (*s == '.') {
         s++;
-        while (isdigit(*s)) decimals++, n = push_digit(n, *s++);
+        while (isdigit_c(*s)) decimals++, n = push_digit(n, *s++);
     }
 
     if (*s == 'E' || *s == 'e') {
         s++;
         if (*s == '+' || *s == '-') esign = *s++;
-        while (isdigit(*s)) e = push_digit(e, *s++);
+        while (isdigit_c(*s)) e = push_digit(e, *s++);
         if (esign == '-') e = -e;
     }
 

--- a/sam.c
+++ b/sam.c
@@ -29,7 +29,6 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-#include <ctype.h>
 #include <zlib.h>
 #include "htslib/sam.h"
 #include "htslib/bgzf.h"
@@ -888,7 +887,7 @@ int sam_parse1(kstring_t *s, bam_hdr_t *h, bam1_t *b)
         uint32_t *cigar;
         size_t n_cigar = 0;
         for (q = p; *p && *p != '\t'; ++p)
-            if (!isdigit(*p)) ++n_cigar;
+            if (!isdigit_c(*p)) ++n_cigar;
         if (*p++ != '\t') goto err_ret;
         _parse_err(n_cigar == 0, "no CIGAR operations");
         _parse_err(n_cigar >= 65536, "too many CIGAR operations");


### PR DESCRIPTION
Previously the cram_stats_encoding() function was written to
roughly minimise the storage requirements.  As such it used HUFFMAN or
BETA codec for data low-volume series and EXTERNAL for larger ones.
This avoided any block overheads.  (Actually there was a lot of
additional commented-out code to deal with subexponential codec too.)

However this comes at the price that (more or less) any field may
potentially be mixed with with any other field in the CORE block.
Checking a random file I see this is so:

$ cram_dump /tmp/_2.cram | egrep 'HUFFMAN|BETA'|less
         RL =>          HUFFMAN {1, 100, 1, 0}
         BA =>          HUFFMAN {4, 65, 67, 71, 84, 4, 1, 2, 3, 3}
         DL =>          HUFFMAN {4, 1, 2, 3, 4, 4, 1, 2, 3, 3}
         RG =>          HUFFMAN {1, 0, 1, 0}
         RI =>          HUFFMAN {1, 0, 1, 0}
         ...

Huffman 1,100, 1,0 is fine (1 symbol [100] with 1 bit-length [0];
so no storage in CORE), but DL and BA series here both require storage
and are interleaved into CORE.  Now BA and DL will be stored with type
EXTERNAL.

The change in file size is expected to be minimal; around 0.01% in
tests and cpu overhead is equally tiny.

The advantage is that is simplifies partial decoding.  Although the
cram_dependent_data_series() works out which data series are
co-locating in the same block, it becomes more efficient to do
partial decodes as fewer items share a common block.  It also becomes
much easier to filter by block, dropping specific data series
completely while retaining others.