### PR TITLE
Fix undefined PTHREAD_MUTEX_RECURSIVE compilation error

### DIFF
--- a/thread_pool.c
+++ b/thread_pool.c
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <config.h>
 #endif
 
+#define _XOPEN_SOURCE 700 // for PTHREAD_MUTEX_RECURSIVE
 #include <stdlib.h>
 #include <inttypes.h>
 #include <signal.h>


### PR DESCRIPTION
A portable (POSIX) way to address issue https://github.com/samtools/htslib/issues/420 , which I have also observed in the Cray Linux Environment (based on SuSE 11.3) is to define _XOPEN_SOURCE 700 at the top of the affected file.
