### PR TITLE
Handle VCF lines with missing `FORMAT=.`

### DIFF
--- a/test/formatmissing-out.vcf
+++ b/test/formatmissing-out.vcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=1>
+##FORMAT=<ID=S,Number=1,Type=String,Description="Text">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3
+1	100	a	A	T	.	.	.	.	.	.	.

--- a/test/formatmissing.vcf
+++ b/test/formatmissing.vcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=1>
+##FORMAT=<ID=S,Number=1,Type=String,Description="Text">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3
+1	100	a	A	T	.	.	.	.	.	.	.

--- a/test/test.pl
+++ b/test/test.pl
@@ -311,6 +311,8 @@ sub test_vcf_various
         cmd => "$$opts{bin}/htsfile -c $$opts{path}/formatcols.vcf");
     test_cmd($opts, %args, out => "noroundtrip-out.vcf",
         cmd => "$$opts{bin}/htsfile -c $$opts{path}/noroundtrip.vcf");
+    test_cmd($opts, %args, out => "formatmissing-out.vcf",
+        cmd => "$$opts{bin}/htsfile -c $$opts{path}/formatmissing.vcf");
 }
 
 sub test_rebgzip

--- a/vcf.c
+++ b/vcf.c
@@ -1618,8 +1618,14 @@ static int vcf_parse_format(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v, char *p
         return -1;
     }
 
-    // get format information from the dictionary
     v->n_fmt = 0;
+    if ( p[0]=='.' && p[1]==0 ) // FORMAT field is empty "."
+    {
+        v->n_sample = bcf_hdr_nsamples(h);
+        return 0;
+    }
+
+    // get format information from the dictionary
     for (j = 0, t = kstrtok(p, ":", &aux1); t; t = kstrtok(0, 0, &aux1), ++j) {
         if (j >= MAX_N_FMT) {
             v->errcode |= BCF_ERR_LIMITS;
@@ -1630,6 +1636,12 @@ static int vcf_parse_format(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v, char *p
         *(char*)aux1.p = 0;
         k = kh_get(vdict, d, t);
         if (k == kh_end(d) || kh_val(d, k).info[BCF_HL_FMT] == 15) {
+            if ( t[0]=='.' && t[1]==0 )
+            {
+                fprintf(stderr, "[E::%s] Invalid FORMAT tag name '.'\n", __func__);
+                v->errcode |= BCF_ERR_TAG_INVALID;
+                return -1;
+            }
             if (hts_verbose >= 2) fprintf(stderr, "[W::%s] FORMAT '%s' is not defined in the header, assuming Type=String\n", __func__, t);
             kstring_t tmp = {0,0,0};
             int l;


### PR DESCRIPTION
For example, this is a valid VCF line

```
1	300	.	C	A	.	PASS	.	.	.	.
```

Previously this would emit a warning saying:
`[W::vcf_parse_format] FORMAT '.' is not defined in the header, assuming Type=String`
and internally we would have a new `FORMAT=.` tag.
This will now be recognised as missing.

htslib already writes out such lines when  `n_fmt == 0` and `n_samples > 0`

Mixing missing and non-missing FORMAT tags (e.g. `.:GT` or `GT:.:AD`) is not allowed.

See conversation in #409