### PR TITLE
Further thread pool fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,14 @@ BUILT_TEST_PROGRAMS = \
 	test/test-vcf-api \
 	test/test-vcf-sweep
 
+BUILT_THRASH_PROGRAMS = \
+	test/thrash_threads1 \
+	test/thrash_threads2 \
+	test/thrash_threads3 \
+	test/thrash_threads4 \
+	test/thrash_threads5 \
+	test/thrash_threads6
+
 all: lib-static lib-shared $(BUILT_PROGRAMS) plugins $(BUILT_TEST_PROGRAMS)
 
 HTSPREFIX =
@@ -374,6 +382,27 @@ test/test-vcf-api.o: test/test-vcf-api.c config.h $(htslib_hts_h) $(htslib_vcf_h
 test/test-vcf-sweep.o: test/test-vcf-sweep.c config.h $(htslib_vcf_sweep_h)
 
 
+test/thrash_threads1: test/thrash_threads1.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads1.o libhts.a -lz $(LIBS)
+
+test/thrash_threads2: test/thrash_threads2.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads2.o libhts.a -lz $(LIBS)
+
+test/thrash_threads3: test/thrash_threads3.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads3.o libhts.a -lz $(LIBS)
+
+test/thrash_threads4: test/thrash_threads4.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads4.o libhts.a -lz $(LIBS)
+
+test/thrash_threads5: test/thrash_threads5.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads5.o libhts.a -lz $(LIBS)
+
+test/thrash_threads6: test/thrash_threads6.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/thrash_threads6.o libhts.a -lz $(LIBS)
+
+test_thrash: $(BUILT_THRASH_PROGRAMS)
+
+
 install: libhts.a $(BUILT_PROGRAMS) $(BUILT_PLUGINS) installdirs install-$(SHLIB_FLAVOUR) install-pkgconfig
 	$(INSTALL_PROGRAM) $(BUILT_PROGRAMS) $(DESTDIR)$(bindir)
 	if test -n "$(BUILT_PLUGINS)"; then $(INSTALL_PROGRAM) $(BUILT_PLUGINS) $(DESTDIR)$(plugindir); fi
@@ -423,7 +452,7 @@ mostlyclean: testclean
 	-rm -f *.o *.pico cram/*.o cram/*.pico test/*.o test/*.dSYM version.h
 
 clean: mostlyclean clean-$(SHLIB_FLAVOUR)
-	-rm -f libhts.a $(BUILT_PROGRAMS) $(BUILT_PLUGINS) $(BUILT_TEST_PROGRAMS)
+	-rm -f libhts.a $(BUILT_PROGRAMS) $(BUILT_PLUGINS) $(BUILT_TEST_PROGRAMS) $(BUILT_THRASH_PROGRAMS)
 
 distclean maintainer-clean: clean
 	-rm -f config.cache config.h config.log config.mk config.status

--- a/bgzf.c
+++ b/bgzf.c
@@ -635,12 +635,16 @@ int bgzf_read_block(BGZF *fp)
             return 0;
         }
         r = hts_tpool_next_result_wait(fp->mt->out_queue);
-        bgzf_job *j = (bgzf_job *)hts_tpool_result_data(r);
-        assert(j);
+        bgzf_job *j = r ? (bgzf_job *)hts_tpool_result_data(r) : NULL;
 
-        if (j->errcode == BGZF_ERR_MT) {
+        if (!j || j->errcode == BGZF_ERR_MT) {
             mt_destroy(fp->mt);
             fp->mt = NULL;
+            fp->uncompressed_block = malloc(2 * BGZF_MAX_BLOCK_SIZE);
+            if (fp->uncompressed_block == NULL) return -1;
+            fp->compressed_block = (char *)fp->uncompressed_block + BGZF_MAX_BLOCK_SIZE;
+            hts_tpool_delete_result(r, 0);
+
             goto single_threaded;
         }
 
@@ -663,6 +667,7 @@ int bgzf_read_block(BGZF *fp)
         // trying again to see if we hit a genuine EOF.
         if (!j->hit_eof && j->uncomp_len == 0) {
             fp->last_block_eof = 1;
+            hts_tpool_delete_result(r, 0);
             goto again;
         }
 
@@ -953,7 +958,7 @@ static void *bgzf_mt_writer(void *vp) {
 
         if (hwrite(fp->fp, j->comp_data, j->comp_len) != j->comp_len) {
             fp->errcode |= BGZF_ERR_IO;
-            return (void *)-1;
+            goto err;
         }
 
         /*
@@ -967,7 +972,7 @@ static void *bgzf_mt_writer(void *vp) {
          */
         if (++mt->flush_pending % 512 == 0)
             if (hflush(fp->fp) != 0)
-                return (void *)-1;
+                goto err;
 
 
         hts_tpool_delete_result(r, 0);
@@ -980,9 +985,15 @@ static void *bgzf_mt_writer(void *vp) {
     }
 
     if (hflush(fp->fp) != 0)
-        return (void *)-1;
+        goto err;
+
+    hts_tpool_process_destroy(mt->out_queue);
 
     return NULL;
+
+ err:
+    hts_tpool_process_destroy(mt->out_queue);
+    return (void *)-1;
 }
 
 
