### PR TITLE
Mpileup speedup

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -389,6 +389,21 @@ int sam_index_build2(const char *fn, const char *fnidx, int min_shift) HTS_RESUL
 #if !defined(BAM_NO_PILEUP)
 
 /*! @typedef
+ @abstract Generic pileup 'client data'.
+
+ @discussion The pileup iterator allows setting a constructor and
+ destructor function, which will be called every time a sequenced is
+ fetched and discarded.  This permits caching of per-sequence data in
+ a tidy manner during the pileup process.  This union is the cached
+ data to be manipulated by the "client" (the caller of pileup).
+*/
+typedef union {
+    void *p;
+    int64_t i;
+    double f;
+} bam_pileup_cd;
+
+/*! @typedef
  @abstract Structure for one alignment covering the pileup position.
  @field  b          pointer to the alignment
  @field  qpos       position of the read base at the pileup site, 0-based
@@ -411,6 +426,7 @@ typedef struct {
     int32_t qpos;
     int indel, level;
     uint32_t is_del:1, is_head:1, is_tail:1, is_refskip:1, aux:28;
+    bam_pileup_cd cd; // generic per-struct data, owned by caller.
 } bam_pileup1_t;
 
 typedef int (*bam_plp_auto_f)(void *data, bam1_t *b);
@@ -435,6 +451,19 @@ typedef struct __bam_mplp_t *bam_mplp_t;
     void bam_plp_set_maxcnt(bam_plp_t iter, int maxcnt);
     void bam_plp_reset(bam_plp_t iter);
 
+    /**
+     *  bam_plp_constructor() - sets a callback to initialise any per-pileup1_t fields.
+     *  @plp:       The bam_plp_t initialised using bam_plp_init.
+     *  @func:      The callback function itself.  When called, it is given the 
+     *              data argument (specified in bam_plp_init), the bam structure and
+     *              a pointer to a locally allocated bam_pileup_cd union.  This union
+     *              will also be present in each bam_pileup1_t created.
+     */
+    void bam_plp_constructor(bam_plp_t plp,
+                             int (*func)(void *data, const bam1_t *b, bam_pileup_cd *cd));
+    void bam_plp_destructor(bam_plp_t plp,
+                            int (*func)(void *data, const bam1_t *b, bam_pileup_cd *cd));
+
     bam_mplp_t bam_mplp_init(int n, bam_plp_auto_f func, void **data);
     /**
      *  bam_mplp_init_overlaps() - if called, mpileup will detect overlapping
@@ -449,6 +478,10 @@ typedef struct __bam_mplp_t *bam_mplp_t;
     void bam_mplp_set_maxcnt(bam_mplp_t iter, int maxcnt);
     int bam_mplp_auto(bam_mplp_t iter, int *_tid, int *_pos, int *n_plp, const bam_pileup1_t **plp);
     void bam_mplp_reset(bam_mplp_t iter);
+    void bam_mplp_constructor(bam_mplp_t iter,
+                              int (*func)(void *data, const bam1_t *b, bam_pileup_cd *cd));
+    void bam_mplp_destructor(bam_mplp_t iter,
+                             int (*func)(void *data, const bam1_t *b, bam_pileup_cd *cd));
 
 #endif // ~!defined(BAM_NO_PILEUP)
 

--- a/probaln.c
+++ b/probaln.c
@@ -71,7 +71,7 @@ static float g_qual2prob[256];
 int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_query,
                    const uint8_t *iqual, const probaln_par_t *c, int *state, uint8_t *q)
 {
-    double **f, **b = 0, *s, m[9], sI, sM, bI, bM;
+    double *f, *b = 0, *s, m[9], sI, sM, bI, bM;
     float *qual, *_qual;
     const uint8_t *ref, *query;
     int bw, bw2, i, k, is_backward = 1, Pr;
@@ -85,16 +85,14 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
     if (bw > c->bw) bw = c->bw;
     if (bw < abs(l_ref - l_query)) bw = abs(l_ref - l_query);
     bw2 = bw * 2 + 1;
+    int i_dim = bw2*3+6;
     // allocate the forward and backward matrices f[][] and b[][] and the scaling array s[]
-    f = calloc(l_query+1, sizeof(double*));
-    if (is_backward) b = calloc(l_query+1, sizeof(double*));
-    for (i = 0; i <= l_query; ++i) {    // FIXME: this will lead in segfault for l_query==0
-        f[i] = calloc(bw2 * 3 + 6, sizeof(double)); // FIXME: this is over-allocated for very short seqs
-        if (is_backward) b[i] = calloc(bw2 * 3 + 6, sizeof(double));
-    }
-    s = calloc(l_query+2, sizeof(double)); // s[] is the scaling factor to avoid underflow
+    // Ideally these callocs would be mallocs + initialisation of the few bits needed.
+    f = calloc((l_query+1)*i_dim, sizeof(double));
+    if (is_backward) b = calloc((l_query+1)*i_dim, sizeof(double));
+    s = malloc((l_query+2)* sizeof(double)); // s[] is the scaling factor to avoid underflow
     // initialize qual
-    _qual = calloc(l_query, sizeof(float));
+    _qual = malloc(l_query* sizeof(float));
     if (g_qual2prob[0] == 0)
         for (i = 0; i < 256; ++i)
             g_qual2prob[i] = pow(10, -i/10.);
@@ -109,9 +107,9 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
     /*** forward ***/
     // f[0]
     set_u(k, bw, 0, 0);
