### PR TITLE
Improve error msg given invalid/corrupt aux data

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -1372,6 +1372,7 @@ static inline uint8_t *skip_aux(uint8_t *s)
         s += 4;
         return s + size * n;
     case 0:
+        fprintf(stderr, "[E::%s] Invalid aux section in BAM record.\n", __func__);
         abort();
         break;
     default:


### PR DESCRIPTION
I've just traced down an issue in a package using htslib (https://github.com/Illumina/manta/issues/65), which turns out to be caused by a corruption of several bytes in the aux field of one BAM record. The interaction with htslib here was suboptimal because the file containing this record could be viewed and indexed with samtools, but our call to `bam_aux_get()`:

```c++
        static const char satag[] = {'S','A'};
        uint8_t* pTag = bam_aux_get(_bp, satag);
```

...aborts in htslib with no error message (at the location edited in this pull request). As a minimum improvement, I'm submitting an error message here. It would be even better if the corrupted data detection was more uniform and pervasive (such that e.g. `samtools view` would flag the invalid record as well). I could submit something more extensive if there's interest.

For reference on how this could fail in `bam_aux_get`, but not `sam_format1`, the sam output for this record is

    HS21_6844:2:1302:9985:43417#5   83      5       164069525       60      100M    =       164069339       -285    GGGTATGGTGGCTCAGGTCTGTAATCCCTGTAATTCCAGTCCTTTGGGAGGCTGAAGCAGGCAGATCACCTGAGGTCAGGAGTTCAAGACCAGCCTGGCC    8@CCDF><E1C-DF>0;E8=<7B9CA%DD5C)DCE,FECA%<6B:D2@@9B;A<A?:FFEB82C;ED>6DEB@7DAEC?B9=C;:BBB/7CFA/FFD<=*    X0:i:1  X1:i:0  MD:Z:40A59      RG:Z:6844_^A

..while the invalid aux data section is approx index 25-36 from:

```
l_data length: 257
aux segment start: 184

aux index: 0 uint: 88 char: X
aux index: 1 uint: 48 char: 0
aux index: 2 uint: 99 char: c
aux index: 3 uint: 1 char: ^A
aux index: 4 uint: 88 char: X
aux index: 5 uint: 49 char: 1
aux index: 6 uint: 99 char: c
aux index: 7 uint: 0 char: ^@
aux index: 8 uint: 77 char: M
aux index: 9 uint: 68 char: D
aux index: 10 uint: 90 char: Z
aux index: 11 uint: 52 char: 4
aux index: 12 uint: 48 char: 0
aux index: 13 uint: 65 char: A
aux index: 14 uint: 53 char: 5
aux index: 15 uint: 57 char: 9
aux index: 16 uint: 0 char: ^@
aux index: 17 uint: 82 char: R
aux index: 18 uint: 71 char: G
aux index: 19 uint: 90 char: Z
aux index: 20 uint: 54 char: 6
aux index: 21 uint: 56 char: 8
aux index: 22 uint: 52 char: 4
aux index: 23 uint: 52 char: 4
aux index: 24 uint: 95 char: _
aux index: 25 uint: 1 char: ^A
aux index: 26 uint: 0 char: ^@
aux index: 27 uint: 0 char: ^@
aux index: 28 uint: 4 char: ^D
aux index: 29 uint: 0 char: ^@
aux index: 30 uint: 0 char: ^@
aux index: 31 uint: 0 char: ^@
aux index: 32 uint: 103 char: g
aux index: 33 uint: 128 char: <80>
aux index: 34 uint: 199 char: Ç
aux index: 35 uint: 9 char:
aux index: 36 uint: 1 char: ^A
aux index: 37 uint: 83 char: S
aux index: 38 uint: 77 char: M
aux index: 39 uint: 99 char: c
aux index: 40 uint: 37 char: %
aux index: 41 uint: 77 char: M
aux index: 42 uint: 81 char: Q
aux index: 43 uint: 99 char: c
aux index: 44 uint: 60 char: <
aux index: 45 uint: 81 char: Q
aux index: 46 uint: 84 char: T
aux index: 47 uint: 90 char: Z
aux index: 48 uint: 64 char: @
aux index: 49 uint: 64 char: @
aux index: 50 uint: 64 char: @
aux index: 51 uint: 70 char: F
aux index: 52 uint: 68 char: D
aux index: 53 uint: 70 char: F
aux index: 54 uint: 68 char: D
aux index: 55 uint: 68 char: D
aux index: 56 uint: 0 char: ^@
aux index: 57 uint: 82 char: R
aux index: 58 uint: 84 char: T
aux index: 59 uint: 90 char: Z
aux index: 60 uint: 65 char: A
aux index: 61 uint: 67 char: C
aux index: 62 uint: 65 char: A
aux index: 63 uint: 71 char: G
aux index: 64 uint: 84 char: T
aux index: 65 uint: 71 char: G
aux index: 66 uint: 71 char: G
aux index: 67 uint: 84 char: T
aux index: 68 uint: 0 char: ^@
aux index: 69 uint: 88 char: X
aux index: 70 uint: 84 char: T
aux index: 71 uint: 65 char: A
aux index: 72 uint: 85 char: U
```
