### PR TITLE
Added a ksprintf_g for %g specialisation.

### DIFF
--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -82,7 +82,7 @@ extern "C" {
 
 	int kvsprintf(kstring_t *s, const char *fmt, va_list ap) KS_ATTR_PRINTF(2,0);
 	int ksprintf(kstring_t *s, const char *fmt, ...) KS_ATTR_PRINTF(2,3);
-    int ksprintf_g(kstring_t *s, double d); // custom %g only handler
+    int kputd(kstring_t *s, double d); // custom %g only handler
 	int ksplit_core(char *s, int delimiter, int *_max, int **_offsets);
 	char *kstrstr(const char *str, const char *pat, int **_prep);
 	char *kstrnstr(const char *str, const char *pat, int n, int **_prep);

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -82,6 +82,7 @@ extern "C" {
 
 	int kvsprintf(kstring_t *s, const char *fmt, va_list ap) KS_ATTR_PRINTF(2,0);
 	int ksprintf(kstring_t *s, const char *fmt, ...) KS_ATTR_PRINTF(2,3);
+    int ksprintf_g(kstring_t *s, double d); // custom %g only handler
 	int ksplit_core(char *s, int delimiter, int *_max, int **_offsets);
 	char *kstrstr(const char *str, const char *pat, int **_prep);
 	char *kstrnstr(const char *str, const char *pat, int n, int **_prep);

--- a/kstring.c
+++ b/kstring.c
@@ -30,13 +30,124 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdint.h>
+#include <math.h>
 #include "htslib/kstring.h"
+
+int ksprintf_g(kstring_t *s, double d) {
+	int len = 0;
+	char buf[21], *cp = buf+20, *ep;
+	if (d == 0) {
+		if (signbit(d)) {
+			kputsn("-0",2,s);
+			return 2;
+		} else {
+			kputsn("0",1,s);
+			return 1;
+		}
+	}
+
+	if (d < 0) {
+		kputc('-',s);
+		d=-d;
+	}
+	if (d < 0.0001 || d > 999999) {
+		if (ks_resize(s, s->l + 50) < 0)
+			return EOF;
+		// We let stdio handle the exponent cases
+		len = sprintf(s->s + s->l, "%g", d);
+		s->l += len;
+		return len;
+	}
+
+	uint64_t i = d*10000000000;
+	// Correction for rounding - rather ugly
+
+	// Optimised for small numbers.
+	// Better still would be __builtin_clz on hi/lo 32 and get the
+	// starting point very rapidly.
+	if (d<.0001)
+		i+=0;
+	else if (d<0.001)
+		 i+=5;
+	else if (d < 0.01)
+		i+=50;
+	else if (d < 0.1)
+		i+=500;
+	else if (d < 1)
+		i+=5000;
+	else if (d < 10)
+		i+=50000;
+	else if (d < 100)
+		i+=500000;
+	else if (d < 1000)
+		i+=5000000;
+	else if (d < 10000)
+		i+=50000000;
+	else if (d < 100000)
+		i+=500000000;
+	else
+		i+=5000000000;
+
+	do {
+		*--cp = '0' + i%10;
+		i /= 10;
+	} while (i >= 1);
+	buf[20] = 0;
+	int p = buf+20-cp;
+	if (p <= 10) { // d < 1
+		//assert(d/1);
+		cp[6] = 0; ep = cp+5;// 6 precision
+		while (p < 10) {
+			*--cp = '0';
+			p++;
+		}
+		*--cp = '.';
+		*--cp = '0';
+	} else {
+		char *xp = --cp;
+		while (p > 10) {
+			xp[0] = xp[1];
+			p--;
+			xp++;
+		}
+		xp[0] = '.';
+		cp[7] = 0; ep=cp+6;
+		if (cp[6] == '.') cp[6] = 0;
+	}
+
+	// Cull trailing zeros
+	while (*ep == '0' && ep > cp)
+		ep--;
+	char *z = ep+1;
+	while (ep > cp) {
+		if (*ep == '.') {
+			if (z[-1] == '.')
+				z[-1] = 0;
+			else
+				z[0] = 0;
+			break;
+		}
+		ep--;
+	}
+
+	len = strlen(cp);
+	kputsn(cp, len, s);
+	return len;
+}
 
 int kvsprintf(kstring_t *s, const char *fmt, va_list ap)
 {
 	va_list args;
 	int l;
 	va_copy(args, ap);
+
+	if (fmt[0] == '%' && fmt[1] == 'g' && fmt[2] == 0) {
+		double d = va_arg(args, double);
+		l = ksprintf_g(s, d);
+		va_end(args);
+		return l;
+	}
+
 	l = vsnprintf(s->s + s->l, s->m - s->l, fmt, args); // This line does not work with glibc 2.0. See `man snprintf'.
 	va_end(args);
 	if (l + 1 > s->m - s->l) {

--- a/kstring.c
+++ b/kstring.c
@@ -48,13 +48,15 @@ int ksprintf_g(kstring_t *s, double d) {
 
 	if (d < 0) {
 		kputc('-',s);
+		len = 1;
 		d=-d;
 	}
 	if (d < 0.0001 || d > 999999) {
 		if (ks_resize(s, s->l + 50) < 0)
 			return EOF;
 		// We let stdio handle the exponent cases
-		len = sprintf(s->s + s->l, "%g", d);
+		int s2 = sprintf(s->s + s->l, "%g", d);
+		len += s2;
 		s->l += len;
 		return len;
 	}
@@ -68,7 +70,7 @@ int ksprintf_g(kstring_t *s, double d) {
 	if (d<.0001)
 		i+=0;
 	else if (d<0.001)
-		 i+=5;
+		i+=5;
 	else if (d < 0.01)
 		i+=50;
 	else if (d < 0.1)
@@ -130,8 +132,9 @@ int ksprintf_g(kstring_t *s, double d) {
 		ep--;
 	}
 
-	len = strlen(cp);
-	kputsn(cp, len, s);
+	int sl = strlen(cp);
+	len += sl;
+	kputsn(cp, sl, s);
 	return len;
 }
 

--- a/sam.c
+++ b/sam.c
@@ -1193,7 +1193,7 @@ int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str)
                 else if ('S' == sub_type) { kputw(*(uint16_t*)s, str); s += 2; }
                 else if ('i' == sub_type) { kputw(*(int32_t*)s, str); s += 4; }
                 else if ('I' == sub_type) { kputuw(*(uint32_t*)s, str); s += 4; }
-                else if ('f' == sub_type) { ksprintf(str, "%g", *(float*)s); s += 4; }
+                else if ('f' == sub_type) { ksprintf_g(str, *(float*)s); s += 4; }
                 else return -1;
             }
         }

--- a/sam.c
+++ b/sam.c
@@ -1193,7 +1193,7 @@ int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str)
                 else if ('S' == sub_type) { kputw(*(uint16_t*)s, str); s += 2; }
                 else if ('i' == sub_type) { kputw(*(int32_t*)s, str); s += 4; }
                 else if ('I' == sub_type) { kputuw(*(uint32_t*)s, str); s += 4; }
-                else if ('f' == sub_type) { ksprintf_g(str, *(float*)s); s += 4; }
+                else if ('f' == sub_type) { kputd(str, *(float*)s); s += 4; }
                 else return -1;
             }
         }

