### PR TITLE
Include <sys/select.h>

### DIFF
--- a/knetfile.c
+++ b/knetfile.c
@@ -43,6 +43,7 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <sys/select.h>
 #endif
 
 #include "htslib/knetfile.h"


### PR DESCRIPTION
The <sys/select.h> header is needed for calling select() on some
non-Linux Unices. Unbreaks build on OpenBSD.