### PR TITLE
Catch negative IDX tags; treat like other IDX parse failures.

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -418,7 +418,7 @@ int bcf_hdr_register_hrec(bcf_hdr_t *hdr, bcf_hrec_t *hrec)
         {
             char *tmp = hrec->vals[idx];
             idx = strtol(hrec->vals[idx], &tmp, 10);
-            if ( *tmp )
+            if ( *tmp || idx < 0 )
             {
                 fprintf(stderr,"[%s:%d %s] Error parsing the IDX tag, skipping.\n", __FILE__,__LINE__,__FUNCTION__);
                 return 0;
@@ -451,7 +451,7 @@ int bcf_hdr_register_hrec(bcf_hdr_t *hdr, bcf_hrec_t *hrec)
         {
             char *tmp = hrec->vals[i];
             idx = strtol(hrec->vals[i], &tmp, 10);
-            if ( *tmp )
+            if ( *tmp || idx < 0 )
             {
                 fprintf(stderr,"[%s:%d %s] Error parsing the IDX tag, skipping.\n", __FILE__,__LINE__,__FUNCTION__);
                 return 0;


### PR DESCRIPTION
Fixes an invalid read error triggered by negative IDX values.  Error found by AFL after it had been left to run for 33 days.  bcf_hdr_set_idx tries to use the negative value in an array look-up, leading to undefined behaviour.

Currently IDX parse errors are handled by printing a warning and then just ignoring the IDX tag.  This makes the same happen for negative IDX values.  Whether or not we should actually fail on bad IDX tags is left as a subject for discussion.