### PR TITLE
Make hts_itr_query find no-coor reads when last reference is unused.

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -1752,11 +1752,17 @@ hts_itr_t *hts_itr_query(const hts_idx_t *idx, int tid, int beg, int end, hts_re
             break;
 
         case HTS_IDX_NOCOOR:
-            if ( idx->n>0 )
-            {
-                bidx = idx->bidx[idx->n - 1];
+            /* No-coor reads sort after all of the mapped reads.  The position is not stored
+               in the index itself, so need to find the end offset for the last mapped read.
+               A loop is needed here in case references at the end of the file have no mapped
+               reads.  See issue samtools#568. */
+            for (i = idx->n - 1; i >= 0; --i) {
+                bidx = idx->bidx[i];
                 k = kh_get(bin, bidx, META_BIN(idx));
-                if (k != kh_end(bidx)) off0 = kh_val(bidx, k).list[0].v;
+                if (k != kh_end(bidx)) {
+                    off0 = kh_val(bidx, k).list[0].v;
+                    break;
+                }
             }
             if ( off0==(uint64_t)-1 && idx->n_no_coor ) off0 = 0; // only no-coor reads in this bam
             break;


### PR DESCRIPTION
When searching for HTS_IDX_NOCOOR reads, hts_itr_query would return the
wrong result for indexes where the last reference was unused.  Such
references have no entries in the binning index so it it not possible
to return an end offset for them.  Add a loop so that hts_itr_query finds
the last reference with mapped reads.  If found, its ending offset is
returned as the location where the no-coor reads start.

Fixes samtools/samtools#568