@@ -1127,6 +1138,7 @@ restart:
         case CLOSE:
             pthread_cond_signal(&mt->command_c);
             pthread_mutex_unlock(&mt->command_m);
+            hts_tpool_process_destroy(mt->out_queue);
             pthread_exit(NULL);
 
         default:
@@ -1147,6 +1159,7 @@ restart:
         // Attempt to multi-thread decode a raw gzip stream cannot be done.
         // We tear down the multi-threaded decoder and revert to the old code.
         hts_tpool_dispatch(mt->pool, mt->out_queue, bgzf_nul_func, j);
+        hts_tpool_process_ref_decr(mt->out_queue);
         pthread_exit(&j->errcode);
     }
 
@@ -1156,8 +1169,10 @@ restart:
 
     j->hit_eof = 1;
     hts_tpool_dispatch(mt->pool, mt->out_queue, bgzf_nul_func, j);
-    if (j->errcode != 0)
+    if (j->errcode != 0) {
+        hts_tpool_process_destroy(mt->out_queue);
         pthread_exit(&j->errcode);
+    }
 
     // We hit EOF so can stop reading, but we may get a subsequent
     // seek request.  In this case we need to restart the reader.
@@ -1186,6 +1201,7 @@ restart:
         case CLOSE:
             pthread_cond_signal(&mt->command_c);
             pthread_mutex_unlock(&mt->command_m);
+            hts_tpool_process_destroy(mt->out_queue);
             pthread_exit(NULL);
         }
     }
@@ -1209,6 +1225,7 @@ int bgzf_thread_pool(BGZF *fp, hts_tpool *pool, int qsize) {
         free(mt);
         return -1;
     }
+    hts_tpool_process_ref_incr(mt->out_queue);
 
     mt->job_pool = pool_create(sizeof(bgzf_job));
 
@@ -1234,6 +1251,12 @@ int bgzf_mt(BGZF *fp, int n_threads, int n_sub_blks)
     hts_tpool *p = hts_tpool_init(n_threads);
     if (!p)
         return -1;