-    f[0][k] = s[0] = 1.;
+    f[0*i_dim+k] = s[0] = 1.;
     { // f[1]
-        double *fi = f[1], sum;
+        double *fi = &f[1*i_dim], sum;
         int beg = 1, end = l_ref < bw + 1? l_ref : bw + 1, _beg, _end;
         for (k = beg, sum = 0.; k <= end; ++k) {
             int u;
@@ -127,15 +125,21 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
     }
     // f[2..l_query]
     for (i = 2; i <= l_query; ++i) {
-        double *fi = f[i], *fi1 = f[i-1], sum, qli = qual[i];
+        double *fi = &f[i*i_dim], *fi1 = &f[(i-1)*i_dim], sum, qli = qual[i];
         int beg = 1, end = l_ref, x, _beg, _end;
         uint8_t qyi = query[i];
         x = i - bw; beg = beg > x? beg : x; // band start
         x = i + bw; end = end < x? end : x; // band end
+        double E[] = {
+            qli * EM, // 00
+            1. - qli, // 01
+            1.,       // 10
+            1.,       // 11
+        };
         for (k = beg, sum = 0.; k <= end; ++k) {
             int u, v11, v01, v10;
             double e;
-            e = (ref[k] > 3 || qyi > 3)? 1. : ref[k] == qyi? 1. - qli : qli * EM;
+            e = E[(ref[k] > 3 || qyi > 3)*2 + (ref[k] == qyi)];
             set_u(u, bw, i, k); set_u(v11, bw, i-1, k-1); set_u(v10, bw, i-1, k); set_u(v01, bw, i, k-1);
             fi[u+0] = e * (m[0] * fi1[v11+0] + m[3] * fi1[v11+1] + m[6] * fi1[v11+2]);
             fi[u+1] = EI * (m[1] * fi1[v10+0] + m[4] * fi1[v10+1]);
@@ -154,7 +158,7 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
             int u;
             set_u(u, bw, l_query, k);
             if (u < 3 || u >= bw2*3+3) continue;
-            sum += f[l_query][u+0] * sM + f[l_query][u+1] * sI;
+            sum += f[l_query*i_dim + u+0] * sM + f[l_query*i_dim + u+1] * sI;
         }
         s[l_query+1] = sum; // the last scaling factor
     }
@@ -167,7 +171,6 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
         Pr1 += -4.343 * log(p * l_ref * l_query);
         Pr = (int)(Pr1 + .499);
         if (!is_backward) { // skip backward and MAP
-            for (i = 0; i <= l_query; ++i) free(f[i]);
             free(f); free(s); free(_qual);
             return Pr;
         }
@@ -176,7 +179,7 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
     // b[l_query] (b[l_query+1][0]=1 and thus \tilde{b}[][]=1/s[l_query+1]; this is where s[l_query+1] comes from)
     for (k = 1; k <= l_ref; ++k) {
         int u;
-        double *bi = b[l_query];
+        double *bi = &b[l_query*i_dim];
         set_u(u, bw, l_query, k);
         if (u < 3 || u >= bw2*3+3) continue;
         bi[u+0] = sM / s[l_query] / s[l_query+1]; bi[u+1] = sI / s[l_query] / s[l_query+1];
@@ -184,15 +187,22 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
     // b[l_query-1..1]
     for (i = l_query - 1; i >= 1; --i) {
         int beg = 1, end = l_ref, x, _beg, _end;
-        double *bi = b[i], *bi1 = b[i+1], y = (i > 1), qli1 = qual[i+1];
+        double *bi = &b[i*i_dim], *bi1 = &b[(i+1)*i_dim], y = (i > 1), qli1 = qual[i+1];
         uint8_t qyi1 = query[i+1];
         x = i - bw; beg = beg > x? beg : x;
         x = i + bw; end = end < x? end : x;
+        double E[] = {
+            qli1 * EM, //000
+            1. - qli1, //001
+            1.,        //010
+            1.,        //011
+            //0,0,0,0    //1xx
+        };
         for (k = end; k >= beg; --k) {
             int u, v11, v01, v10;
             double e;
             set_u(u, bw, i, k); set_u(v11, bw, i+1, k+1); set_u(v10, bw, i+1, k); set_u(v01, bw, i, k+1);
-            e = (k >= l_ref? 0 : (ref[k+1] > 3 || qyi1 > 3)? 1. : ref[k+1] == qyi1? 1. - qli1 : qli1 * EM) * bi1[v11];
+            e = (k>=l_ref)?0 :E[(ref[k+1] > 3 || qyi1 > 3)*2 + (ref[k+1] == qyi1)] * bi1[v11];
             bi[u+0] = e * m[0] + EI * m[1] * bi1[v10+1] + m[2] * bi[v01+2]; // bi1[v11] has been foled into e.
             bi[u+1] = e * m[3] + EI * m[4] * bi1[v10+1];
             bi[u+2] = (e * m[6] + m[8] * bi[v01+2]) * y;
@@ -210,14 +220,14 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
             double e = (ref[k] > 3 || query[1] > 3)? 1. : ref[k] == query[1]? 1. - qual[1] : qual[1] * EM;
             set_u(u, bw, 1, k);
             if (u < 3 || u >= bw2*3+3) continue;
-            sum += e * b[1][u+0] * bM + EI * b[1][u+1] * bI;
+            sum += e * b[1*i_dim + u+0] * bM + EI * b[1*i_dim + u+1] * bI;
         }
         set_u(k, bw, 0, 0);
-        b[0][k] = sum / s[0]; // if everything works as is expected, b[0][k] == 1.0
+        b[0*i_dim + k] = sum / s[0]; // if everything works as is expected, b[0][k] == 1.0
     }
     /*** MAP ***/
     for (i = 1; i <= l_query; ++i) {
-        double sum = 0., *fi = f[i], *bi = b[i], max = 0.;
+        double sum = 0., *fi = &f[i*i_dim], *bi = &b[i*i_dim], max = 0.;
         int beg = 1, end = l_ref, x, max_k = -1;
         x = i - bw; beg = beg > x? beg : x;
         x = i + bw; end = end < x? end : x;
@@ -232,14 +242,11 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
         if (state) state[i-1] = max_k;
         if (q) k = (int)(-4.343 * log(1. - max) + .499), q[i-1] = k > 100? 99 : k;
 #ifdef _MAIN
-        fprintf(stderr, "(%.10lg,%.10lg) (%d,%d:%c,%c:%d) %lg\n", pb, sum, i-1, max_k>>2,
+        fprintf(stderr, "(%.10lg,%.10lg) (%d,%d:%c,%c:%d) %lg\n", 0.0/*pb*/, sum, i-1, max_k>>2,
                 "ACGT"[query[i]], "ACGT"[ref[(max_k>>2)+1]], max_k&3, max); // DEBUG
 #endif
     }
     /*** free ***/
-    for (i = 0; i <= l_query; ++i) {
-        free(f[i]); free(b[i]);
-    }
     free(f); free(b); free(s); free(_qual);
     return Pr;
 }

--- a/probaln.c
+++ b/probaln.c
@@ -92,7 +92,7 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
     if (is_backward) b = calloc((l_query+1)*i_dim, sizeof(double));
     s = malloc((l_query+2)* sizeof(double)); // s[] is the scaling factor to avoid underflow
     // initialize qual
-    _qual = malloc(l_query* sizeof(float));
+    _qual = malloc(l_query * sizeof(float));
     if (g_qual2prob[0] == 0)
         for (i = 0; i < 256; ++i)
             g_qual2prob[i] = pow(10, -i/10.);
@@ -242,7 +242,7 @@ int probaln_glocal(const uint8_t *_ref, int l_ref, const uint8_t *_query, int l_
         if (state) state[i-1] = max_k;
         if (q) k = (int)(-4.343 * log(1. - max) + .499), q[i-1] = k > 100? 99 : k;
 #ifdef _MAIN
-        fprintf(stderr, "(%.10lg,%.10lg) (%d,%d:%c,%c:%d) %lg\n", 0.0/*pb*/, sum, i-1, max_k>>2,
+        fprintf(stderr, "(%.10lg,%.10lg) (%d,%d:%c,%c:%d) %lg\n", pb, sum, i-1, max_k>>2,
                 "ACGT"[query[i]], "ACGT"[ref[(max_k>>2)+1]], max_k&3, max); // DEBUG
 #endif
     }

--- a/sam.c
+++ b/sam.c
@@ -1912,9 +1912,9 @@ static void overlap_remove(bam_plp_t iter, const bam1_t *b)
 // buffer yet (the current position is still the maximum position across all buffered reads).
 const bam_pileup1_t *bam_plp_next(bam_plp_t iter, int *_tid, int *_pos, int *_n_plp)
 {
-    if (iter->error) { *_n_plp = -1; return 0; }
+    if (iter->error) { *_n_plp = -1; return NULL; }
     *_n_plp = 0;
-    if (iter->is_eof && iter->head == iter->tail) return 0;
+    if (iter->is_eof && iter->head == iter->tail) return NULL;
     while (iter->is_eof || iter->max_tid > iter->tid || (iter->max_tid == iter->tid && iter->max_pos > iter->pos)) {
         int n_plp = 0;
         // write iter->plp at iter->pos
@@ -1947,7 +1947,7 @@ const bam_pileup1_t *bam_plp_next(bam_plp_t iter, int *_tid, int *_pos, int *_n_
                 fprintf(stderr, "[%s] unsorted input. Pileup aborts.\n", __func__);
                 iter->error = 1;
                 *_n_plp = -1;
-                return 0;
+                return NULL;
             }
         }
         if (iter->tid < iter->head->b.core.tid) { // come to a new reference sequence
@@ -1959,7 +1959,7 @@ const bam_pileup1_t *bam_plp_next(bam_plp_t iter, int *_tid, int *_pos, int *_n_
         if (n_plp) return iter->plp;
         if (iter->is_eof && iter->head == iter->tail) break;
     }
-    return 0;
+    return NULL;
 }
 
 int bam_plp_push(bam_plp_t iter, const bam1_t *b)

--- a/sam.c
+++ b/sam.c
@@ -1510,6 +1510,7 @@ typedef struct __linkbuf_t {
     int32_t beg, end;
     cstate_t s;
     struct __linkbuf_t *next;
+    bam_pileup_cd cd;
 } lbnode_t;
 
 typedef struct {
@@ -1654,6 +1655,11 @@ struct __bam_plp_t {
     bam_plp_auto_f func;
     void *data;
     olap_hash_t *overlaps;
+
+    // For notification of creation and destruction events
+    // and associated client-owned pointer.
+    int (*plp_construct)(void *data, const bam1_t *b, bam_pileup_cd *cd);
+    int (*plp_destruct )(void *data, const bam1_t *b, bam_pileup_cd *cd);
 };
 
 bam_plp_t bam_plp_init(bam_plp_auto_f func, void *data)
@@ -1691,6 +1697,15 @@ void bam_plp_destroy(bam_plp_t iter)
     free(iter);
 }
 
+void bam_plp_constructor(bam_plp_t plp,
+                         int (*func)(void *data, const bam1_t *b, bam_pileup_cd *cd)) {
+    plp->plp_construct = func;
+}
+
+void bam_plp_destructor(bam_plp_t plp,
+                        int (*func)(void *data, const bam1_t *b, bam_pileup_cd *cd)) {
+    plp->plp_destruct = func;
+}
 
 //---------------------------------
 //---  Tweak overlapping reads
@@ -1908,6 +1923,8 @@ const bam_pileup1_t *bam_plp_next(bam_plp_t iter, int *_tid, int *_pos, int *_n_
             lbnode_t *p = *pptr;
             if (p->b.core.tid < iter->tid || (p->b.core.tid == iter->tid && p->end <= iter->pos)) { // then remove
                 overlap_remove(iter, &p->b);
+                if (iter->plp_destruct)
+                    iter->plp_destruct(iter->data, &p->b, &p->cd);
                 *pptr = p->next; mp_free(iter->mp, p);
             }
             else {
@@ -1917,6 +1934,7 @@ const bam_pileup1_t *bam_plp_next(bam_plp_t iter, int *_tid, int *_pos, int *_n_
                         iter->plp = (bam_pileup1_t*)realloc(iter->plp, sizeof(bam_pileup1_t) * iter->max_plp);
                     }
                     iter->plp[n_plp].b = &p->b;
+                    iter->plp[n_plp].cd = p->cd;
                     if (resolve_cigar2(iter->plp + n_plp, iter->pos, &p->s)) ++n_plp; // actually always true...
                 }
                 pptr = &(*pptr)->next;
@@ -1976,6 +1994,8 @@ int bam_plp_push(bam_plp_t iter, const bam1_t *b)
         }
         iter->max_tid = b->core.tid; iter->max_pos = iter->tail->beg;
         if (iter->tail->end > iter->pos || iter->tail->b.core.tid > iter->tid) {
+            if (iter->plp_construct)
+                iter->plp_construct(iter->data, b, &iter->tail->cd);
             iter->tail->next = mp_alloc(iter->mp);
             iter->tail = iter->tail->next;
         }
@@ -2112,6 +2132,20 @@ void bam_mplp_reset(bam_mplp_t iter)
         iter->n_plp[i] = 0;
         iter->plp[i] = NULL;
     }
+}
+
+void bam_mplp_constructor(bam_mplp_t iter,
+                          int (*func)(void *arg, const bam1_t *b, bam_pileup_cd *cd)) {
+    int i;
+    for (i = 0; i < iter->n; ++i)
+        bam_plp_constructor(iter->iter[i], func);
+}
+
+void bam_mplp_destructor(bam_mplp_t iter,
+                         int (*func)(void *arg, const bam1_t *b, bam_pileup_cd *cd)) {
+    int i;
+    for (i = 0; i < iter->n; ++i)
+        bam_plp_destructor(iter->iter[i], func);
 }
 
 #endif // ~!defined(BAM_NO_PILEUP)


### PR DESCRIPTION
This involves two main components.

1) Speeding up the probaln_glocal function to do less malloc/freeing, have better memory layout and to avoid so much cache pollution. (It still needs a lot of work there though.)

2) To add a callback mechanism to mpileup, permitting the caller to attach arbitrary additional information to pileup structs.  ABI breaking.

This is needed by my PR to the bcftools feature/mpileup branch.