--- a/test/noroundtrip-out.vcf
+++ b/test/noroundtrip-out.vcf
@@ -3,7 +3,7 @@
 ##contig=<ID=3>
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA1
-3	50	.	A	T	0	PASS	.	GT:GT	2,4:.
-3	60	.	T	C	0	PASS	.	GT	0/1
-3	70	.	G	A	0	PASS	.	GT:GT	2,4:.
-3	80	.	C	G	0	PASS	.	GT:GT	2,4:0/1
+3	50	.	A	T	0.	PASS	.	GT:GT	2,4:.
+3	60	.	T	C	0.	PASS	.	GT	0/1
+3	70	.	G	A	0.	PASS	.	GT:GT	2,4:.
+3	80	.	C	G	0.	PASS	.	GT:GT	2,4:0/1

--- a/test/test-vcf-api.out
+++ b/test/test-vcf-api.out
@@ -20,9 +20,9 @@
 ##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
 ##FORMAT=<ID=TS,Number=1,Type=String,Description="Test String">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
-20	14370	rs6054257	G	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ:TS	0|0:48:1:51,51:String1	1|0:48:8:51,51:SomeOtherString2	1/1:43:5:.,.:YetAnotherString3
-20	14370	.	G	A	29	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:DP:HQ:TS	0|0:1:51,51:String1	1|0:8:51,51:SomeOtherString2	1/1:5:.,.:YetAnotherString3
-20	14370	.	G	A	29	PASS	NS=3;DP=99;AF=0.5;DB;H2	GT:DP:HQ:TS	0|0:9:51,51:String1	1|0:9:51,51:SomeOtherString2	1/1:9:.,.:YetAnotherString3
-20	1110696	.	A	G,T	67	.	NS=2;DP=10;AF=0.333,.;AA=T;DB	GT	2	1	./.
-20	1110696	.	A	G,T	67	.	NS=2;DP=10;AF=0.333,.;AA=T;DB	GT	2	1	./.
-20	1110696	.	G	A	67	.	NS=2;DP=99;AF=0.333,.;AA=T;DB	GT:DP	2:9	1:9	./.:9
+20	14370	rs6054257	G	A	29.	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:GQ:DP:HQ:TS	0|0:48:1:51,51:String1	1|0:48:8:51,51:SomeOtherString2	1/1:43:5:.,.:YetAnotherString3
+20	14370	.	G	A	29.	PASS	NS=3;DP=14;AF=0.5;DB;H2	GT:DP:HQ:TS	0|0:1:51,51:String1	1|0:8:51,51:SomeOtherString2	1/1:5:.,.:YetAnotherString3
+20	14370	.	G	A	29.	PASS	NS=3;DP=99;AF=0.5;DB;H2	GT:DP:HQ:TS	0|0:9:51,51:String1	1|0:9:51,51:SomeOtherString2	1/1:9:.,.:YetAnotherString3
+20	1110696	.	A	G,T	67.	.	NS=2;DP=10;AF=0.333,.;AA=T;DB	GT	2	1	./.
+20	1110696	.	A	G,T	67.	.	NS=2;DP=10;AF=0.333,.;AA=T;DB	GT	2	1	./.
+20	1110696	.	G	A	67.	.	NS=2;DP=99;AF=0.333,.;AA=T;DB	GT:DP	2:9	1:9	./.:9

