### PR TITLE
Fix undefined behaviour and improve endian-related behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ lib*.so.*
 /tabix
 /test/fieldarith
 /test/hfile
+/test/hts_endian
 /test/sam
 /test/test-regidx
 /test/test-vcf-api

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ BUILT_PROGRAMS = \
 	tabix
 
 BUILT_TEST_PROGRAMS = \
+	test/hts_endian \
 	test/fieldarith \
 	test/hfile \
 	test/sam \
@@ -185,7 +186,8 @@ PLUGIN_OBJS =
 
 cram_h = cram/cram.h $(cram_samtools_h) $(cram_sam_header_h) $(cram_structs_h) $(cram_io_h) cram/cram_encode.h cram/cram_decode.h cram/cram_stats.h cram/cram_codecs.h cram/cram_index.h $(htslib_cram_h)
 cram_io_h = cram/cram_io.h $(cram_misc_h)
-cram_misc_h = cram/misc.h cram/os.h
+cram_misc_h = cram/misc.h $(cram_os_h)
+cram_os_h = cram/os.h $(htslib_hts_endian_h)
 cram_sam_header_h = cram/sam_header.h cram/string_alloc.h cram/pooled_alloc.h $(htslib_khash_h) $(htslib_kstring_h)
 cram_samtools_h = cram/cram_samtools.h $(htslib_sam_h) $(cram_sam_header_h)
 cram_structs_h = cram/cram_structs.h $(htslib_thread_pool_h) cram/string_alloc.h $(htslib_khash_h)
@@ -302,23 +304,23 @@ realn.o realn.pico: realn.c config.h $(htslib_hts_h) $(htslib_sam_h)
 textutils.o textutils.pico: textutils.c config.h $(htslib_hfile_h) $(htslib_kstring_h) $(hts_internal_h)
 
 cram/cram_codecs.o cram/cram_codecs.pico: cram/cram_codecs.c config.h $(cram_h)
-cram/cram_decode.o cram/cram_decode.pico: cram/cram_decode.c config.h $(cram_h) cram/os.h $(htslib_hts_h)
-cram/cram_encode.o cram/cram_encode.pico: cram/cram_encode.c config.h $(cram_h) cram/os.h $(htslib_hts_h)
+cram/cram_decode.o cram/cram_decode.pico: cram/cram_decode.c config.h $(cram_h) $(cram_os_h) $(htslib_hts_h)
+cram/cram_encode.o cram/cram_encode.pico: cram/cram_encode.c config.h $(cram_h) $(cram_os_h) $(htslib_hts_h) $(htslib_hts_endian_h)
 cram/cram_external.o cram/cram_external.pico: cram/cram_external.c config.h $(htslib_hfile_h) $(cram_h)
-cram/cram_index.o cram/cram_index.pico: cram/cram_index.c config.h $(htslib_hfile_h) $(hts_internal_h) $(cram_h) cram/os.h cram/zfio.h
-cram/cram_io.o cram/cram_io.pico: cram/cram_io.c config.h $(cram_h) cram/os.h $(htslib_hts_h) $(cram_open_trace_file_h) cram/rANS_static.h $(htslib_hfile_h) $(htslib_bgzf_h) $(htslib_faidx_h) $(hts_internal_h)
+cram/cram_index.o cram/cram_index.pico: cram/cram_index.c config.h $(htslib_hfile_h) $(hts_internal_h) $(cram_h) $(cram_os_h) cram/zfio.h
+cram/cram_io.o cram/cram_io.pico: cram/cram_io.c config.h $(cram_h) $(cram_os_h) $(htslib_hts_h) $(cram_open_trace_file_h) cram/rANS_static.h $(htslib_hfile_h) $(htslib_bgzf_h) $(htslib_faidx_h) $(hts_internal_h)
 cram/cram_samtools.o cram/cram_samtools.pico: cram/cram_samtools.c config.h $(cram_h) $(htslib_sam_h)
-cram/cram_stats.o cram/cram_stats.pico: cram/cram_stats.c config.h $(cram_h) cram/os.h
+cram/cram_stats.o cram/cram_stats.pico: cram/cram_stats.c config.h $(cram_h) $(cram_os_h)
 cram/files.o cram/files.pico: cram/files.c config.h $(cram_misc_h)
-cram/mFILE.o cram/mFILE.pico: cram/mFILE.c config.h cram/os.h cram/mFILE.h cram/vlen.h
-cram/open_trace_file.o cram/open_trace_file.pico: cram/open_trace_file.c config.h cram/os.h $(cram_open_trace_file_h) $(cram_misc_h) $(htslib_hfile_h)
+cram/mFILE.o cram/mFILE.pico: cram/mFILE.c config.h $(cram_os_h) cram/mFILE.h cram/vlen.h
+cram/open_trace_file.o cram/open_trace_file.pico: cram/open_trace_file.c config.h $(cram_os_h) $(cram_open_trace_file_h) $(cram_misc_h) $(htslib_hfile_h)
 cram/pooled_alloc.o cram/pooled_alloc.pico: cram/pooled_alloc.c config.h cram/pooled_alloc.h $(cram_misc_h)
 cram/rANS_static.o cram/rANS_static.pico: cram/rANS_static.c config.h cram/rANS_static.h cram/rANS_byte.h
 cram/sam_header.o cram/sam_header.pico: cram/sam_header.c config.h $(cram_sam_header_h) cram/string_alloc.h
 cram/string_alloc.o cram/string_alloc.pico: cram/string_alloc.c config.h cram/string_alloc.h
 thread_pool.o thread_pool.pico: thread_pool.c config.h $(thread_pool_internal_h)
-cram/vlen.o cram/vlen.pico: cram/vlen.c config.h cram/vlen.h cram/os.h
-cram/zfio.o cram/zfio.pico: cram/zfio.c config.h cram/os.h cram/zfio.h
+cram/vlen.o cram/vlen.pico: cram/vlen.c config.h cram/vlen.h $(cram_os_h)
+cram/zfio.o cram/zfio.pico: cram/zfio.c config.h $(cram_os_h) cram/zfio.h
 
 
 bgzip: bgzip.o libhts.a
@@ -338,11 +340,15 @@ tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htsl
 # For tests that might use it, set $REF_PATH explicitly to use only reference
 # areas within the test suite (or set it to ':' to use no reference areas).
 check test: bgzip htsfile $(BUILT_TEST_PROGRAMS)
+	test/hts_endian
 	test/fieldarith test/fieldarith.sam
 	test/hfile
 	REF_PATH=: test/sam test/ce.fa test/faidx.fa
 	test/test-regidx
 	cd test && REF_PATH=: ./test.pl
+
+test/hts_endian: test/hts_endian.o
+	$(CC) $(LDFLAGS) -o $@ test/hts_endian.o $(LIBS)
 
 test/fieldarith: test/fieldarith.o libhts.a
 	$(CC) -pthread $(LDFLAGS) -o $@ test/fieldarith.o libhts.a -lz $(LIBS)
@@ -365,6 +371,7 @@ test/test-vcf-api: test/test-vcf-api.o libhts.a
 test/test-vcf-sweep: test/test-vcf-sweep.o libhts.a
 	$(CC) -pthread $(LDFLAGS) -o $@ test/test-vcf-sweep.o libhts.a -lz $(LIBS)
 
+test/hts_endian.o: test/hts_endian.c $(htslib_hts_endian_h)
 test/fieldarith.o: test/fieldarith.c config.h $(htslib_sam_h)
 test/hfile.o: test/hfile.c config.h $(htslib_hfile_h) $(htslib_hts_defs_h)
 test/sam.o: test/sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for htslib, a C library for high-throughput sequencing data formats.
 #