+
+    if (!fp->is_write) {
+        free(fp->uncompressed_block);
+        fp->uncompressed_block = NULL;
+        fp->compressed_block = NULL;
+    }
 
     if (bgzf_thread_pool(fp, p, 0) != 0) {
         hts_tpool_destroy(p);
@@ -1262,10 +1285,11 @@ static void mt_destroy(mtaux_t *mt)
     pthread_cond_destroy(&mt->command_c);
     if (mt->curr_job)
         pool_free(mt->job_pool, mt->curr_job);
-    pool_destroy(mt->job_pool);
 
     if (mt->own_pool)
         hts_tpool_destroy(mt->pool);
+
+    pool_destroy(mt->job_pool);
 
     free(mt);
     fflush(stderr);
@@ -1510,7 +1534,7 @@ int64_t bgzf_seek(BGZF* fp, int64_t pos, int where)
     int block_offset;
     int64_t block_address;
 
-    if (fp->is_write || where != SEEK_SET) {
+    if (fp->is_write || where != SEEK_SET || fp->is_gzip) {
         fp->errcode |= BGZF_ERR_MISUSE;
         return -1;
     }

--- a/htslib/thread_pool.h
+++ b/htslib/thread_pool.h
@@ -274,6 +274,15 @@ void hts_tpool_process_shutdown(hts_tpool_process *q);
 void hts_tpool_process_attach(hts_tpool *p, hts_tpool_process *q);
 void hts_tpool_process_detach(hts_tpool *p, hts_tpool_process *q);
 
+/*
+ * Increment and decrement the reference count in a process-queue.
+ * If the queue is being driven from two external (non thread-pool)
+ * threads, eg "main" and a "reader", this permits each end to
+ * decrement its use of the process-queue independently.
+ */
+void hts_tpool_process_ref_incr(hts_tpool_process *q);
+void hts_tpool_process_ref_decr(hts_tpool_process *q);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/thrash_threads1.c
+++ b/test/thrash_threads1.c
@@ -1,0 +1,25 @@
+// Test extreme rapid turnover of readers, to check for
+// race conditions between reader thread launching and file close.
+
+#include <config.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include "htslib/bgzf.h"
+
+int main(int argc, char *argv[]) {
+    if (argc <= 1) {
+	fprintf(stderr, "Usage: thrash_threads1 input.bam\n");
+	exit(1);
+    }
+
+    int i;
+    for (i = 0; i < 10000; i++) {
+	printf("i=%d\n", i);
+	BGZF *fpin  = bgzf_open(argv[1], "r");
+	bgzf_mt(fpin, 2, 256);
+	if (bgzf_close(fpin) < 0) abort();
+    }
+    return 0;
+}

--- a/test/thrash_threads2.c
+++ b/test/thrash_threads2.c
@@ -1,0 +1,23 @@
+// Test extreme rapid turnover of writers, to check for
+// race conditions between reader thread launching and file close.
+
+#include <config.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include "htslib/bgzf.h"
+#include "htslib/thread_pool.h"
+
+int main(int argc, char *argv[]) {
+    int i;
+    for (i = 0; i < 1000; i++) {
+	printf("i=%d\n", i);
+	BGZF *fp  = bgzf_open("/dev/null", "w");
+	bgzf_mt(fp, 8, 256);
+	if (bgzf_close(fp))
+	    abort();
+    }
+
+    return 0;
+}

--- a/test/thrash_threads3.c
+++ b/test/thrash_threads3.c
@@ -1,0 +1,27 @@
+// Simple open,read,close thrash.
+
+#include <config.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include "htslib/bgzf.h"
+
+int main(int argc, char *argv[]) {
+    char buf[1000];
+    int i;
+
+    if (argc <= 1) {
+	fprintf(stderr, "Usage: thrash_threads3 input.bam\n");
+	exit(1);
+    }
+
+    for (i = 0; i < 10000; i++) {
+	printf("i=%d\n", i);
+	BGZF *fpin  = bgzf_open(argv[1], "r");
+	bgzf_mt(fpin, 8, 256);
+	if (bgzf_read(fpin, buf, 1000) < 0) abort();
+	if (bgzf_close(fpin) < 0) abort();
+    }
+    return 0;
+}

--- a/test/thrash_threads4.c
+++ b/test/thrash_threads4.c
@@ -1,0 +1,46 @@
+// Spam seeks
+#include <config.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "htslib/bgzf.h"
+#include "htslib/thread_pool.h"
+
+int main(int argc, char *argv[]) {
+    if (argc <= 1) {
+	fprintf(stderr, "Usage: thrash_threads4 input.bam\n");
+	exit(1);
+    }
+
+    // Find a valid seek location ~64M into the file
+    int i;
+    BGZF *fpin  = bgzf_open(argv[1], "r");
+    char buf[65536];
+    for (i = 0; i < 1000; i++)
+	if (bgzf_read(fpin, buf, 65536) < 0)
+	    abort();
+    int64_t pos = bgzf_tell(fpin);
+    bgzf_close(fpin);
+
+#define N 1000
+
+    // Spam seeks
+    for (i = 0; i < 1000; i++) {
+	printf("i=%d\n", i);
+	fpin  = bgzf_open(argv[1], "r");
+	bgzf_mt(fpin, 8, 256);
+	if (bgzf_seek(fpin, pos, SEEK_SET) < 0) puts("!");//abort();
+	usleep(N);
+	//if (bgzf_read(fpin, buf, 65536) < 0) abort();
+	//write(1, buf, 65536);
+	if (bgzf_seek(fpin, 0LL, SEEK_SET) < 0) puts("!");//abort();
+	usleep(N);
+	//if (bgzf_read(fpin, buf, 65536) < 0) abort();
+	//write(1, buf, 65536);
+	if (bgzf_close(fpin))
+	    abort();
+    }
+
+    return 0;
+}

--- a/test/thrash_threads5.c
+++ b/test/thrash_threads5.c
@@ -1,0 +1,37 @@
+// A basic 'zcat filename [N-threads]'
+
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "htslib/bgzf.h"
+#include "htslib/thread_pool.h"
+
+#define N 1000
+int main(int argc, char *argv[]) {
+    char buf[N];
+    ssize_t l, t = 0;
+    BGZF *fpin  = bgzf_open(argv[1], "r");
+    hts_tpool *p = NULL;
+    if (argc > 2) {
+        p = hts_tpool_init(atoi(argv[2]));
+        bgzf_thread_pool(fpin,  p, 0);
+    }
+    int n = rand()%(N-1)+1;
+    while ((l = bgzf_read(fpin, buf, n)) > 0) {
+        if (l != write(1, buf, l)) abort();
+	t += l;
+        if (l != n) {
+            fprintf(stderr, "expected %d bytes, got %d\n", n, (int)l);
+            break;
+        }
+        n = rand()%(N-1)+1;
+    }
+    fprintf(stderr, "close=%d\n", (int)bgzf_close(fpin));
+    if (p) hts_tpool_destroy(p);
+
+    fprintf(stderr, "wrote %d bytes\n", (int)t);
+
+    return 0;
+}

--- a/test/thrash_threads6.c
+++ b/test/thrash_threads6.c
@@ -1,0 +1,70 @@
+// Spam seeks
+#include <config.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include "htslib/bgzf.h"
+#include "htslib/thread_pool.h"
+
+int main(int argc, char *argv[]) {
+    if (argc <= 1) {
+	fprintf(stderr, "Usage: thrash_threads4 input.bam\n");
+	exit(1);
+    }
+
+    // Find a valid seek location ~64M into the file
+    int i;
+    BGZF *fpin  = bgzf_open(argv[1], "r");
+    char buf[100000];
+    for (i = 0; i < 100; i++)
+	if (bgzf_read(fpin, buf, 65536) < 0)
+	    abort();
+    int64_t pos = bgzf_tell(fpin);
+    while ((i = bgzf_read(fpin, buf, 65536)) > 0)
+	continue;
+    if (i < 0) abort();
+    int64_t end = bgzf_tell(fpin);
+    bgzf_close(fpin);
+
+#define N 1000
+
+    // Spam random seeks & reads
+    for (i = 0; i < 1000; i++) {
+	printf("i=%d\t", i);
+	fpin  = bgzf_open(argv[1], "r");
+	bgzf_mt(fpin, 8, 256);
+	int j, eof = 0;
+	for (j = 0; j < 80; j++) {
+	    int n = rand() % 6;
+	    putchar('0'+n); fflush(stdout);
+	    switch (n) {
+	    case 0: // start
+		if (bgzf_seek(fpin, 0LL, SEEK_SET) < 0) puts("!");//abort();
+		eof = 0;
+		break;
+	    case 1: // mid
+		if (bgzf_seek(fpin, pos, SEEK_SET) < 0) puts("!");//abort();
+		eof = 0;
+		break;
+	    case 2: // eof
+		if (bgzf_seek(fpin, end, SEEK_SET) < 0) puts("!");//abort();
+		eof = 1;
+		break;
+	    case 3: case 4: {
+		int l = rand()%(n==3?100000:100);
+		if (bgzf_read(fpin, buf, l) != l*(1-eof)) abort();
+		break;
+	    }
+	    case 5:
+		usleep(N);
+		break;
+	    }
+	}
+	printf("\n");
+	if (bgzf_close(fpin))
+	    abort();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This replaces PR #462 with a revised method suggested by @daviesrob.
The synchronisation between main and reader is now done within thread
pool using half-shutdown of the process-queue via reference counting.

Also fixed some memory leaks during shutdowns.