### PR TITLE
Make hts_expand handle realloc failure a bit better.

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -2182,3 +2182,52 @@ hts_idx_t *hts_idx_load2(const char *fn, const char *fnidx)
 
     return hts_idx_load_local(fnidx);
 }
+
+
+
+/**********************
+ ***     Memory     ***
+ **********************/
+
+/* For use with hts_expand macros *only* */
+size_t hts_realloc_or_die(size_t n, size_t m, size_t m_sz, size_t size,
+                          int clear, void **ptr, const char *func) {
+    /* If new_m and size are both below this limit, multiplying them
+       together can't overflow */
+    const size_t safe = (size_t) 1 << (sizeof(size_t) * 4);
+    void *new_ptr;
+    size_t bytes, new_m;
+
+    new_m = n;
+    kroundup_size_t(new_m);
+
+    bytes = size * new_m;
+
+    /* Check for overflow.  Both ensure that new_m will fit in m (we make the
+       pessimistic assumption that m is signed), and that bytes has not
+       wrapped around. */
+    if (new_m > ((1 << (m_sz * 8 - 1)) - 1)
+        || ((size > safe || new_m > safe)
+            && bytes / new_m != size)) {
+        errno = ENOMEM;
+        goto die;
+    }
+
+    new_ptr = realloc(*ptr, bytes);
+    if (new_ptr == NULL) goto die;
+
+    if (clear) {
+        if (new_m > m) {
+            memset((char *) new_ptr + m * size, 0, (new_m - m) * size);
+        }
+    }
+
+    *ptr = new_ptr;
+
+    return new_m;
+
+ die:
+    if (hts_verbose > 1)
+        fprintf(stderr, "[E::%s] %s\n", func, strerror(errno));
+    exit(1);
+}


### PR DESCRIPTION
The hts_expand() and hts_expand0() macros don't return a value, and will
set (ptr) to NULL if realloc fails.  This could lead to segmentation faults
if callers don't check the value of (ptr).  As few if any do, and some
callers are in external packages, the best solution is to make the
hts_expand macros print an error message and call exit(1).

It's not ideal behaviour for library code, but fixing this in any other
way is just too hard.

This implementation removes the assumption that (m) and (n) are of type
int.  It should work with any integer type no bigger than size_t.