-#    Copyright (C) 2013-2016 Genome Research Ltd.
+#    Copyright (C) 2013-2017 Genome Research Ltd.
 #
 #    Author: John Marshall <jm18@sanger.ac.uk>
 #
@@ -287,8 +287,8 @@ hfile_libcurl.o hfile_libcurl.pico: hfile_libcurl.c config.h $(hfile_internal_h)
 hfile_net.o hfile_net.pico: hfile_net.c config.h $(hfile_internal_h) $(htslib_knetfile_h)
 hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hts_internal_h) $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
 hts.o hts.pico: hts.c config.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) version.h $(hts_internal_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h)
-vcf.o vcf.pico: vcf.c config.h $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_hfile_h) $(hts_internal_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_khash_h) $(htslib_kseq_h)
-sam.o sam.pico: sam.c config.h $(htslib_sam_h) $(htslib_bgzf_h) $(cram_h) $(hts_internal_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_kstring_h)
+vcf.o vcf.pico: vcf.c config.h $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_hfile_h) $(hts_internal_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_hts_endian_h)
+sam.o sam.pico: sam.c config.h $(htslib_sam_h) $(htslib_bgzf_h) $(cram_h) $(hts_internal_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_kstring_h) $(htslib_hts_endian_h)
 tbx.o tbx.pico: tbx.c config.h $(htslib_tbx_h) $(htslib_bgzf_h) $(hts_internal_h) $(htslib_khash_h)
 faidx.o faidx.pico: faidx.c config.h $(htslib_bgzf_h) $(htslib_faidx_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kstring_h) $(hts_internal_h)
 synced_bcf_reader.o synced_bcf_reader.pico: synced_bcf_reader.c config.h $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) $(htslib_bgzf_h) $(htslib_thread_pool_h)
