### PR TITLE
Add a kputd for %g specialisation

### DIFF
--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -82,6 +82,7 @@ extern "C" {
 
 	int kvsprintf(kstring_t *s, const char *fmt, va_list ap) KS_ATTR_PRINTF(2,0);
 	int ksprintf(kstring_t *s, const char *fmt, ...) KS_ATTR_PRINTF(2,3);
+    int kputd(kstring_t *s, double d); // custom %g only handler
 	int ksplit_core(char *s, int delimiter, int *_max, int **_offsets);
 	char *kstrstr(const char *str, const char *pat, int **_prep);
 	char *kstrnstr(const char *str, const char *pat, int n, int **_prep);

--- a/kstring.c
+++ b/kstring.c
@@ -57,7 +57,7 @@ int kputd(kstring_t *s, double d) {
 		// We let stdio handle the exponent cases
 		int s2 = sprintf(s->s + s->l, "%g", d);
 		len += s2;
-		s->l += len;
+		s->l += s2;
 		return len;
 	}
 

--- a/sam.c
+++ b/sam.c
@@ -1231,7 +1231,7 @@ int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str)
                 else if ('S' == sub_type) { kputw(*(uint16_t*)s, str); s += 2; }
                 else if ('i' == sub_type) { kputw(*(int32_t*)s, str); s += 4; }
                 else if ('I' == sub_type) { kputuw(*(uint32_t*)s, str); s += 4; }
-                else if ('f' == sub_type) { ksprintf(str, "%g", *(float*)s); s += 4; }
+                else if ('f' == sub_type) { kputd(str, *(float*)s); s += 4; }
                 else return -1;
             }
         }

--- a/vcf.c
+++ b/vcf.c
@@ -1764,7 +1764,7 @@ void bcf_fmt_array(kstring_t *s, int n, int type, void *data)
             case BCF_BT_INT8:  BRANCH(int8_t,  p[j]==bcf_int8_missing,  p[j]==bcf_int8_vector_end,  kputw(p[j], s)); break;
             case BCF_BT_INT16: BRANCH(int16_t, p[j]==bcf_int16_missing, p[j]==bcf_int16_vector_end, kputw(p[j], s)); break;
             case BCF_BT_INT32: BRANCH(int32_t, p[j]==bcf_int32_missing, p[j]==bcf_int32_vector_end, kputw(p[j], s)); break;
-            case BCF_BT_FLOAT: BRANCH(float,   bcf_float_is_missing(p[j]), bcf_float_is_vector_end(p[j]), ksprintf(s, "%g", p[j])); break;
+            case BCF_BT_FLOAT: BRANCH(float,   bcf_float_is_missing(p[j]), bcf_float_is_vector_end(p[j]), kputd(s, p[j])); break;
             default: fprintf(stderr,"todo: type %d\n", type); exit(1); break;
         }
         #undef BRANCH
@@ -2398,7 +2398,7 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
     } else kputc('.', s);
     kputc('\t', s); // QUAL
     if ( bcf_float_is_missing(v->qual) ) kputc('.', s); // QUAL
-    else ksprintf(s, "%g", v->qual);
+    else kputd(s, v->qual);
     kputc('\t', s); // FILTER
     if (v->d.n_flt) {
         for (i = 0; i < v->d.n_flt; ++i) {
@@ -2424,7 +2424,7 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
                     case BCF_BT_INT8:  if ( z->v1.i==bcf_int8_missing ) kputc('.', s); else kputw(z->v1.i, s); break;
                     case BCF_BT_INT16: if ( z->v1.i==bcf_int16_missing ) kputc('.', s); else kputw(z->v1.i, s); break;
                     case BCF_BT_INT32: if ( z->v1.i==bcf_int32_missing ) kputc('.', s); else kputw(z->v1.i, s); break;
-                    case BCF_BT_FLOAT: if ( bcf_float_is_missing(z->v1.f) ) kputc('.', s); else ksprintf(s, "%g", z->v1.f); break;
+                    case BCF_BT_FLOAT: if ( bcf_float_is_missing(z->v1.f) ) kputc('.', s); else kputd(s, z->v1.f); break;
                     case BCF_BT_CHAR:  kputc(z->v1.i, s); break;
                     default: fprintf(stderr,"todo: type %d\n", z->type); exit(1); break;
                 }


### PR DESCRIPTION
Update to PR #395 from @jkbonfield to speed up `ksprintf(s,"%g",val)`. See discussion there.

Squashes those commits, reverts the addition of trailing `.` for whole floating point numbers. Also fixes a small bug for negative exponential values.