### PR TITLE
Reworked knetfile to handle FTP authentication with credentials provi…

### DIFF
--- a/htslib/knetfile.h
+++ b/htslib/knetfile.h
@@ -60,6 +60,7 @@ typedef struct knetFile_s {
 
 	// the following are for HTTP only
 	char *path, *http_host;
+	char *user_cmd, *password_cmd;
 } knetFile;
 
 #define knet_tell(fp) ((fp)->offset)

--- a/knetfile.c
+++ b/knetfile.c
@@ -274,8 +274,8 @@ int kftp_connect(knetFile *ftp)
 	ftp->ctrl_fd = socket_connect(ftp->host, ftp->port);
 	if (ftp->ctrl_fd == -1) return -1;
 	kftp_get_response(ftp);
-	kftp_send_cmd(ftp, "USER anonymous\r\n", 1);
-	kftp_send_cmd(ftp, "PASS kftp@\r\n", 1);
+	kftp_send_cmd(ftp, ftp->user_cmd, 1);
+	kftp_send_cmd(ftp, ftp->password_cmd, 1);
 	kftp_send_cmd(ftp, "TYPE I\r\n", 1);
 	return 0;
 }
@@ -307,9 +307,38 @@ knetFile *kftp_parse_url(const char *fn, const char *mode)
 	/* the Linux/Mac version of socket_connect() also recognizes a port
 	 * like "ftp", but the Windows version does not. */
 	fp->port = strdup("21");
-	fp->host = (char*)calloc(l + 1, 1);
 	if (strchr(mode, 'c')) fp->no_reconnect = 1;
-	strncpy(fp->host, fn + 6, l);
+
+	char* host_with_creds = (char*) calloc(l + 1, 1);
+	strncpy(host_with_creds, fn + 6, l);
+
+	char* host_only;
+	char* uname;
+	char* pwd;
+	if ((host_only = strstr(host_with_creds, "@")) != NULL) {
+		int l_host = host_with_creds - host_only + l - 1;
+		fp->host = (char*) calloc(l_host + 1, 1);
+		strncpy(fp->host, host_only + 1, l_host);
+		*host_only = '\0';
+		uname = host_with_creds;
+		char* pwd_token;
+		if ((pwd_token = strstr(host_with_creds, ":")) != NULL) {
+			*pwd_token = '\0';
+			pwd = pwd_token + 1;
+		} else {
+			pwd = "";
+		}
+
+	} else {
+		uname = "anonymous";
+		pwd = "kftp@";
+		fp->host = host_with_creds;
+	}
+	fp->user_cmd = (char*) calloc(strlen(uname) + 8, 1);
+	sprintf(fp->user_cmd, "USER %s\r\n", uname); // "USER anonymous\r\n"
+	fp->password_cmd = (char*) calloc(strlen(pwd) + 8, 1);
+	sprintf(fp->password_cmd, "PASS %s\r\n", pwd); // "PASS kftp@\r\n"
+
 	fp->retr = (char*)calloc(strlen(p) + 8, 1);
 	sprintf(fp->retr, "RETR %s\r\n", p);
     fp->size_cmd = (char*)calloc(strlen(p) + 8, 1);


### PR DESCRIPTION
As of now, samtools (and other htslib-based tools) could use only anonymous ftp access, since that was hardcoded in knetfile.c. This change allows parsing username and password from FTP URL (ftp://username:password@ftp.address/filename). If no username and password is provided, new version falls back to anonymous connection. If only username is provided, it attempts to connect with that username and empty password. Tested OK under CentOS 7.