--- a/vcf.c
+++ b/vcf.c
@@ -1561,7 +1561,7 @@ void bcf_fmt_array(kstring_t *s, int n, int type, void *data)
             case BCF_BT_INT8:  BRANCH(int8_t,  p[j]==bcf_int8_missing,  p[j]==bcf_int8_vector_end,  kputw(p[j], s)); break;
             case BCF_BT_INT16: BRANCH(int16_t, p[j]==bcf_int16_missing, p[j]==bcf_int16_vector_end, kputw(p[j], s)); break;
             case BCF_BT_INT32: BRANCH(int32_t, p[j]==bcf_int32_missing, p[j]==bcf_int32_vector_end, kputw(p[j], s)); break;
-            case BCF_BT_FLOAT: BRANCH(float,   bcf_float_is_missing(p[j]), bcf_float_is_vector_end(p[j]), ksprintf_g(s, p[j])); break;
+            case BCF_BT_FLOAT: BRANCH(float,   bcf_float_is_missing(p[j]), bcf_float_is_vector_end(p[j]), kputd(s, p[j])); break;
             default: fprintf(stderr,"todo: type %d\n", type); exit(1); break;
         }
         #undef BRANCH
@@ -2183,7 +2183,7 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
     } else kputc('.', s);
     kputc('\t', s); // QUAL
     if ( bcf_float_is_missing(v->qual) ) kputc('.', s); // QUAL
