### PR TITLE
Add bcf_hdr_format(), handle BCF headers larger than 2GiB

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -421,11 +421,20 @@ typedef struct {
     /** Read VCF header from a file and update the header */
     int bcf_hdr_set(bcf_hdr_t *hdr, const char *fname);
 
+    /// Appends formatted header text to _str_.
+    /** If _is_bcf_ is zero, `IDX` fields are discarded.
+     *  @return 0 if successful, or negative if an error occurred
+     *  @since 1.4
+     */
+    int bcf_hdr_format(const bcf_hdr_t *hdr, int is_bcf, kstring_t *str);
+
     /** Returns formatted header (newly allocated string) and its length,
      *  excluding the terminating \0. If is_bcf parameter is unset, IDX
      *  fields are discarded.
+     *  @deprecated Use bcf_hdr_format() instead as it can handle huge headers.
      */
-    char *bcf_hdr_fmt_text(const bcf_hdr_t *hdr, int is_bcf, int *len);
+    char *bcf_hdr_fmt_text(const bcf_hdr_t *hdr, int is_bcf, int *len)
+        HTS_DEPRECATED("use bcf_hdr_format() instead");
 
     /** Append new VCF header line, returns 0 on success */
     int bcf_hdr_append(bcf_hdr_t *h, const char *line);

--- a/vcf.c
+++ b/vcf.c
@@ -877,16 +877,17 @@ int bcf_hdr_write(htsFile *hfp, bcf_hdr_t *h)
     if (hfp->format.format == vcf || hfp->format.format == text_format)
         return vcf_hdr_write(hfp, h);
 
-    int hlen;
-    char *htxt = bcf_hdr_fmt_text(h, 1, &hlen);
-    hlen++; // include the \0 byte
+    kstring_t htxt = {0,0,0};
+    bcf_hdr_format(h, 1, &htxt);
+    kputc('\0', &htxt); // include the \0 byte
 
     BGZF *fp = hfp->fp.bgzf;
     if ( bgzf_write(fp, "BCF\2\2", 5) !=5 ) return -1;
+    uint32_t hlen = htxt.l;
     if ( bgzf_write(fp, &hlen, 4) !=4 ) return -1;
-    if ( bgzf_write(fp, htxt, hlen) != hlen ) return -1;
+    if ( bgzf_write(fp, htxt.s, htxt.l) != htxt.l ) return -1;
 
-    free(htxt);
+    free(htxt.s);
     return 0;
 }
 
@@ -1412,22 +1413,29 @@ void bcf_hrec_format(const bcf_hrec_t *hrec, kstring_t *str)
 {
     _bcf_hrec_format(hrec,0,str);
 }
