### PR TITLE
Protect against sequences starting beyond reference end.

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1485,7 +1485,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
 	} else {
 	    s->hdr->ref_seq_id    = c->ref_id;
 	    s->hdr->ref_seq_start = first_base;
-	    s->hdr->ref_seq_span  = last_base - first_base + 1;
+	    s->hdr->ref_seq_span  = MAX(0, last_base - first_base + 1);
 	}
 	s->hdr->num_records = r2;
     }
@@ -2510,7 +2510,7 @@ void cram_update_curr_slice(cram_container *c) {
     } else {
 	s->hdr->ref_seq_id    = c->curr_ref;
 	s->hdr->ref_seq_start = c->first_base;
-	s->hdr->ref_seq_span  = c->last_base - c->first_base + 1;
+	s->hdr->ref_seq_span  = MAX(0, c->last_base - c->first_base + 1);
     }
     s->hdr->num_records   = c->curr_rec;
 


### PR DESCRIPTION
This was previously causing the slice reference md5sum to crash.

Fixes samtools/samtools#600, but note this perhaps isn't a perfect
fix.  The test data for that issue is broken, but ideally we should be
able to reproduce the broken input after round-tripping.  Currently we
lose track of MD/NM tags.

However making cram totally lossless even when faced with invalid data
is an issue for another date.

NOTE: the CRAM file produced here cannot be decoded by htsjdk (however it also couldn't turn the test BAM into CRAM either).  Perhaps it's just a case of garbage in, garbage out, but fixing a crash is nonetheless important.