-    else ksprintf_g(s, v->qual);
+    else kputd(s, v->qual);
     kputc('\t', s); // FILTER
     if (v->d.n_flt) {
         for (i = 0; i < v->d.n_flt; ++i) {
@@ -2209,7 +2209,7 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
                     case BCF_BT_INT8:  if ( z->v1.i==bcf_int8_missing ) kputc('.', s); else kputw(z->v1.i, s); break;
                     case BCF_BT_INT16: if ( z->v1.i==bcf_int16_missing ) kputc('.', s); else kputw(z->v1.i, s); break;
                     case BCF_BT_INT32: if ( z->v1.i==bcf_int32_missing ) kputc('.', s); else kputw(z->v1.i, s); break;
-                    case BCF_BT_FLOAT: if ( bcf_float_is_missing(z->v1.f) ) kputc('.', s); else ksprintf_g(s, z->v1.f); break;
+                    case BCF_BT_FLOAT: if ( bcf_float_is_missing(z->v1.f) ) kputc('.', s); else kputd(s, z->v1.f); break;
                     case BCF_BT_CHAR:  kputc(z->v1.i, s); break;
                     default: fprintf(stderr,"todo: type %d\n", z->type); exit(1); break;
                 }

--- a/vcf.c
+++ b/vcf.c
@@ -1561,7 +1561,7 @@ void bcf_fmt_array(kstring_t *s, int n, int type, void *data)
             case BCF_BT_INT8:  BRANCH(int8_t,  p[j]==bcf_int8_missing,  p[j]==bcf_int8_vector_end,  kputw(p[j], s)); break;
             case BCF_BT_INT16: BRANCH(int16_t, p[j]==bcf_int16_missing, p[j]==bcf_int16_vector_end, kputw(p[j], s)); break;
             case BCF_BT_INT32: BRANCH(int32_t, p[j]==bcf_int32_missing, p[j]==bcf_int32_vector_end, kputw(p[j], s)); break;
-            case BCF_BT_FLOAT: BRANCH(float,   bcf_float_is_missing(p[j]), bcf_float_is_vector_end(p[j]), ksprintf(s, "%g", p[j])); break;
+            case BCF_BT_FLOAT: BRANCH(float,   bcf_float_is_missing(p[j]), bcf_float_is_vector_end(p[j]), ksprintf_g(s, p[j])); break;
             default: fprintf(stderr,"todo: type %d\n", type); exit(1); break;
         }
         #undef BRANCH
@@ -2183,7 +2183,7 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
     } else kputc('.', s);
     kputc('\t', s); // QUAL
     if ( bcf_float_is_missing(v->qual) ) kputc('.', s); // QUAL
-    else ksprintf(s, "%g", v->qual);
+    else ksprintf_g(s, v->qual);
     kputc('\t', s); // FILTER
     if (v->d.n_flt) {
         for (i = 0; i < v->d.n_flt; ++i) {
@@ -2209,7 +2209,7 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
                     case BCF_BT_INT8:  if ( z->v1.i==bcf_int8_missing ) kputc('.', s); else kputw(z->v1.i, s); break;
                     case BCF_BT_INT16: if ( z->v1.i==bcf_int16_missing ) kputc('.', s); else kputw(z->v1.i, s); break;
                     case BCF_BT_INT32: if ( z->v1.i==bcf_int32_missing ) kputc('.', s); else kputw(z->v1.i, s); break;
-                    case BCF_BT_FLOAT: if ( bcf_float_is_missing(z->v1.f) ) kputc('.', s); else ksprintf(s, "%g", z->v1.f); break;
+                    case BCF_BT_FLOAT: if ( bcf_float_is_missing(z->v1.f) ) kputc('.', s); else ksprintf_g(s, z->v1.f); break;
                     case BCF_BT_CHAR:  kputc(z->v1.i, s); break;
                     default: fprintf(stderr,"todo: type %d\n", z->type); exit(1); break;
                 }


### PR DESCRIPTION
VCF spends a lot of time doing ksprintf(s,"%g",val), especially on
VCFs with many samples.  The ksprintf_g is a dedicated function for
this one specific task that runs significantly quicker than the glibc
printf code giving around 4x speed improvement overall.  (Assumed less on single sample VCF.)

On a 1000genomes test user time was previously 50.5s and after this
patch was 12.5s, to convert uncompressed BCF to uncompressed VCF. (But
still -Ou for uncomp BCF is 0.2s, so VCF generation is still slow).

I haven't look at VCF decoding (vs encoding), but likely there is room
there too.  uBCF->uBCF is ~0.2s; uVCF->uBCF is 21.7s.
