### PR TITLE
Correct constant passed to bcf_hdr_id2int in bcf_hdr_check_sanity.

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -601,7 +601,7 @@ void bcf_hdr_check_sanity(bcf_hdr_t *hdr)
     }
     if ( !GL_warned )
     {
-        int id = bcf_hdr_id2int(hdr, BCF_HL_FMT, "GL");
+        int id = bcf_hdr_id2int(hdr, BCF_DT_ID, "GL");
         if ( bcf_hdr_idinfo_exists(hdr,BCF_HL_FMT,id) && bcf_hdr_id2length(hdr,BCF_HL_FMT,id)!=BCF_VL_G )
         {
             if (hts_verbose >= 2) fprintf(stderr,"[W::%s] GL should be declared as Number=G\n", __func__);


### PR DESCRIPTION
Change BCF_HL_FMT to BCF_DT_ID when looking up GL header id.
The GL check can't have worked correctly, and using the wrong dictionary
caused odd things to happen if you used GL as a sample name.