### PR TITLE
More thread pool fixes (see issue #537).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,11 @@ BUILT_TEST_PROGRAMS = \
 	test/test-regidx \
 	test/test_view \
 	test/test-vcf-api \
-	test/test-vcf-sweep
+	test/test-vcf-sweep \
+	test/thrash_threads1 \
+	test/thrash_threads2 \
+	test/thrash_threads3 \
+	test/thrash_threads4
 
 all: lib-static lib-shared $(BUILT_PROGRAMS) plugins $(BUILT_TEST_PROGRAMS)
 
@@ -372,6 +376,18 @@ test/test-regidx.o: test/test-regidx.c config.h $(htslib_regidx_h) $(hts_interna
 test/test_view.o: test/test_view.c config.h $(cram_h) $(htslib_sam_h)
 test/test-vcf-api.o: test/test-vcf-api.c config.h $(htslib_hts_h) $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_kseq_h)
 test/test-vcf-sweep.o: test/test-vcf-sweep.c config.h $(htslib_vcf_sweep_h)
+
+test/thrash_threads1: test/thrash_threads1.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads1.o libhts.a -lz $(LIBS)
+
+test/thrash_threads2: test/thrash_threads2.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads2.o libhts.a -lz $(LIBS)
+
+test/thrash_threads3: test/thrash_threads3.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads3.o libhts.a -lz $(LIBS)
+
+test/thrash_threads4: test/thrash_threads4.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads4.o libhts.a -lz $(LIBS)
 
 
 install: libhts.a $(BUILT_PROGRAMS) $(BUILT_PLUGINS) installdirs install-$(SHLIB_FLAVOUR) install-pkgconfig

--- a/test/thrash_threads1.c
+++ b/test/thrash_threads1.c
@@ -1,0 +1,25 @@
+// Test extreme rapid turnover of readers, to check for
+// race conditions between reader thread launching and file close.
+
+#include <config.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include "htslib/bgzf.h"
+
+int main(int argc, char *argv[]) {
+    if (argc <= 1) {
+	fprintf(stderr, "Usage: thrash_threads1 input.bam\n");
+	exit(1);
+    }
+
+    int i;
+    for (i = 0; i < 10000; i++) {
+	printf("i=%d\n", i);
+	BGZF *fpin  = bgzf_open(argv[1], "r");
+	bgzf_mt(fpin, 2, 256);
+	if (bgzf_close(fpin) < 0) abort();
+    }
+    return 0;
+}

--- a/test/thrash_threads2.c
+++ b/test/thrash_threads2.c
@@ -1,0 +1,23 @@
+// Test extreme rapid turnover of writers, to check for
+// race conditions between reader thread launching and file close.
+
+#include <config.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include "htslib/bgzf.h"
+#include "htslib/thread_pool.h"
+
+int main(int argc, char *argv[]) {
+    int i;
+    for (i = 0; i < 1000; i++) {
+	printf("i=%d\n", i);
+	BGZF *fp  = bgzf_open("/dev/null", "w");
+	bgzf_mt(fp, 8, 256);
+	if (bgzf_close(fp))
+	    abort();
+    }
+
+    return 0;
+}

--- a/test/thrash_threads3.c
+++ b/test/thrash_threads3.c
@@ -1,0 +1,27 @@
+// Simple open,read,close thrash.
+
+#include <config.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include "htslib/bgzf.h"
+
+int main(int argc, char *argv[]) {
+    char buf[1000];
+    int i;
+
+    if (argc <= 1) {
+	fprintf(stderr, "Usage: thrash_threads3 input.bam\n");
+	exit(1);
+    }
+
+    for (i = 0; i < 10000; i++) {
+	printf("i=%d\n", i);
+	BGZF *fpin  = bgzf_open(argv[1], "r");
+	bgzf_mt(fpin, 8, 256);
+	if (bgzf_read(fpin, buf, 1000) < 0) abort();
+	if (bgzf_close(fpin) < 0) abort();
+    }
+    return 0;
+}

--- a/test/thrash_threads4.c
+++ b/test/thrash_threads4.c
@@ -1,0 +1,46 @@
+// Spam seeks
+#include <config.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "htslib/bgzf.h"
+#include "htslib/thread_pool.h"
+
+int main(int argc, char *argv[]) {
+    if (argc <= 1) {
+	fprintf(stderr, "Usage: thrash_threads4 input.bam\n");
+	exit(1);
+    }
+
+    // Find a valid seek location ~64M into the file
+    int i;
+    BGZF *fpin  = bgzf_open(argv[1], "r");
+    char buf[65536];
+    for (i = 0; i < 1000; i++)
+	if (bgzf_read(fpin, buf, 65536) < 0)
+	    abort();
+    int64_t pos = bgzf_tell(fpin);
+    bgzf_close(fpin);
+
+#define N 1000
+
+    // Spam seeks
+    for (i = 0; i < 1000; i++) {
+	printf("i=%d\n", i);
+	fpin  = bgzf_open(argv[1], "r");
+	bgzf_mt(fpin, 8, 256);
+	if (bgzf_seek(fpin, pos, SEEK_SET) < 0) abort();
+	usleep(N);
+	//if (bgzf_read(fpin, buf, 65536) < 0) abort();
+	//write(1, buf, 65536);
+	if (bgzf_seek(fpin, 0LL, SEEK_SET) < 0) abort();
+	usleep(N);
+	//if (bgzf_read(fpin, buf, 65536) < 0) abort();
+	//write(1, buf, 65536);
+	if (bgzf_close(fpin))
+	    abort();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
These come with some test code for thrashing the bgzf multi-threading,
but the tests are not normal tests and do not get executed by make
check.  Instead they are designed to be run manually to look for
lockups and to be executed under valgrind (memcheck, drd, helgrind
tools) to look for issues.

The bugs fixed include race conditions on both reader and writer
between shutting down the thread pool and starting the reader/writer
itself and races between shutting down and the reader/writer exiting.