### PR TITLE
Example doxygen @file annotations [POLL]

### DIFF
--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -1,5 +1,6 @@
-/* The MIT License
-
+/// @file htslib/bgzf.h
+/// Low-level routines for direct BGZF operations.
+/*
    Copyright (c) 2008 Broad Institute / Massachusetts Institute of Technology
                  2011, 2012 Attractive Chaos <attractor@live.co.uk>
    Copyright (C) 2009, 2013, 2014 Genome Research Ltd

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -1,5 +1,6 @@
-/*  cram.h -- public CRAM-specific API functions.
-
+/// @file htslib/cram.h
+/// CRAM format-specific API functions.
+/*
     Copyright (C) 2015, 2016 Genome Research Ltd.
 
     Author: James Bonfield <jkb@sanger.ac.uk>
@@ -22,9 +23,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.  */
 
-/*! \file
- * CRAM interface.
- *
+/** @file
  * Consider using the higher level hts_*() API for programs that wish to
  * be file format agnostic (see htslib/hts.h).
  *

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -1,5 +1,6 @@
-/* faidx.h -- FASTA random access.
-
+/// @file htslib/faidx.h
+/// FASTA random access.
+/*
    Copyright (C) 2008, 2009, 2013, 2014 Genome Research Ltd.
 
    Author: Heng Li <lh3@sanger.ac.uk>

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -1,5 +1,6 @@
-/*  hfile.h -- buffered low-level input/output streams.
-
+/// @file htslib/hfile.h
+/// Buffered low-level input/output streams.
+/*
     Copyright (C) 2013-2015 Genome Research Ltd.
 
     Author: John Marshall <jm18@sanger.ac.uk>

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -1,5 +1,6 @@
-/*  hts.h -- format-neutral I/O, indexing, and iterator API functions.
-
+/// @file htslib/hts.h
+/// Format-neutral I/O, indexing, and iterator API functions.
+/*
     Copyright (C) 2012-2016 Genome Research Ltd.
     Copyright (C) 2010, 2012 Broad Institute.
     Portions copyright (C) 2003-2006, 2008-2010 by Heng Li <lh3@live.co.uk>

--- a/htslib/regidx.h
+++ b/htslib/regidx.h
@@ -1,3 +1,5 @@
+/// @file htslib/regidx.h
+/// Region indexing.
 /* 
     Copyright (C) 2014 Genome Research Ltd.
 

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1,5 +1,6 @@
-/*  sam.h -- SAM and BAM file I/O and manipulation.
-
+/// @file htslib/sam.h
+/// High-level SAM/BAM/CRAM sequence file operations.
+/*
     Copyright (C) 2008, 2009, 2013-2014 Genome Research Ltd.
     Copyright (C) 2010, 2012, 2013 Broad Institute.
 

--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -1,5 +1,6 @@
-/*  synced_bcf_reader.h -- stream through multiple VCF files.
-
+/// @file htslib/synced_bcf_reader.h
+/// Stream through multiple VCF files.
+/*
     Copyright (C) 2012-2014 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>

--- a/htslib/tbx.h
+++ b/htslib/tbx.h
@@ -1,5 +1,6 @@
-/*  tbx.h -- tabix API functions.
-
+/// @file htslib/tbx.h
+/// Tabix API functions.
+/*
     Copyright (C) 2009, 2012-2015 Genome Research Ltd.
     Copyright (C) 2010, 2012 Broad Institute.
 

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -1,5 +1,6 @@
-/*  vcf.h -- VCF/BCF API functions.
-
+/// @file htslib/vcf.h
+/// High-level VCF/BCF variant calling file operations.
+/*
     Copyright (C) 2012, 2013 Broad Institute.
     Copyright (C) 2012-2014 Genome Research Ltd.
 

--- a/htslib/vcf_sweep.h
+++ b/htslib/vcf_sweep.h
@@ -1,5 +1,6 @@
-/*  vcf_sweep.h -- forward/reverse sweep API.
-
+/// @file htslib/vcf_sweep.h
+/// Forward/reverse sweep API.
+/*
     Copyright (C) 2013 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>

--- a/htslib/vcfutils.h
+++ b/htslib/vcfutils.h
@@ -1,5 +1,6 @@
-/*  vcfutils.h -- allele-related utility functions.
-
+/// @file htslib/vcfutils.h
+/// Allele-related utility functions.
+/*
     Copyright (C) 2012, 2013, 2015 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>


### PR DESCRIPTION
We will soon start using [doxygen](http://doxygen.org/) to generate API documentation web pages.  However doxygen only generates documentation for items within header files that have `@file` annotations, so we need to add those to each of _htslib/*.h_ that we want to appear in the API docs.  Here are a couple of styles for adding them — each has various pros and cons.

Since it is Friday, here is a poll on a topic I'm sure we all care about deeply!

Please add a :+1: reaction on one of the comments below to vote for the one you think is preferable…