@@ -296,7 +296,7 @@ vcf_sweep.o vcf_sweep.pico: vcf_sweep.c config.h $(htslib_vcf_sweep_h) $(htslib_
 vcfutils.o vcfutils.pico: vcfutils.c config.h $(htslib_vcfutils_h) $(htslib_kbitset_h)
 kfunc.o kfunc.pico: kfunc.c config.h $(htslib_kfunc_h)
 regidx.o regidx.pico: regidx.c config.h $(htslib_hts_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) $(htslib_regidx_h) $(hts_internal_h)
-md5.o md5.pico: md5.c config.h $(htslib_hts_h)
+md5.o md5.pico: md5.c config.h $(htslib_hts_h) $(htslib_hts_endian_h)
 multipart.o multipart.pico: multipart.c config.h $(htslib_kstring_h) $(hts_internal_h) $(hfile_internal_h)
 plugin.o plugin.pico: plugin.c config.h $(hts_internal_h) $(htslib_kstring_h)
 probaln.o probaln.pico: probaln.c config.h $(htslib_hts_h)

--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,9 @@ Noteworthy changes in release 1.4
     and (along with bam1_t) so that CIGAR entries are aligned in memory
   - hopen() has vararg arguments for setting URL scheme-dependent options
   - the various tbx_conf_* presets are now const
+  - auxiliary fields in bam1_t are now always stored in little-endian byte
+    order (previously this depended on if you read a bam, sam or cram file)
+  - bam_aux2i() now returns an int64_t value
 
 * New errmod_cal(), probaln_glocal(), sam_cap_mapq(), and sam_prob_realn()
   functions, previously internal to SAMtools, have been added to HTSlib.
@@ -35,6 +38,14 @@ Noteworthy changes in release 1.4
 
 * APIs to portably read and write (possibly unaligned) data in little-endian
   byte order have been added.
+
+* New functions bam_auxB_len(), bam_auxB2i() and bam_auxB2f() have been
+  added to make accessing array-type auxiliary data easier.  bam_aux2i()
+  can now return the full range of values that can be stored in an integer
+  tag (including unsigned 32 bit tags).  bam_aux2f() will return the value
+  of integer tags (as a double) as well as floating-point ones.  All of
+  the bam_aux2 and bam_auxB2 functions will set errno if the requested
+  conversion is not valid.
 
 Noteworthy changes in release 1.3.2  (13 September 2016)
 

--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,8 @@ Noteworthy changes in release 1.4
   Configure no longer has a --with-irods option; instead build the plugin
   found at <https://github.com/samtools/htslib-plugins>.
 
+* APIs to portably read and write (possibly unaligned) data in little-endian
+  byte order have been added.
 
 Noteworthy changes in release 1.3.2  (13 September 2016)
 

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cram/cram.h"
 #include "cram/os.h"
 #include "htslib/hts.h"
+#include "htslib/hts_endian.h"
 
 KHASH_MAP_INIT_STR(m_s2u64, uint64_t)
 
@@ -2598,8 +2599,8 @@ static int process_one_read(cram_fd *fd, cram_container *c,
     seq = cp = (char *)BLOCK_END(s->seqs_blk);
 
     *seq = 0;
+#if HTS_ALLOW_UNALIGNED != 0
     {
-#ifdef ALLOW_UAC
 	// Convert seq 2 bases at a time for speed.
 	static const uint16_t code2base[256] = {
 	    15677, 16701, 17213, 19773, 18237, 21053, 21309, 22077,

--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -128,10 +128,11 @@ static inline int safe_itf8_get(const char *cp, const char *endp,
         *val_p = ((up[0]<<16) | (up[1]<< 8) |  up[2])             & 0x1fffff;
         return 3;
     } else if (up[0] < 0xf0) {
-        *val_p = ((up[0]<<24) | (up[1]<<16) | (up[2]<<8) | up[3]) & 0x0fffffff;
+        *val_p = (((uint32_t)up[0]<<24) | (up[1]<<16) | (up[2]<<8) | up[3]) & 0x0fffffff;
         return 4;
     } else {
-        *val_p = ((up[0] & 0x0f)<<28) | (up[1]<<20) | (up[2]<<12) | (up[3]<<4) | (up[4] & 0x0f);
+        uint32_t uv = (((uint32_t)up[0] & 0x0f)<<28) | (up[1]<<20) | (up[2]<<12) | (up[3]<<4) | (up[4] & 0x0f);
+        *val_p = uv < 0x80000000UL ? uv : -((int32_t) (0xffffffffUL - uv)) - 1;
         return 5;
     }
 }

--- a/cram/cram_samtools.c
+++ b/cram/cram_samtools.c
@@ -108,7 +108,7 @@ int bam_construct_seq(bam_seq_t **bp, size_t extra_len,
     for (i = 0; i < qname_nuls; i++)
 	cp[qname_len+i] = '\0';
     cp += qname_len+qname_nuls;
-    memcpy(cp, cigar, ncigar*4);
+    if (ncigar > 0) memcpy(cp, cigar, ncigar*4);
     cp += ncigar*4;
 
     for (i = 0; i+1 < len; i+=2) {

--- a/htslib.mk
+++ b/htslib.mk
@@ -53,6 +53,7 @@ HTSLIB_PUBLIC_HEADERS = \
 	$(HTSDIR)/htslib/hfile.h \
 	$(HTSDIR)/htslib/hts.h \
 	$(HTSDIR)/htslib/hts_defs.h \
+	$(HTSDIR)/htslib/hts_endian.h \
 	$(HTSDIR)/htslib/kbitset.h \
 	$(HTSDIR)/htslib/kfunc.h \
 	$(HTSDIR)/htslib/khash.h \

--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -1,6 +1,6 @@
 /*  hts_defs.h -- Miscellaneous definitions.
 
-    Copyright (C) 2013-2015 Genome Research Ltd.
+    Copyright (C) 2013-2015,2017 Genome Research Ltd.
 
     Author: John Marshall <jm18@sanger.ac.uk>
 
@@ -67,6 +67,12 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_DEPRECATED(message) __attribute__ ((__deprecated__))
 #else
 #define HTS_DEPRECATED(message)
+#endif
+
+#if HTS_COMPILER_HAS(__format__) || HTS_GCC_AT_LEAST(3,0)
+#define HTS_FORMAT(type, idx, first) __attribute__((__format__ (type, idx, first)))
+#else
+#define HTS_FORMAT(type, idx, first)
 #endif
 
 #endif

--- a/htslib/hts_endian.h
+++ b/htslib/hts_endian.h
@@ -1,0 +1,354 @@
+/// @file hts_endian.h
+/// Byte swapping and unaligned access functions.
+/*
+   Copyright (C) 2017 Genome Research Ltd.
+
+    Author: Rob Davies <rmd@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#ifndef HTS_ENDIAN_H
+#define HTS_ENDIAN_H
+
+#include <stdint.h>
+
+/*
+ * Compile-time endianness tests.
+ *
+ * Note that these tests may fail.  They should only be used to enable
+ * faster versions of endian-neutral implementations.  The endian-neutral
+ * version should always be available as a fall-back.
+ *
+ * See https://sourceforge.net/p/predef/wiki/Endianness/
+ */
+
+/* Save typing as both endian and unaligned tests want to know about x86 */
+#if (defined(__i386__) || defined(__i386) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(__i686__) || defined(__i686)) && !defined(HTS_x86)
+#    define HTS_x86  /* x86 and x86_64 platform */
+#endif
+
+/** @def HTS_LITTLE_ENDIAN
+ *  @brief Defined if platform is known to be little-endian
+ */
+
+#ifndef HTS_LITTLE_ENDIAN
+#    if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) \
+      || defined(__LITTLE_ENDIAN__) \
+      || defined(HTS_x86) \
+      || defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) \
+      || defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__)
+#        define HTS_LITTLE_ENDIAN
+#    endif
+#endif
+
+/** @def HTS_BIG_ENDIAN
+ *  @brief Defined if platform is known to be big-endian
+ */
+
+#ifndef HTS_BIG_ENDIAN
+#    if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) \
+      || defined(__BIG_ENDIAN__) \
+      || defined(__ARMEB__) || defined(__THUMBEB__) || defined(__AAARCHEB__) \
+      || defined(_MIPSEB) || defined(__MIPSEB) || defined(__MIPSEB__)
+#        define HTS_BIG_ENDIAN
+#    endif
+#endif
+
+/** @def HTS_ENDIAN_NEUTRAL
+ *  @brief Define this to disable any endian-specific optimizations
+ */
+
+#if defined(HTS_ENDIAN_NEUTRAL) || (defined(HTS_LITTLE_ENDIAN) && defined(HTS_BIG_ENDIAN))
+/* Disable all endian-specific code. */
+#    undef HTS_LITTLE_ENDIAN
+#    undef HTS_BIG_ENDIAN
+#endif
+
+/** @def HTS_ALLOW_UNALIGNED
+ *  @brief Control use of unaligned memory access.
+ * 
+ * Defining HTS_ALLOW_UNALIGNED=1 converts shift-and-or to simple casts on
+ * little-endian platforms that can tolerate unaligned access (notably Intel
+ * x86).
+ *
+ * Defining HTS_ALLOW_UNALIGNED=0 forces shift-and-or.
+ */
+
+// Consider using AX_CHECK_ALIGNED_ACCESS_REQUIRED in autoconf.
+#ifndef HTS_ALLOW_UNALIGNED
+#    if defined(HTS_x86)
+#        define HTS_ALLOW_UNALIGNED 1
+#    else
+#        define HTS_ALLOW_UNALIGNED 0
+#    endif
+#endif
+
+#if HTS_ALLOW_UNALIGNED != 0
+#    if defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+// This prevents problems with gcc's vectoriser generating the wrong
+// instructions for unaligned data.
+typedef uint16_t uint16_u __attribute__ ((__aligned__ (1)));
+typedef uint32_t uint32_u __attribute__ ((__aligned__ (1)));
+typedef uint64_t uint64_u __attribute__ ((__aligned__ (1)));
+#else
+typedef uint16_t uint16_u;
+typedef uint32_t uint32_u;
+typedef uint64_t uint64_u;
+#    endif
+#endif
+
+/// Get a uint16_t value from an unsigned byte array
+/** @param buf Pointer to source byte, may be unaligned
+ *  @return A 16 bit unsigned integer
+ *  The input is read in little-endian byte order.
+ */
+static inline uint16_t le_to_u16(const uint8_t *buf) {
+#if defined(HTS_LITTLE_ENDIAN) && HTS_ALLOW_UNALIGNED != 0
+    return *((uint16_u *) buf);
+#else
+    return (uint16_t) buf[0] | ((uint16_t) buf[1] << 8);
+#endif
+}
+
+/// Get a uint32_t value from an unsigned byte array
+/** @param buf Pointer to source byte array, may be unaligned
+ *  @return A 32 bit unsigned integer
+ *  The input is read in little-endian byte order.
+ */
+static inline uint32_t le_to_u32(const uint8_t *buf) {
+#if defined(HTS_LITTLE_ENDIAN) && HTS_ALLOW_UNALIGNED != 0
+    return *((uint32_u *) buf);
+#else
+    return ((uint32_t) buf[0] |
+            ((uint32_t) buf[1] << 8) | 
+            ((uint32_t) buf[2] << 16) |
+            ((uint32_t) buf[3] << 24));
+#endif
+}
+
+/// Get a uint64_t value from an unsigned byte array
+/** @param buf Pointer to source byte array, may be unaligned
+ *  @return A 64 bit unsigned integer
+ *  The input is read in little-endian byte order.
+ */
+static inline uint64_t le_to_u64(const uint8_t *buf) {
+#if defined(HTS_LITTLE_ENDIAN) && HTS_ALLOW_UNALIGNED != 0
+    return *((uint64_u *) buf);
+#else
+    return ((uint64_t) buf[0] |
+            ((uint64_t) buf[1] << 8) |
+            ((uint64_t) buf[2] << 16) |
+            ((uint64_t) buf[3] << 24) |
+            ((uint64_t) buf[4] << 32) |
+            ((uint64_t) buf[5] << 40) |
+            ((uint64_t) buf[6] << 48) |
+            ((uint64_t) buf[7] << 56));
+#endif
+}
+
+/// Store a uint16_t value in little-endian byte order
+/** @param val The value to store
+ *  @param buf Where to store it (may be unaligned)
+ */
+static inline void u16_to_le(uint16_t val, uint8_t *buf) {
+#if defined(HTS_LITTLE_ENDIAN) && HTS_ALLOW_UNALIGNED != 0
+    *((uint16_u *) buf) = val;
+#else
+    buf[0] = val & 0xff;
+    buf[1] = (val >> 8) & 0xff;
+#endif
+}
+
+/// Store a uint32_t value in little-endian byte order
+/** @param val The value to store
+ *  @param buf Where to store it (may be unaligned)
+ */
+static inline void u32_to_le(uint32_t val, uint8_t *buf) {
+#if defined(HTS_LITTLE_ENDIAN) && HTS_ALLOW_UNALIGNED != 0
+    *((uint32_u *) buf) = val;
+#else
+    buf[0] = val & 0xff;
+    buf[1] = (val >> 8) & 0xff;
+    buf[2] = (val >> 16) & 0xff;
+    buf[3] = (val >> 24) & 0xff;
+#endif
+}
+
+/// Store a uint64_t value in little-endian byte order
+/** @param val The value to store
+ *  @param buf Where to store it (may be unaligned)
+ */
+static inline void u64_to_le(uint64_t val, uint8_t *buf) {
+#if defined(HTS_LITTLE_ENDIAN) && HTS_ALLOW_UNALIGNED != 0
+    *((uint64_u *) buf) = val;
+#else
+    buf[0] = val & 0xff;
+    buf[1] = (val >> 8) & 0xff;
+    buf[2] = (val >> 16) & 0xff;
+    buf[3] = (val >> 24) & 0xff;
+    buf[4] = (val >> 32) & 0xff;
+    buf[5] = (val >> 40) & 0xff;
+    buf[6] = (val >> 48) & 0xff;
+    buf[7] = (val >> 56) & 0xff;
+#endif
+}
+
+/* Signed values.  Grab the data as unsigned, then convert to signed without
+ * triggering undefined behaviour.  On any sensible platform, the conversion
+ * should optimise away to nothing.
+ */
+
+/// Get an int8_t value from an unsigned byte array
+/** @param buf Pointer to source byte array, may be unaligned
+ *  @return A 8 bit signed integer
+ *  The input data is interpreted as 2's complement representation.
+ */
+static inline int8_t le_to_i8(const uint8_t *buf) {
+    return *buf < 0x80 ? *buf : -((int8_t) (0xff - *buf)) - 1;
+}
+
+/// Get an int16_t value from an unsigned byte array
+/** @param buf Pointer to source byte array, may be unaligned
+ *  @return A 16 bit signed integer
+ *  The input data is interpreted as 2's complement representation in
+ *  little-endian byte order.
+ */
+static inline int16_t le_to_i16(const uint8_t *buf) {
+    uint16_t v = le_to_u16(buf);
+    return v < 0x8000 ? v : -((int16_t) (0xffff - v)) - 1;
+}
+
+/// Get an int32_t value from an unsigned byte array
+/** @param buf Pointer to source byte array, may be unaligned
+ *  @return A 32 bit signed integer
+ *  The input data is interpreted as 2's complement representation in
+ *  little-endian byte order.
+ */
+static inline int32_t le_to_i32(const uint8_t *buf) {
+    uint32_t v = le_to_u32(buf);
+    return v < 0x80000000U ? v : -((int32_t) (0xffffffffU - v)) - 1;
+}
+
+/// Get an int64_t value from an unsigned byte array
+/** @param buf Pointer to source byte array, may be unaligned
+ *  @return A 64 bit signed integer
+ *  The input data is interpreted as 2's complement representation in
+ *  little-endian byte order.
+ */
+static inline int64_t le_to_i64(const uint8_t *buf) {
+    uint64_t v = le_to_u64(buf);
+    return (v < 0x8000000000000000ULL
+            ? v : -((int64_t) (0xffffffffffffffffULL - v)) - 1);
+}
+
+// Converting the other way is easier as signed -> unsigned is well defined.
+
+/// Store a uint16_t value in little-endian byte order
+/** @param val The value to store
+ *  @param buf Where to store it (may be unaligned)
+ */
+static inline void i16_to_le(int16_t val, uint8_t *buf) {
+    u16_to_le(val, buf);
+}
+
+/// Store a uint32_t value in little-endian byte order
+/** @param val The value to store
+ *  @param buf Where to store it (may be unaligned)
+ */
+static inline void i32_to_le(int32_t val, uint8_t *buf) {
+    u32_to_le(val, buf);
+}
+
+/// Store a uint64_t value in little-endian byte order
+/** @param val The value to store
+ *  @param buf Where to store it (may be unaligned)
+ */
+static inline void i64_to_le(int64_t val, uint8_t *buf) {
+    u64_to_le(val, buf);
+}
+
+/* Floating point.  Assumptions:
+ *  Platform uses IEEE 754 format
+ *  sizeof(float) == sizeof(uint32_t) 
+ *  sizeof(double) == sizeof(uint64_t)
+ *  Endian-ness is the same for both floating point and integer
+ *  Type-punning via a union is allowed
+ */
+
+/// Get a float value from an unsigned byte array
+/** @param buf Pointer to source byte array, may be unaligned
+ *  @return A 32 bit floating point value
+ *  The input is interpreted as an IEEE 754 format float in little-endian
+ *  byte order.
+ */
+static inline float le_to_float(const uint8_t *buf) {
+    union {
+        uint32_t u;
+        float   f;
+    } convert;
+
+    convert.u = le_to_u32(buf);
+    return convert.f;
+}
+
+/// Get a double value from an unsigned byte array
+/** @param buf Pointer to source byte array, may be unaligned
+ *  @return A 64 bit floating point value
+ *  The input is interpreted as an IEEE 754 format double in little-endian
+ *  byte order.
+ */
+static inline double le_to_double(const uint8_t *buf) {
+    union {
+        uint64_t u;
+        double   f;
+    } convert;
+
+    convert.u = le_to_u64(buf);
+    return convert.f;
+}
+
+/// Store a float value in little-endian byte order
+/** @param val The value to store
+ *  @param buf Where to store it (may be unaligned)
+ */
+static inline void float_to_le(float val, uint8_t *buf) {
+    union {
+        uint32_t u;
+        float f;
+    } convert;
+
+    convert.f = val;
+    u32_to_le(convert.u, buf);
+}
+
+/// Store a double value in little-endian byte order
+/** @param val The value to store
+ *  @param buf Where to store it (may be unaligned)
+ */
+static inline void double_to_le(double val, uint8_t *buf) {
+    union {
+        uint64_t u;
+        double f;
+    } convert;
+
+    convert.f = val;
+    u64_to_le(convert.u, buf);
+}
+
+#endif /* HTS_ENDIAN_H */

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -382,15 +382,98 @@ int sam_index_build3(const char *fn, const char *fnidx, int min_shift, int nthre
      *** Manipulating auxiliary fields ***
      *************************************/
 
-    uint8_t *bam_aux_get(const bam1_t *b, const char tag[2]);
-    int32_t bam_aux2i(const uint8_t *s);
-    double bam_aux2f(const uint8_t *s);
-    char bam_aux2A(const uint8_t *s);
-    char *bam_aux2Z(const uint8_t *s);
+/// Return a pointer to an aux record
+/** @param b   Pointer to the bam record
+    @param tag Desired aux tag
+    @return Pointer to the tag data, or NULL if tag is not present
+ */
+uint8_t *bam_aux_get(const bam1_t *b, const char tag[2]);
 
-    void bam_aux_append(bam1_t *b, const char tag[2], char type, int len, const uint8_t *data);
-    int bam_aux_del(bam1_t *b, uint8_t *s);
-    int bam_aux_update_str(bam1_t *b, const char tag[2], int len, const char *data);
+/// Get an integer aux value
+/** @param s Pointer to the tag data, as returned by bam_aux_get()
+    @return The value, or 0 if the tag was not an integer type
+    If the tag is not an integer type, errno is set to EINVAL.  This function
+    will not return the value of floating-point tags.
+*/
+int64_t bam_aux2i(const uint8_t *s);
+
+/// Get an integer aux value
+/** @param s Pointer to the tag data, as returned by bam_aux_get()
+    @return The value, or 0 if the tag was not an integer type
+    If the tag is not an numeric type, errno is set to EINVAL.  The value of
+    integer flags will be returned cast to a double.
+*/
+double bam_aux2f(const uint8_t *s);
+
+/// Get a character aux value
+/** @param s Pointer to the tag data, as returned by bam_aux_get().
+    @return The value, or 0 if the tag was not a character ('A') type
+    If the tag is not a character type, errno is set to EINVAL.
+*/
+char bam_aux2A(const uint8_t *s);
+
+/// Get a string aux value
+/** @param s Pointer to the tag data, as returned by bam_aux_get().
+    @return Pointer to the string, or NULL if the tag was not a string type
+    If the tag is not a string type ('Z' or 'H'), errno is set to EINVAL.
+*/
+char *bam_aux2Z(const uint8_t *s);
+
+/// Get the length of an array-type ('B') tag
+/** @param s Pointer to the tag data, as returned by bam_aux_get().
+    @return The length of the array, or 0 if the tag is not an array type.
+    If the tag is not an array type, errno is set to EINVAL.
+ */
+uint32_t bam_auxB_len(const uint8_t *s);
+
+/// Get an integer value from an array-type tag
+/** @param s   Pointer to the tag data, as returned by bam_aux_get().
+    @param idx 0-based Index into the array
+    @return The idx'th value, or 0 on error.
+    If the array is not an integer type, errno is set to EINVAL.  If idx
+    is greater than or equal to  the value returned by bam_auxB_len(s),
+    errno is set to ERANGE.  In both cases, 0 will be returned.    
+ */
+int64_t bam_auxB2i(const uint8_t *s, uint32_t idx);
+
+/// Get a floating-point value from an array-type tag
+/** @param s   Pointer to the tag data, as returned by bam_aux_get().
+    @param idx 0-based Index into the array
+    @return The idx'th value, or 0.0 on error.
+    If the array is not a numeric type, errno is set to EINVAL.  This can
+    only actually happen if the input record has an invalid type field.  If
+    idx is greater than or equal to  the value returned by bam_auxB_len(s),
+    errno is set to ERANGE.  In both cases, 0.0 will be returned.
+ */
+double bam_auxB2f(const uint8_t *s, uint32_t idx);
+
+/// Append tag data to a bam record
+/* @param b    The bam record to append to.
+   @param tag  Tag identifier
+   @param type Tag data type
+   @param len  Length of the data in bytes
+   @param data The data to append
+   @return 0 on success; -1 on failure.
+If there is not enough space to store the additional tag, errno is set to
+ENOMEM.  If the type is invalid, errno may be set to EINVAL.
+*/
+int bam_aux_append(bam1_t *b, const char tag[2], char type, int len, const uint8_t *data);
+
+/// Delete tag data from a bam record
+/* @param b The bam record to update
+   @param s Pointer to the tag to delete, as returned by bam_aux_get().
+   @return 0
+*/
+int bam_aux_del(bam1_t *b, uint8_t *s);
+
+/// Update a string-type tag
+/* @param b    The bam record to update
+   @param tag  Tag identifier
+   @param len  The length of the new string
+   @param data The new string
+   @return 0 on success, -1 on failure
+*/
+int bam_aux_update_str(bam1_t *b, const char tag[2], int len, const char *data);
 
 /**************************
  *** Pileup and Mpileup ***

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -39,6 +39,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "hts.h"
 #include "kstring.h"
 #include "hts_defs.h"
+#include "hts_endian.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -967,13 +968,13 @@ static inline int32_t bcf_dec_int1(const uint8_t *p, int type, uint8_t **q)
 {
     if (type == BCF_BT_INT8) {
         *q = (uint8_t*)p + 1;
-        return *(int8_t*)p;
+        return le_to_i8(p);
     } else if (type == BCF_BT_INT16) {
         *q = (uint8_t*)p + 2;
-        return *(int16_t*)p;
+        return le_to_i16(p);
     } else {
         *q = (uint8_t*)p + 4;
-        return *(int32_t*)p;
+        return le_to_i32(p);
     }
 }
 

--- a/htslib_vars.mk
+++ b/htslib_vars.mk
@@ -1,6 +1,6 @@
 # Makefile variables useful for third-party code using htslib's public API.
 #
-#    Copyright (C) 2013-2016 Genome Research Ltd.
+#    Copyright (C) 2013-2017 Genome Research Ltd.
 #
 #    Author: John Marshall <jm18@sanger.ac.uk>
 #
@@ -46,6 +46,6 @@ htslib_sam_h = $(HTSPREFIX)htslib/sam.h $(htslib_hts_h)
 htslib_synced_bcf_reader_h = $(HTSPREFIX)htslib/synced_bcf_reader.h $(htslib_hts_h) $(htslib_vcf_h) $(htslib_tbx_h)
 htslib_tbx_h = $(HTSPREFIX)htslib/tbx.h $(htslib_hts_h)
 htslib_thread_pool_h = $(HTSPREFIX)htslib/thread_pool.h
-htslib_vcf_h = $(HTSPREFIX)htslib/vcf.h $(htslib_hts_h) $(htslib_kstring_h) $(htslib_hts_defs_h)
+htslib_vcf_h = $(HTSPREFIX)htslib/vcf.h $(htslib_hts_h) $(htslib_kstring_h) $(htslib_hts_defs_h) $(htslib_hts_endian_h)
 htslib_vcf_sweep_h = $(HTSPREFIX)htslib/vcf_sweep.h $(htslib_hts_h) $(htslib_vcf_h)
 htslib_vcfutils_h = $(HTSPREFIX)htslib/vcfutils.h $(htslib_vcf_h)

--- a/htslib_vars.mk
+++ b/htslib_vars.mk
@@ -31,6 +31,7 @@ htslib_faidx_h = $(HTSPREFIX)htslib/faidx.h $(htslib_hts_defs_h)
 htslib_hfile_h = $(HTSPREFIX)htslib/hfile.h $(htslib_hts_defs_h)
 htslib_hts_h = $(HTSPREFIX)htslib/hts.h $(htslib_hts_defs_h)
 htslib_hts_defs_h = $(HTSPREFIX)htslib/hts_defs.h
+htslib_hts_endian_h = $(HTSPREFIX)htslib/hts_endian.h
 htslib_kbitset_h = $(HTSPREFIX)htslib/kbitset.h
 htslib_kfunc_h = $(HTSPREFIX)htslib/kfunc.h
 htslib_khash_h = $(HTSPREFIX)htslib/khash.h

--- a/md5.c
+++ b/md5.c
@@ -50,6 +50,7 @@
 
 #include <stdlib.h>
 #include "htslib/hts.h"
+#include "htslib/hts_endian.h"
 
 #ifndef HAVE_OPENSSL
 
@@ -94,7 +95,7 @@ struct hts_md5_context {
  * memory accesses is just an optimization.  Nothing will break if it
  * doesn't work.
  */
-#if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
+#if defined(HTS_LITTLE_ENDIAN) && HTS_ALLOW_UNALIGNED != 0
 #define SET(n) \
 	(*(hts_md5_u32plus *)&ptr[(n) * 4])
 #define GET(n) \

--- a/test/hts_endian.c
+++ b/test/hts_endian.c
@@ -1,0 +1,510 @@
+/*  test/hts_endian.c -- hts_endian.h unit tests
+
+    Copyright (C) 2017 Genome Research Ltd.
+
+    Author: Rob Davies <rmd@sanger.ac.uk>
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include "htslib/hts_endian.h"
+
+typedef struct {
+    uint8_t u8[2];
+    uint8_t u8_unaligned[3];
+    int16_t  i16;
+    uint16_t u16;
+} Test16;
+
+typedef struct {
+    uint8_t u8[4];
+    uint8_t u8_unaligned[5];
+    int32_t  i32;
+    uint32_t u32;
+} Test32;
+
+typedef struct {
+    uint8_t u8[8];
+    uint8_t u8_unaligned[9];
+    int64_t  i64;
+    uint64_t u64;
+} Test64;
+
+typedef struct {
+    uint8_t u8[4];
+    uint8_t u8_unaligned[5];
+    float f;
+} Test_float;
+
+typedef struct {
+    uint8_t u8[8];
+    uint8_t u8_unaligned[9];
+    double d;
+} Test_double;
+
+#define T16(b0, b1, sgn, unsgn) { { b0, b1 }, { 0x00, b0, b1 }, sgn, unsgn }
+
+Test16 tests_16_bit[] = {
+    T16(0x00, 0x00,      0,     0),
+    T16(0x01, 0x00,      1,     1),
+    T16(0x00, 0x01,    256,   256),
+    T16(0xff, 0x7f,  32767, 32767),
+    T16(0x00, 0x80, -32768, 32768),
+    T16(0xff, 0xff,     -1, 65535),
+};
+
+#define T32(b0, b1, b2, b3, sgn, unsgn) { \
+     { b0, b1, b2, b3 },                  \
+     { 0x00, b0, b1, b2, b3 },            \
+     sgn, unsgn                           \
+}
+
+Test32 tests_32_bit[] = {
+    T32(0x00, 0x00, 0x00, 0x00,           0,              0),
+    T32(0x01, 0x00, 0x00, 0x00,           1,              1),
+    T32(0x00, 0x01, 0x00, 0x00,         256,            256),
+    T32(0x00, 0x00, 0x01, 0x00,       65536,          65536),
+    T32(0xff, 0xff, 0xff, 0x7f,  2147483647,     2147483647),
+    // Odd coding of signed result below avoids a compiler warning
+    // as 2147483648 can't fit in a signed 32-bit number
+    T32(0x00, 0x00, 0x00, 0x80, -2147483647 - 1, 2147483648U),
+    T32(0xff, 0xff, 0xff, 0xff,          -1,     4294967295U),
+};
+
+#define T64(b0, b1, b2, b3, b4, b5, b6, b7, sgn, unsgn) { \
+     { b0, b1, b2, b3, b4, b5, b6, b7 },                  \
+     { 0x00, b0, b1, b2, b3, b4, b5, b6, b7 },            \
+     sgn, unsgn                                           \
+}
+
+
+Test64 tests_64_bit[] = {
+    T64(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0, 0),
+    T64(0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 1, 1),
+    T64(0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 256, 256),
+    T64(0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 65536, 65536),
+    T64(0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 4294967296, 4294967296),
+    T64(0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f,
+        9223372036854775807LL, 9223372036854775807ULL),
+    // Odd coding of signed result below avoids a compiler warning
+    // as 9223372036854775808 can't fit in a signed 64-bit number
+    T64(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
+        -9223372036854775807LL - 1LL, 9223372036854775808ULL),
+    T64(0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        -1, 18446744073709551615ULL),
+};
+
+#define TF(b0, b1, b2, b3, f) { { b0, b1, b2, b3 }, { 0x00, b0, b1, b2, b3}, f }
+
+Test_float tests_float[] = {
+    TF(0x00, 0x00, 0x00, 0x00,  0.0f),
+    TF(0x00, 0x00, 0x80, 0x3f,  1.0f),
+    TF(0x00, 0x00, 0x80, 0xbf, -1.0f),
+    TF(0x00, 0x00, 0x20, 0x41, 10.0f),
+    TF(0xd0, 0x0f, 0x49, 0x40,  3.14159f),
+    TF(0xa8, 0x0a, 0xff, 0x66,  6.022e23f),
+    TF(0xcd, 0x84, 0x03, 0x13,  1.66e-27f),
+};
+
+#define TD(b0, b1, b2, b3, b4, b5, b6, b7, d) { \
+    { b0, b1, b2, b3, b4, b5, b6, b7 },         \
+    { 0x00, b0, b1, b2, b3, b4, b5, b6, b7 },   \
+    d                                           \
+}
+
+Test_double tests_double[] = {
+    TD(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  0.0),
+    TD(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0x3f,  1.0),
+    TD(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf0, 0xbf, -1.0),
+    TD(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x24, 0x40, 10.0),
+    TD(0x18, 0x2d, 0x44, 0x54, 0xfb, 0x21, 0x09, 0x40,  3.141592653589793),
+    TD(0x2b, 0x08, 0x0c, 0xd3, 0x85, 0xe1, 0xdf, 0x44,  6.022140858e23),
+    TD(0x55, 0xfa, 0x81, 0x74, 0xf7, 0x71, 0x60, 0x3a,  1.66053904e-27),
+};
+
+#define NELE(x) (sizeof(x)/sizeof(x[0]))
+
+static char * to_hex(uint8_t *buf, int len) {
+    static char str[64];
+    int i, o;
+
+    for (i = 0, o = 0; i < len; i++, o += 3) {
+        snprintf(str + o, sizeof(str) - o, "%02x ", buf[i]);
+    }
+    return str;
+}
+
+static int t16_bit(int verbose) {
+    uint8_t buf[9];
+    size_t i;
+    int errors = 0;
+
+    for (i = 0; i < NELE(tests_16_bit); i++) {
+        uint16_t u16;
+        int16_t  i16;
+
+        if (verbose) {
+            fprintf(stderr, "%s %6"PRId16" %6"PRId16"\n",
+                    to_hex(tests_16_bit[i].u8, 2),
+                    tests_16_bit[i].i16, tests_16_bit[i].u16);
+        }
+
+        u16 = le_to_u16(tests_16_bit[i].u8);
+        if (u16 != tests_16_bit[i].u16) {
+            fprintf(stderr, "Failed %s => %"PRIu16"; expected %"PRIu16"\n",
+                    to_hex(tests_16_bit[i].u8, 2), u16, tests_16_bit[i].u16);
+            errors++;
+        }
+
+        i16 = le_to_i16(tests_16_bit[i].u8);
+        if (i16 != tests_16_bit[i].i16) {
+            fprintf(stderr, "Failed %s => %"PRId16"; expected %"PRId16"\n",
+                    to_hex(tests_16_bit[i].u8, 2), i16, tests_16_bit[i].i16);
+            errors++;
+        }
+
+        u16 = le_to_u16(tests_16_bit[i].u8_unaligned + 1);
+        if (u16 != tests_16_bit[i].u16) {
+            fprintf(stderr,
+                    "Failed unaligned %s => %"PRIu16"; expected %"PRIu16"\n",
+                    to_hex(tests_16_bit[i].u8_unaligned + 1, 2),
+                    u16, tests_16_bit[i].u16);
+            errors++;
+        }
+
+        i16 = le_to_i16(tests_16_bit[i].u8_unaligned + 1);
+        if (i16 != tests_16_bit[i].i16) {
+            fprintf(stderr,
+                    "Failed unaligned %s => %"PRId16"; expected %"PRId16"\n",
+                    to_hex(tests_16_bit[i].u8_unaligned + 1, 2),
+                    i16, tests_16_bit[i].i16);
+            errors++;
+        }
+
+        u16_to_le(tests_16_bit[i].u16, buf);
+        if (memcmp(buf, tests_16_bit[i].u8, 2) != 0) {
+            fprintf(stderr, "Failed %"PRIu16" => %s; expected %s\n",
+                    tests_16_bit[i].u16,
+                    to_hex(buf, 2), to_hex(tests_16_bit[i].u8, 2));
+            errors++;
+        }
+
+        i16_to_le(tests_16_bit[i].i16, buf);
+        if (memcmp(buf, tests_16_bit[i].u8, 2) != 0) {
+            fprintf(stderr, "Failed %"PRId16" => %s; expected %s\n",
+                    tests_16_bit[i].i16,
+                    to_hex(buf, 2), to_hex(tests_16_bit[i].u8, 2));
+            errors++;
+        }
+
+        u16_to_le(tests_16_bit[i].u16, buf + 1);
+        if (memcmp(buf + 1, tests_16_bit[i].u8, 2) != 0) {
+            fprintf(stderr, "Failed unaligned %"PRIu16" => %s; expected %s\n",
+                    tests_16_bit[i].u16,
+                    to_hex(buf + 1, 2), to_hex(tests_16_bit[i].u8, 2));
+            errors++;
+        }
+
+        i16_to_le(tests_16_bit[i].i16, buf + 1);
+        if (memcmp(buf + 1, tests_16_bit[i].u8, 2) != 0) {
+            fprintf(stderr, "Failed unaligned %"PRId16" => %s; expected %s\n",
+                    tests_16_bit[i].i16,
+                    to_hex(buf + 1, 2), to_hex(tests_16_bit[i].u8, 2));
+            errors++;
+        }
+    }
+
+    return errors;
+}
+
+static int t32_bit(int verbose) {
+    uint8_t buf[9];
+    size_t i;
+    int errors = 0;
+
+    for (i = 0; i < NELE(tests_32_bit); i++) {
+        uint32_t u32;
+        int32_t  i32;
+
+        if (verbose) {
+            fprintf(stderr, "%s %11"PRId32" %11"PRIu32"\n",
+                    to_hex(tests_32_bit[i].u8, 4),
+                    tests_32_bit[i].i32, tests_32_bit[i].u32);
+        }
+
+        u32 = le_to_u32(tests_32_bit[i].u8);
+        if (u32 != tests_32_bit[i].u32) {
+            fprintf(stderr, "Failed %s => %"PRIu32"; expected %"PRIu32"\n",
+                    to_hex(tests_32_bit[i].u8, 4), u32, tests_32_bit[i].u32);
+            errors++;
+        }
+        i32 = le_to_i32(tests_32_bit[i].u8);
+        if (i32 != tests_32_bit[i].i32) {
+            fprintf(stderr, "Failed %s => %"PRId32"; expected %"PRId32"\n",
+                    to_hex(tests_32_bit[i].u8, 4), i32, tests_32_bit[i].i32);
+            errors++;
+        }
+
+        u32 = le_to_u32(tests_32_bit[i].u8_unaligned + 1);
+        if (u32 != tests_32_bit[i].u32) {
+            fprintf(stderr,
+                    "Failed unaligned %s => %"PRIu32"; expected %"PRIu32"\n",
+                    to_hex(tests_32_bit[i].u8_unaligned + 1, 4),
+                    u32, tests_32_bit[i].u32);
+            errors++;
+        }
+        i32 = le_to_i32(tests_32_bit[i].u8_unaligned + 1);
+        if (i32 != tests_32_bit[i].i32) {
+            fprintf(stderr,
+                    "Failed unaligned %s => %"PRId32"; expected %"PRId32"\n",
+                    to_hex(tests_32_bit[i].u8_unaligned + 1, 4),
+                    i32, tests_32_bit[i].i32);
+            errors++;
+        }
+
+        u32_to_le(tests_32_bit[i].u32, buf);
+        if (memcmp(buf, tests_32_bit[i].u8, 4) != 0) {
+            fprintf(stderr, "Failed %"PRIu32" => %s; expected %s\n",
+                    tests_32_bit[i].u32,
+                    to_hex(buf, 4), to_hex(tests_32_bit[i].u8, 4));
+            errors++;
+        }
+
+        i32_to_le(tests_32_bit[i].i32, buf);
+        if (memcmp(buf, tests_32_bit[i].u8, 4) != 0) {
+            fprintf(stderr, "Failed %"PRId32" => %s; expected %s\n",
+                    tests_32_bit[i].i32,
+                    to_hex(buf, 4), to_hex(tests_32_bit[i].u8, 4));
+            errors++;
+        }
+
+        u32_to_le(tests_32_bit[i].u32, buf + 1);
+        if (memcmp(buf + 1, tests_32_bit[i].u8, 4) != 0) {
+            fprintf(stderr, "Failed unaligned %"PRIu32" => %s; expected %s\n",
+                    tests_32_bit[i].u32,
+                    to_hex(buf + 1, 4), to_hex(tests_32_bit[i].u8, 4));
+            errors++;
+        }
+
+        i32_to_le(tests_32_bit[i].i32, buf + 1);
+        if (memcmp(buf + 1, tests_32_bit[i].u8, 4) != 0) {
+            fprintf(stderr, "Failed unaligned %"PRId32" => %s; expected %s\n",
+                    tests_32_bit[i].i32,
+                    to_hex(buf + 1, 4), to_hex(tests_32_bit[i].u8, 4));
+            errors++;
+        }
+    }
+
+    return errors;
+}
+
+static int t64_bit(int verbose) {
+    uint8_t buf[9];
+    size_t i;
+    int errors = 0;
+
+    for (i = 0; i < NELE(tests_64_bit); i++) {
+        uint64_t u64;
+        int64_t  i64;
+
+        if (verbose) {
+            fprintf(stderr, "%s %20"PRId64" %20"PRIu64"\n",
+                    to_hex(tests_64_bit[i].u8, 8),
+                    tests_64_bit[i].i64, tests_64_bit[i].u64);
+        }
+
+        u64 = le_to_u64(tests_64_bit[i].u8);
+        if (u64 != tests_64_bit[i].u64) {
+            fprintf(stderr, "Failed %s => %"PRIu64"; expected %"PRIu64"\n",
+                    to_hex(tests_64_bit[i].u8, 8), u64, tests_64_bit[i].u64);
+            errors++;
+        }
+
+        i64 = le_to_i64(tests_64_bit[i].u8);
+        if (i64 != tests_64_bit[i].i64) {
+            fprintf(stderr, "Failed %s => %"PRId64"; expected %"PRId64"\n",
+                    to_hex(tests_64_bit[i].u8, 8), i64, tests_64_bit[i].i64);
+            errors++;
+        }
+
+        u64 = le_to_u64(tests_64_bit[i].u8_unaligned + 1);
+        if (u64 != tests_64_bit[i].u64) {
+            fprintf(stderr,
+                    "Failed unaligned %s => %"PRIu64"; expected %"PRIu64"\n",
+                    to_hex(tests_64_bit[i].u8_unaligned + 1, 8),
+                    u64, tests_64_bit[i].u64);
+            errors++;
+        }
+
+        i64 = le_to_i64(tests_64_bit[i].u8_unaligned + 1);
+        if (i64 != tests_64_bit[i].i64) {
+            fprintf(stderr,
+                    "Failed unaligned %s => %"PRId64"; expected %"PRId64"\n",
+                    to_hex(tests_64_bit[i].u8_unaligned + 1, 8),
+                    i64, tests_64_bit[i].i64);
+            errors++;
+        }
+
+        u64_to_le(tests_64_bit[i].u64, buf);
+        if (memcmp(buf, tests_64_bit[i].u8, 8) != 0) {
+            fprintf(stderr, "Failed %"PRIu64" => %s; expected %s\n",
+                    tests_64_bit[i].u64,
+                    to_hex(buf, 8), to_hex(tests_64_bit[i].u8, 8));
+            errors++;
+        }
+
+        i64_to_le(tests_64_bit[i].i64, buf);
+        if (memcmp(buf, tests_64_bit[i].u8, 8) != 0) {
+            fprintf(stderr, "Failed %"PRId64" => %s; expected %s\n",
+                    tests_64_bit[i].i64,
+                    to_hex(buf, 8), to_hex(tests_64_bit[i].u8, 8));
+            errors++;
+        }
+
+        u64_to_le(tests_64_bit[i].u64, buf + 1);
+        if (memcmp(buf + 1, tests_64_bit[i].u8, 8) != 0) {
+            fprintf(stderr, "Failed unaligned %"PRIu64" => %s; expected %s\n",
+                    tests_64_bit[i].u64,
+                    to_hex(buf + 1, 8), to_hex(tests_64_bit[i].u8, 8));
+            errors++;
+        }
+
+        i64_to_le(tests_64_bit[i].i64, buf + 1);
+        if (memcmp(buf + 1, tests_64_bit[i].u8, 8) != 0) {
+            fprintf(stderr, "Failed unaligned %"PRId64" => %s; expected %s\n",
+                    tests_64_bit[i].i64,
+                    to_hex(buf + 1, 8), to_hex(tests_64_bit[i].u8, 8));
+            errors++;
+        }
+    }
+
+    return errors;
+}
+
+int t_float(int verbose) {
+    uint8_t buf[9];
+    size_t i;
+    int errors = 0;
+
+    for (i = 0; i < NELE(tests_float); i++) {
+        float f;
+
+        if (verbose) {
+            fprintf(stderr, "%s %g\n",
+                    to_hex(tests_float[i].u8, 4), tests_float[i].f);
+        }
+
+        f = le_to_float(tests_float[i].u8);
+        if (f != tests_float[i].f) {
+            fprintf(stderr, "Failed %s => %g; expected %g\n",
+                    to_hex(tests_float[i].u8, 4), f, tests_float[i].f);
+            errors++;
+        }
+
+        f = le_to_float(tests_float[i].u8_unaligned + 1);
+        if (f != tests_float[i].f) {
+            fprintf(stderr, "Failed unaligned %s => %g; expected %g\n",
+                    to_hex(tests_float[i].u8_unaligned + 1, 4),
+                    f, tests_float[i].f);
+            errors++;
+        }
+
+        float_to_le(tests_float[i].f, buf);
+        if (memcmp(tests_float[i].u8, buf, 4) != 0) {
+            fprintf(stderr, "Failed %g => %s; expected %s\n",
+                    tests_float[i].f,
+                    to_hex(buf, 4), to_hex(tests_float[i].u8, 4));
+        }
+
+        float_to_le(tests_float[i].f, buf + 1);
+        if (memcmp(tests_float[i].u8, buf + 1, 4) != 0) {
+            fprintf(stderr, "Failed unaligned %g => %s; expected %s\n",
+                    tests_float[i].f,
+                    to_hex(buf + 1, 4), to_hex(tests_float[i].u8, 4));
+        }
+    }
+    return errors;
+}
+
+int t_double(int verbose) {
+    uint8_t buf[9];
+    size_t i;
+    int errors = 0;
+
+    for (i = 0; i < NELE(tests_double); i++) {
+        double f;
+
+        if (verbose) {
+            fprintf(stderr, "%s %.15g\n",
+                    to_hex(tests_double[i].u8, 8), tests_double[i].d);
+        }
+
+        f = le_to_double(tests_double[i].u8);
+        if (f != tests_double[i].d) {
+            fprintf(stderr, "Failed %s => %.15g; expected %.15g\n",
+                    to_hex(tests_double[i].u8, 8), f, tests_double[i].d);
+            errors++;
+        }
+
+        f = le_to_double(tests_double[i].u8_unaligned + 1);
+        if (f != tests_double[i].d) {
+            fprintf(stderr, "Failed unaligned %s => %.15g; expected %.15g\n",
+                    to_hex(tests_double[i].u8_unaligned + 1, 8),
+                    f, tests_double[i].d);
+            errors++;
+        }
+
+        double_to_le(tests_double[i].d, buf);
+        if (memcmp(tests_double[i].u8, buf, 8) != 0) {
+            fprintf(stderr, "Failed %.15g => %s; expected %s\n",
+                    tests_double[i].d,
+                    to_hex(buf, 8), to_hex(tests_double[i].u8, 8));
+        }
+
+        double_to_le(tests_double[i].d, buf + 1);
+        if (memcmp(tests_double[i].u8, buf + 1, 8) != 0) {
+            fprintf(stderr, "Failed unaligned %.15g => %s; expected %s\n",
+                    tests_double[i].d,
+                    to_hex(buf + 1, 8), to_hex(tests_double[i].u8, 8));
+        }
+    }
+    return errors;
+}
+
+int main(int argc, char **argv) {
+    int verbose = 0;
+    int errors = 0;
+
+    if (argc > 1 && strcmp(argv[1], "-v") == 0) verbose = 1;
+
+    errors += t16_bit(verbose);
+    errors += t32_bit(verbose);
+    errors += t64_bit(verbose);
+    errors += t_float(verbose);
+    errors += t_double(verbose);
+    if (errors) {
+        fprintf(stderr, "%d errors\n", errors);
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/test/test.pl
+++ b/test/test.pl
@@ -125,7 +125,7 @@ sub test_cmd
     print "$test:\n";
     print "\t$args{cmd}\n";
 
-    my ($ret,$out) = _cmd("$args{cmd} 2>&1");
+    my ($ret,$out) = _cmd("$args{cmd}");
     if ( $ret ) { failed($opts,$test); return; }
     if ( $$opts{redo_outputs} && -e "$$opts{path}/$args{out}" )
     {


### PR DESCRIPTION
Undefined behaviour includes:
    
* Illegal shifts
* Calls to memcpy(ptr, NULL, 0)
* Unaligned access

A new header file htslib/hts_endian.h is added.  This includes functions to read and write little-endian
values, which may be unaligned, in a portable way.  Some endian-specific code is rewritten to be
endian-neutral, but with optional optimisations for little-endian platforms that allow unaligned access.
    
Behaviour on big-endian systems is also changed, notably bam auxiliary data is now stored in little-endian order instead of being byte-swapped.  This means code accessing aux data needs to byte swap integer and float values on big-endian platforms.  To assist this, more bam_aux functions are added.  These include bam_auxB_len(), bam_auxB2i() and bam_auxB2f() for accessing array elements.
    
Justification for this:
    
* The data was previously stored inconsistently depending on if you read a sam, bam or cram file.  This meant big-endian platforms basically didn't work before this change.
* The values are often unaligned.  Some platforms (e.g. sparc, mips, armhf) need special handling for unaligned data, and it's easy to do the byte swapping at the same time.
* No time is wasted byte swapping aux values that aren't going to be accessed (although this is only an advantage for bam).

Undefined behaviour detected by compiling with -fsanitize=undefined and running the test harnesses for htslib, samtools and bcftools.

Endian compatibility tested using netbsd on sparc (emulated with qemu).

Should help with issues  #98, #119, #355, #450, https://github.com/samtools/samtools/issues/268 and https://github.com/samtools/samtools/issues/612.  I'll mark them as fixed once we have more evidence that the problem has actually been solved for the platforms in those issues.  Samtools issues are likely to need some extra work on samtools itself.