### PR TITLE
Add interfaces to hfile for delimited string input.

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -28,6 +28,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <limits.h>
 
 #include <pthread.h>
 
@@ -42,6 +43,10 @@ DEALINGS IN THE SOFTWARE.  */
 #endif
 #ifndef EPROTONOSUPPORT
 #define EPROTONOSUPPORT ENOSYS
+#endif
+
+#ifndef SSIZE_MAX /* SSIZE_MAX is POSIX 1 */
+#define SSIZE_MAX LONG_MAX
 #endif
 
 /* hFILE fields are used as follows:
@@ -144,6 +149,65 @@ static ssize_t refill_buffer(hFILE *fp)
 int hgetc2(hFILE *fp)
 {
     return (refill_buffer(fp) > 0)? (unsigned char) *(fp->begin++) : EOF;
+}
+
+ssize_t hgetdelim(char *buffer, size_t size, int delim, hFILE *fp)
+{
+    char *found;
+    size_t n, copied = 0;
+    ssize_t got;
+
+    if (size < 1 || size > SSIZE_MAX) {
+        fp->has_errno = errno = EINVAL;
+        return -1;
+    }
+    if (fp->end < fp->begin) { /* fp in writing mode */
+        fp->has_errno = errno = EBADF;
+        return -1;
+    }
+
+    --size; /* to allow space for the NUL terminator */
+
+    do {
+        n = fp->end - fp->begin;
+        if (n > size - copied) n = size - copied;
+
+        /* Look in the hFILE buffer for the delimiter */
+        found = memchr(fp->begin, delim, n);
+        if (found != NULL) {
+            n = found - fp->begin + 1;
+            memcpy(buffer + copied, fp->begin, n);
+            buffer[n + copied] = '\0';
+            fp->begin += n;
+            return n + copied;
+        }
+
+        /* No delimiter yet, copy as much as we can and refill if necessary */
+        memcpy(buffer + copied, fp->begin, n);
+        fp->begin += n;
+        copied += n;
+
+        if (copied == size) { /* Output buffer full */
+            buffer[copied] = '\0';
+            return copied;
+        }
+
+        got = refill_buffer(fp);
+    } while (got > 0);
+
+    if (got < 0) return -1; /* Error on refill. */
+
+    buffer[copied] = '\0';  /* EOF, return anything that was copied. */
+    return copied;
+}
+
+char * hfgets(char *buffer, int size, hFILE *fp)
+{
+    if (size < 1) {
+        fp->has_errno = errno = EINVAL;
+        return NULL;
+    }
+    return hgetln(buffer, size, fp) > 0 ? buffer : NULL;
 }
 
 ssize_t hpeek(hFILE *fp, void *buffer, size_t nbytes)

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -129,6 +129,44 @@ static inline int hgetc(hFILE *fp)
 }
 
 /*!
+  @abstract  Delimited string input, up to a maximum length.
+  @param buffer  The buffer into which bytes will be placed.
+  @param size    The size of the buffer.
+  @param delim   The delimiter (interpreted as an unsigned char)
+  @param fp      The file stream.
+  @return   The number of bytes read, or -1 on error.
+  @notes  Bytes will be read into the buffer up to and including a
+    delimiter, EOF, or (size - 1) bytes, whichever comes first.  The string
+    will then be terminated with a NUL byte ('\0').
+*/
+ssize_t hgetdelim(char *buffer, size_t size, int delim, hFILE *fp) HTS_RESULT_USED;
+
+/*!
+  @abstract  Read a line into a buffer, up to a maximum length.
+  @param buffer  The buffer into which bytes will be written.
+  @param size    The size of the buffer.
+  @param fp      The file stream.
+  @return   The number of bytes read, or -1 on error.
+  @notes  Specialization of hgetdelim() for a '\n' delimiter.
+*/
+static inline ssize_t HTS_RESULT_USED
+hgetln(char *buffer, size_t size, hFILE *fp)
+{
+    return hgetdelim(buffer, size, '\n', fp);
+}
+
+/*!
+  @abstract  Read a line into a buffer, up to a maximum length.
+  @param buffer  The buffer into which bytes will be written.
+  @param size    The size of the buffer (must be > 1 to be useful).
+  @param fp      The file stream.
+  @return    buffer on success, or NULL if an error occurred.
+  @notes  This function can be used as a replacement for fgets(), or with
+  kstring's kgetline() function to read lines into a kstring.
+*/
+char * hfgets(char *buffer, int size, hFILE *fp) HTS_RESULT_USED;
+
+/*!
   @abstract  Peek at characters to be read without removing them from buffers
   @param fp      The file stream
   @param buffer  The buffer to which the peeked bytes will be written

--- a/test/hfile.c
+++ b/test/hfile.c
@@ -136,6 +136,14 @@ int main(void)
     if (n < 0) fail("hread");
 
     reopen("test/hfile4.tmp", "test/hfile5.tmp");
+    while (hfgets(buffer, 80, fin) != NULL) {
+        size_t l = strlen(buffer);
+        if (l > 79) fail("hfgets read %zu bytes, should be < 80", l);
+        if (hwrite(fout, buffer, l) != l) fail("hwrite");
+    }
+    if (herrno(fin)) fail("hfgets");
+
+    reopen("test/hfile5.tmp", "test/hfile6.tmp");
     n = hread(fin, buffer, 200);
     if (n < 0) fail("hread");
     else if (n != 200) fail("hread only got %d", (int)n);
@@ -165,7 +173,7 @@ int main(void)
     if (hflush(fout) == EOF) fail("hflush");
 
     original = slurp("vcf.c");
-    for (i = 1; i <= 5; i++) {
+    for (i = 1; i <= 6; i++) {
         char *text;
         sprintf(buffer, "test/hfile%d.tmp", i);
         text = slurp(buffer);


### PR DESCRIPTION
There are three versions:
  hgetdelim - Reads up to a given delimiter.
  hgetln    - Specialization of hgetdelim for '\n'
  hfgets    - Wrapper for hgetln that provides the same interface as fgets.

Time to argue about if the `hFILE` pointer should be at the start or the end, and if `hfgets` should be `hgets`.