### PR TITLE
Fix endianness, integer type and memory safety issues in index metadata

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,8 +9,12 @@ Noteworthy changes in release 1.4
   - the various tbx_conf_* presets are now const
   - auxiliary fields in bam1_t are now always stored in little-endian byte
     order (previously this depended on if you read a bam, sam or cram file)
+  - index metadata (accessible via hts_idx_get_meta()) is now always
+    stored in little-endian byte order (previously this depended on if
+    the index was in tbi or csi format)
   - bam_aux2i() now returns an int64_t value
   - fai_load() will no longer save local copies of remote fasta indexes
+  - hts_idx_get_meta() now takes a uint32_t * for l_meta (was int32_t *)
 
 * New errmod_cal(), probaln_glocal(), sam_cap_mapq(), and sam_prob_realn()
   functions, previously internal to SAMtools, have been added to HTSlib.

--- a/hts.c
+++ b/hts.c
@@ -39,6 +39,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/bgzf.h"
 #include "cram/cram.h"
 #include "htslib/hfile.h"
+#include "htslib/hts_endian.h"
 #include "version.h"
 #include "hts_internal.h"
 
@@ -1248,7 +1249,7 @@ struct __hts_idx_t {
     uint64_t n_no_coor;
     bidx_t **bidx;
     lidx_t *lidx;
-    uint8_t *meta;
+    uint8_t *meta; // MUST have a terminating NUL on the end
     struct {
         uint32_t last_bin, save_bin;
         int last_coor, last_tid, save_tid, finished;
@@ -1774,8 +1775,11 @@ static hts_idx_t *hts_idx_load_local(const char *fn)
         if (bgzf_read(fp, x, 12) != 12) goto fail;
         if (is_be) for (i = 0; i < 3; ++i) ed_swap_4p(&x[i]);
         if (x[2]) {
-            if ((meta = (uint8_t*)malloc(x[2])) == NULL) goto fail;
+            if (SIZE_MAX - x[2] < 1) goto fail; // Prevent possible overflow
+            if ((meta = (uint8_t*)malloc((size_t) x[2] + 1)) == NULL) goto fail;
             if (bgzf_read(fp, meta, x[2]) != x[2]) goto fail;
+            // Prevent possible strlen past the end in tbx_index_load2
+            meta[x[2]] = '\0';
         }
         if (bgzf_read(fp, &n, 4) != 4) goto fail;
         if (is_be) ed_swap_4p(&n);
@@ -1786,14 +1790,23 @@ static hts_idx_t *hts_idx_load_local(const char *fn)
         if (hts_idx_load_core(idx, fp, HTS_FMT_CSI) < 0) goto fail;
     }
     else if (memcmp(magic, "TBI\1", 4) == 0) {
-        uint32_t x[8];
-        if (bgzf_read(fp, x, 32) != 32) goto fail;
-        if (is_be) for (i = 0; i < 8; ++i) ed_swap_4p(&x[i]);
-        if ((idx = hts_idx_init(x[0], HTS_FMT_TBI, 0, 14, 5)) == NULL) goto fail;
-        idx->l_meta = 28 + x[7];
-        if ((idx->meta = (uint8_t*)malloc(idx->l_meta)) == NULL) goto fail;
-        memcpy(idx->meta, &x[1], 28);
-        if (bgzf_read(fp, idx->meta + 28, x[7]) != x[7]) goto fail;
+        uint8_t x[8 * 4];
+        uint32_t n;
+        // Read file header
+        if (bgzf_read(fp, x, sizeof(x)) != sizeof(x)) goto fail;
+        n = le_to_u32(&x[0]); // location of n_ref
+        if ((idx = hts_idx_init(n, HTS_FMT_TBI, 0, 14, 5)) == NULL) goto fail;
+        n = le_to_u32(&x[7*4]); // location of l_nm
+        if (n > UINT32_MAX - 29) goto fail; // Prevent possible overflow
+        idx->l_meta = 28 + n;
+        if ((idx->meta = (uint8_t*)malloc(idx->l_meta + 1)) == NULL) goto fail;
+        // copy format, col_seq, col_beg, col_end, meta, skip, l_nm
+        // N.B. left in little-endian byte order.
+        memcpy(idx->meta, &x[1*4], 28);
+        // Read in sequence names.
+        if (bgzf_read(fp, idx->meta + 28, n) != n) goto fail;
+        // Prevent possible strlen past the end in tbx_index_load2
+        idx->meta[idx->l_meta] = '\0';
         if (hts_idx_load_core(idx, fp, HTS_FMT_TBI) < 0) goto fail;
     }
     else if (memcmp(magic, "BAI\1", 4) == 0) {
@@ -1815,17 +1828,29 @@ fail:
     return NULL;
 }
 
-void hts_idx_set_meta(hts_idx_t *idx, int l_meta, uint8_t *meta, int is_copy)
+int hts_idx_set_meta(hts_idx_t *idx, uint32_t l_meta, uint8_t *meta,
+                      int is_copy)
 {
+    uint8_t *new_meta = meta;
+    if (is_copy) {
+        size_t l = l_meta;
+        if (l > SIZE_MAX - 1) {
+            errno = ENOMEM;
+            return -1;
+        }
+        new_meta = malloc(l + 1);
+        if (!new_meta) return -1;
+        memcpy(new_meta, meta, l);
+        // Prevent possible strlen past the end in tbx_index_load2
+        meta[l + 1] = '\0';
+    }
     if (idx->meta) free(idx->meta);
     idx->l_meta = l_meta;
-    if (is_copy) {
-        idx->meta = (uint8_t*)malloc(l_meta);
-        memcpy(idx->meta, meta, l_meta);
-    } else idx->meta = meta;
+    idx->meta = new_meta;
+    return 0;
 }
 
-uint8_t *hts_idx_get_meta(hts_idx_t *idx, int *l_meta)
+uint8_t *hts_idx_get_meta(hts_idx_t *idx, uint32_t *l_meta)
 {
     *l_meta = idx->l_meta;
     return idx->meta;

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -568,8 +568,33 @@ hts_idx_t *hts_idx_load(const char *fn, int fmt);
 */
 hts_idx_t *hts_idx_load2(const char *fn, const char *fnidx);
 
-    uint8_t *hts_idx_get_meta(hts_idx_t *idx, int *l_meta);
-    void hts_idx_set_meta(hts_idx_t *idx, int l_meta, uint8_t *meta, int is_copy);
+
+/// Get extra index meta-data
+/** @param idx    The index
+    @param l_meta Pointer to where the length of the extra data is stored
+    @return Pointer to the extra data if present; NULL otherwise
+
+    Indexes (both .tbi and .csi) made by tabix include extra data about
+    the indexed file.  The returns a pointer to this data.  Note that the
+    data is stored exactly as it is in the index.  Callers need to interpret
+    the results themselves, including knowing what sort of data to expect;
+    byte swapping etc.
+*/
+uint8_t *hts_idx_get_meta(hts_idx_t *idx, uint32_t *l_meta);
+
+/// Set extra index meta-data
+/** @param idx     The index
+    @param l_meta  Length of data
+    @param meta    Pointer to the extra data
+    @param is_copy If not zero, a copy of the data is taken
+    @return 0 on success; -1 on failure (out of memory).
+
+    Sets the data that is returned by hts_idx_get_meta().
+
+    If is_copy != 0, a copy of the input data is taken.  If not, ownership of
+    the data pointed to by *meta passes to the index.
+*/
+int hts_idx_set_meta(hts_idx_t *idx, uint32_t l_meta, uint8_t *meta, int is_copy);
 
     int hts_idx_get_stat(const hts_idx_t* idx, int tid, uint64_t* mapped, uint64_t* unmapped);
     uint64_t hts_idx_get_n_no_coor(const hts_idx_t* idx);

--- a/tbx.c
+++ b/tbx.c
@@ -1,6 +1,6 @@
 /*  tbx.c -- tabix API functions.
 
-    Copyright (C) 2009, 2010, 2012-2015 Genome Research Ltd.
+    Copyright (C) 2009, 2010, 2012-2015, 2017 Genome Research Ltd.
     Copyright (C) 2010-2012 Broad Institute.
 
     Author: Heng Li <lh3@sanger.ac.uk>
@@ -29,8 +29,10 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
+#include <errno.h>
 #include "htslib/tbx.h"
 #include "htslib/bgzf.h"
+#include "htslib/hts_endian.h"
 #include "hts_internal.h"
 
 #include "htslib/khash.h"
@@ -57,9 +59,17 @@ static inline int get_tid(tbx_t *tbx, const char *ss, int is_add)
     if (is_add) {
         int absent;
         k = kh_put(s2i, d, ss, &absent);
-        if (absent) {
-            kh_key(d, k) = strdup(ss);
-            kh_val(d, k) = kh_size(d) - 1;
+        if (absent < 0) {
+            return -1; // Out of memory
+        } else if (absent) {
+            char *ss_dup = strdup(ss);
+            if (ss_dup) {
+                kh_key(d, k) = ss_dup;
+                kh_val(d, k) = kh_size(d) - 1;
+            } else {
+                kh_del(s2i, d, k);
+                return -1; // Out of memory
+            }
         }
     } else k = kh_get(s2i, d, ss);
     return k == kh_end(d)? -1 : kh_val(d, k);
@@ -283,8 +293,7 @@ tbx_t *tbx_index_load2(const char *fn, const char *fnidx)
     tbx_t *tbx;
     uint8_t *meta;
     char *nm, *p;
-    uint32_t x[7];
-    int l_meta, l_nm;
+    uint32_t l_meta, l_nm;
     tbx = (tbx_t*)calloc(1, sizeof(tbx_t));
     tbx->idx = fnidx? hts_idx_load2(fn, fnidx) : hts_idx_load(fn, HTS_FMT_TBI);
     if ( !tbx->idx )
@@ -293,17 +302,37 @@ tbx_t *tbx_index_load2(const char *fn, const char *fnidx)
         return NULL;
     }
     meta = hts_idx_get_meta(tbx->idx, &l_meta);
-    if ( !meta )
-    {
-        free(tbx);
-        return NULL;
-    }
-    memcpy(x, meta, 28);
-    memcpy(&tbx->conf, x, 24);
+    if ( !meta || l_meta < 28) goto invalid;
+
+    tbx->conf.preset = le_to_i32(&meta[0]);
+    tbx->conf.sc = le_to_i32(&meta[4]);
+    tbx->conf.bc = le_to_i32(&meta[8]);
+    tbx->conf.ec = le_to_i32(&meta[12]);
+    tbx->conf.meta_char = le_to_i32(&meta[16]);
+    tbx->conf.line_skip = le_to_i32(&meta[20]);
+    l_nm = le_to_u32(&meta[24]);
+    if (l_nm > l_meta - 28) goto invalid;
+
     p = nm = (char*)meta + 28;
-    l_nm = x[6];
-    for (; p - nm < l_nm; p += strlen(p) + 1) get_tid(tbx, p, 1);
+    // This assumes meta is NUL-terminated, so we can merrily strlen away.
+    // hts_idx_load_local() assures this for us by adding a NUL on the end
+    // of whatever it reads.
+    for (; p - nm < l_nm; p += strlen(p) + 1) {
+        if (get_tid(tbx, p, 1) < 0) {
+            fprintf(stderr, "[E::%s] %s\n", __func__, strerror(errno));
+            goto fail;
+        }
+    }
     return tbx;
+
+ invalid:
+    if (hts_verbose >= 1) {
+        fprintf(stderr, "[E::%s] Invalid index header for %s\n",
+                __func__, fnidx ? fnidx : fn);
+    }
+ fail:
+    tbx_destroy(tbx);
+    return NULL;
 }
 
 tbx_t *tbx_index_load(const char *fn)


### PR DESCRIPTION
Index metadata stored in an hts_idx_t struct was byte-swapped for
tbi indicies but not for csi.  Make them both the same by leaving the
data in little-endian order, and make tbx_index_load2() access the
data in an endian-neutral manner.

Functions hts_idx_get_meta() and hts_idx_set_meta() are changed to
treat the metadata length as an unsigned value (uint32_t) to match
the integer type that is used to store the length in the hts_idx_t
struct.  hts_idx_set_meta() is also changed to return an int
so callers can detect if it ran out of memory.

hts_idx_load_local() and hts_idx_set_meta() now ensure that the stored
meta-data is always followed by a NUL.  This is to prevent tbx_index_load2()
from running off the end of the metadata if there is an unterminated
string in the list of sequence names.

get_tid() is made to return -1 if it fails to add a hash entry.  A few
other calls to malloc are also made safer.