-char *bcf_hdr_fmt_text(const bcf_hdr_t *hdr, int is_bcf, int *len)
+
+int bcf_hdr_format(const bcf_hdr_t *hdr, int is_bcf, kstring_t *str)
 {
     int i;
-    kstring_t txt = {0,0,0};
     for (i=0; i<hdr->nhrec; i++)
-        _bcf_hrec_format(hdr->hrec[i], is_bcf, &txt);
+        _bcf_hrec_format(hdr->hrec[i], is_bcf, str);
 
-    ksprintf(&txt,"#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO");
+    ksprintf(str, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO");
     if ( bcf_hdr_nsamples(hdr) )
     {
-        ksprintf(&txt,"\tFORMAT");
+        ksprintf(str, "\tFORMAT");
         for (i=0; i<bcf_hdr_nsamples(hdr); i++)
-            ksprintf(&txt,"\t%s", hdr->samples[i]);
+            ksprintf(str, "\t%s", hdr->samples[i]);
     }
-    ksprintf(&txt,"\n");
+    ksprintf(str, "\n");
 
+    return 0;
+}
+
+char *bcf_hdr_fmt_text(const bcf_hdr_t *hdr, int is_bcf, int *len)
+{
+    kstring_t txt = {0,0,0};
+    bcf_hdr_format(hdr, is_bcf, &txt);
     if ( len ) *len = txt.l;
     return txt.s;
 }
@@ -1454,15 +1462,15 @@ const char **bcf_hdr_seqnames(const bcf_hdr_t *h, int *n)
 
 int vcf_hdr_write(htsFile *fp, const bcf_hdr_t *h)
 {
-    int hlen;
-    char *htxt = bcf_hdr_fmt_text(h, 0, &hlen);
-    while (hlen && htxt[hlen-1] == 0) --hlen; // kill trailing zeros
+    kstring_t htxt = {0,0,0};
+    bcf_hdr_format(h, 0, &htxt);
+    while (htxt.l && htxt.s[htxt.l-1] == '\0') --htxt.l; // kill trailing zeros
     int ret;
     if ( fp->format.compression!=no_compression )
-        ret = bgzf_write(fp->fp.bgzf, htxt, hlen);
+        ret = bgzf_write(fp->fp.bgzf, htxt.s, htxt.l);
     else
-        ret = hwrite(fp->fp.hfile, htxt, hlen);
-    free(htxt);
+        ret = hwrite(fp->fp.hfile, htxt.s, htxt.l);
+    free(htxt.s);
     return ret<0 ? -1 : 0;
 }
 
@@ -2431,9 +2439,10 @@ bcf_hdr_t *bcf_hdr_merge(bcf_hdr_t *dst, const bcf_hdr_t *src)
     {
         // this will effectively strip existing IDX attributes from src to become dst
         dst = bcf_hdr_init("r");
-        char *htxt = bcf_hdr_fmt_text(src, 0, NULL);
-        bcf_hdr_parse(dst, htxt);
-        free(htxt);
+        kstring_t htxt = {0,0,0};
+        bcf_hdr_format(src, 0, &htxt);
+        bcf_hdr_parse(dst, htxt.s);
+        free(htxt.s);
         return dst;
     }
 
@@ -2615,49 +2624,46 @@ int bcf_translate(const bcf_hdr_t *dst_hdr, bcf_hdr_t *src_hdr, bcf1_t *line)
 bcf_hdr_t *bcf_hdr_dup(const bcf_hdr_t *hdr)
 {
     bcf_hdr_t *hout = bcf_hdr_init("r");
-    char *htxt = bcf_hdr_fmt_text(hdr, 1, NULL);
     if (!hout) {
         fprintf(stderr, "[E::%s] failed to allocate bcf header\n", __func__);
-        free(htxt);
         return NULL;
     }
-    bcf_hdr_parse(hout, htxt);
-    free(htxt);
+    kstring_t htxt = {0,0,0};
+    bcf_hdr_format(hdr, 1, &htxt);
+    bcf_hdr_parse(hout, htxt.s);
+    free(htxt.s);
     return hout;
 }
 
 bcf_hdr_t *bcf_hdr_subset(const bcf_hdr_t *h0, int n, char *const* samples, int *imap)
 {
-    int hlen;
     void *names_hash = khash_str2int_init();
-    char *htxt = bcf_hdr_fmt_text(h0, 1, &hlen);
-    kstring_t str;
-    bcf_hdr_t *h;
-    str.l = str.m = 0; str.s = 0;
-    h = bcf_hdr_init("w");
+    kstring_t htxt = {0,0,0};
+    kstring_t str = {0,0,0};
+    bcf_hdr_t *h = bcf_hdr_init("w");
     if (!h) {
         fprintf(stderr, "[E::%s] failed to allocate bcf header\n", __func__);
-        free(htxt);
         return NULL;
     }
+    bcf_hdr_format(h0, 1, &htxt);
     bcf_hdr_set_version(h,bcf_hdr_get_version(h0));
     int j;
     for (j=0; j<n; j++) imap[j] = -1;
     if ( bcf_hdr_nsamples(h0) > 0) {
-        char *p = find_chrom_header_line(htxt);
+        char *p = find_chrom_header_line(htxt.s);
         int i = 0, end = n? 8 : 7;
         while ((p = strchr(p, '\t')) != 0 && i < end) ++i, ++p;
         if (i != end) {
             free(h); free(str.s);
             return 0; // malformated header
         }
-        kputsn(htxt, p - htxt, &str);
+        kputsn(htxt.s, p - htxt.s, &str);
         for (i = 0; i < n; ++i) {
             if ( khash_str2int_has_key(names_hash,samples[i]) )
             {
                 fprintf(stderr,"[E::bcf_hdr_subset] Duplicate sample name \"%s\".\n", samples[i]);
                 free(str.s);
-                free(htxt);
+                free(htxt.s);
                 khash_str2int_destroy(names_hash);
                 bcf_hdr_destroy(h);
                 return NULL;
@@ -2668,12 +2674,12 @@ bcf_hdr_t *bcf_hdr_subset(const bcf_hdr_t *h0, int n, char *const* samples, int 
             kputs(samples[i], &str);
             khash_str2int_inc(names_hash,samples[i]);
         }
-    } else kputsn(htxt, hlen, &str);
+    } else kputsn(htxt.s, htxt.l, &str);
     while (str.l && (!str.s[str.l-1] || str.s[str.l-1]=='\n') ) str.l--; // kill trailing zeros and newlines
     kputc('\n',&str);
     bcf_hdr_parse(h, str.s);
     free(str.s);
-    free(htxt);
+    free(htxt.s);
     khash_str2int_destroy(names_hash);
     return h;
 }

--- a/vcf.c
+++ b/vcf.c
@@ -72,6 +72,14 @@ static const char *dump_char(char *buffer, char c)
     return buffer;
 }
 
+static char *find_chrom_header_line(char *s)
+{
+    char *nl;
+    if (strncmp(s, "#CHROM\t", 7) == 0) return s;
+    else if ((nl = strstr(s, "\n#CHROM\t")) != NULL) return nl+1;
+    else return NULL;
+}
+
 /*************************
  *** VCF header parser ***
  *************************/
@@ -2636,10 +2644,8 @@ bcf_hdr_t *bcf_hdr_subset(const bcf_hdr_t *h0, int n, char *const* samples, int 
     int j;
     for (j=0; j<n; j++) imap[j] = -1;
     if ( bcf_hdr_nsamples(h0) > 0) {
-        char *p;
+        char *p = find_chrom_header_line(htxt);
         int i = 0, end = n? 8 : 7;
-        while ((p = strstr(htxt, "#CHROM\t")) != 0)
-            if (p > htxt && *(p-1) == '\n') break;
         while ((p = strchr(p, '\t')) != 0 && i < end) ++i, ++p;
         if (i != end) {
             free(h); free(str.s);

--- a/vcf.c
+++ b/vcf.c
@@ -853,7 +853,7 @@ bcf_hdr_t *bcf_hdr_read(htsFile *hfp)
         bcf_hdr_destroy(h);
         return NULL;
     }
-    int hlen;
+    uint32_t hlen;
     char *htxt = NULL;
     if (bgzf_read(fp, &hlen, 4) != 4) goto fail;
     htxt = (char*)malloc(hlen);


### PR DESCRIPTION
`bcf_hdr_read()` and `bcf_hdr_write()` need to consider BCF's `l_text` (header text length) as unsigned, so that huge headers can be handled.

Fixes samtools/samtools#567.