### PR TITLE
Cram bug fixes

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1031,6 +1031,7 @@ void cram_decode_estimate_sizes(cram_block_compression_hdr *hdr, cram_slice *s,
 
     /* Qual */
     cd = hdr->codecs[DS_QS];
+    if (cd == NULL) return;
     bnum1 = cram_codec_to_id(cd, &bnum2);
     if (bnum1 < 0 && bnum2 >= 0) bnum1 = bnum2;
     if (cram_ds_unique(hdr, cd, bnum1)) {
@@ -1042,6 +1043,7 @@ void cram_decode_estimate_sizes(cram_block_compression_hdr *hdr, cram_slice *s,
 
     /* Name */
     cd = hdr->codecs[DS_RN];
+    if (cd == NULL) return;
     bnum1 = cram_codec_to_id(cd, &bnum2);
     if (bnum1 < 0 && bnum2 >= 0) bnum1 = bnum2;
     if (cram_ds_unique(hdr, cd, bnum1)) {

--- a/cram/rANS_byte.h
+++ b/cram/rANS_byte.h
@@ -333,4 +333,18 @@ static inline void RansDecRenorm(RansState* r, uint8_t** pptr)
     *r = x;
 }
 
+// Renormalize, with extra checks for falling off the end of the input.
+static inline void RansDecRenormSafe(RansState* r, uint8_t** pptr, uint8_t *ptr_end)
+{
+    uint32_t x = *r;
+    uint8_t* ptr = *pptr;
+    if (x >= RANS_BYTE_L || ptr >= ptr_end) return;
+    x = (x << 8) | *ptr++;
+    if (x < RANS_BYTE_L && ptr < ptr_end)
+        x = (x << 8) | *ptr++;
+    *pptr = ptr;
+    *r = x;
+}
+
+
 #endif // RANS_BYTE_HEADER


### PR DESCRIPTION
Fixes a couple of problems detected during American Fuzzy Lop testing:

* cram_decode_estimate_sizes() would segfault if either the SQ or RN data series codecs were not defined.
* The rANS uncompressors could try to read beyond the end of the input data, for malformed inputs.
