### PR TITLE
Reworked synced VCF/BCF reading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ BUILT_TEST_PROGRAMS = \
 	test/test-regidx \
 	test/test_view \
 	test/test-vcf-api \
-	test/test-vcf-sweep
+	test/test-vcf-sweep \
+	test/test-bcf-sr
 
 BUILT_THRASH_PROGRAMS = \
 	test/thrash_threads1 \
@@ -153,6 +154,7 @@ LIBHTS_OBJS = \
 	kfunc.o \
 	knetfile.o \
 	kstring.o \
+	bcf_sr_sort.o \
 	bgzf.o \
 	errmod.o \
 	faidx.o \
@@ -300,7 +302,8 @@ vcf.o vcf.pico: vcf.c config.h $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) 
 sam.o sam.pico: sam.c config.h $(htslib_sam_h) $(htslib_bgzf_h) $(cram_h) $(hts_internal_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_kstring_h) $(htslib_hts_endian_h)
 tbx.o tbx.pico: tbx.c config.h $(htslib_tbx_h) $(htslib_bgzf_h) $(hts_internal_h) $(htslib_khash_h)
 faidx.o faidx.pico: faidx.c config.h $(htslib_bgzf_h) $(htslib_faidx_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kstring_h) $(hts_internal_h)
-synced_bcf_reader.o synced_bcf_reader.pico: synced_bcf_reader.c config.h $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) $(htslib_bgzf_h) $(htslib_thread_pool_h)
+bcf_sr_sort.o bcf_sr_sort.pico: bcf_sr_sort.c config.h bcf_sr_sort.h $(htslib_kseq_h) $(htslib_khash_str2int_h)
+synced_bcf_reader.o synced_bcf_reader.pico: synced_bcf_reader.c config.h bcf_sr_sort.h $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) $(htslib_bgzf_h) $(htslib_thread_pool_h)
 vcf_sweep.o vcf_sweep.pico: vcf_sweep.c config.h $(htslib_vcf_sweep_h) $(htslib_bgzf_h)
 vcfutils.o vcfutils.pico: vcfutils.c config.h $(htslib_vcfutils_h) $(htslib_kbitset_h)
 kfunc.o kfunc.pico: kfunc.c config.h $(htslib_kfunc_h)
@@ -385,6 +388,9 @@ test/test-vcf-api: test/test-vcf-api.o libhts.a
 test/test-vcf-sweep: test/test-vcf-sweep.o libhts.a
 	$(CC) -pthread $(LDFLAGS) -o $@ test/test-vcf-sweep.o libhts.a -lz $(LIBS)
 
+test/test-bcf-sr: test/test-bcf-sr.o libhts.a
+	$(CC) -pthread $(LDFLAGS) -o $@ test/test-bcf-sr.o libhts.a -lz $(LIBS)
+
 test/hts_endian.o: test/hts_endian.c $(htslib_hts_endian_h)
 test/fieldarith.o: test/fieldarith.c config.h $(htslib_sam_h)
 test/hfile.o: test/hfile.c config.h $(htslib_hfile_h) $(htslib_hts_defs_h)
@@ -394,6 +400,7 @@ test/test-regidx.o: test/test-regidx.c config.h $(htslib_regidx_h) $(hts_interna
 test/test_view.o: test/test_view.c config.h $(cram_h) $(htslib_sam_h)
 test/test-vcf-api.o: test/test-vcf-api.c config.h $(htslib_hts_h) $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_kseq_h)
 test/test-vcf-sweep.o: test/test-vcf-sweep.c config.h $(htslib_vcf_sweep_h)
+test/test-bcf-sr.o: test/test-bcf-sr.c config.h $(htslib_vcf_sweep_h) bcf_sr_sort.h
 
 
 test/thrash_threads1: test/thrash_threads1.o libhts.a

--- a/bcf_sr_sort.c
+++ b/bcf_sr_sort.c
@@ -1,0 +1,645 @@
+/* 
+    Copyright (C) 2017 Genome Research Ltd.
+
+    Author: Petr Danecek <pd3@sanger.ac.uk>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+#include "bcf_sr_sort.h"
+#include "htslib/khash_str2int.h"
+
+#define SR_REF   1
+#define SR_SNP   2
+#define SR_INDEL 4
+#define SR_OTHER 8
+#define SR_SCORE(srt,a,b) (srt)->score[((a)<<4)|(b)]
+
+// Resize a bit set.
+static inline kbitset_t *kbs_resize(kbitset_t *bs, size_t ni)
+{
+    if ( !bs ) return kbs_init(ni);
+    size_t n = (ni + KBS_ELTBITS-1) / KBS_ELTBITS;
+    if ( n==bs->n ) return bs;
+
+    bs = (kbitset_t *) realloc(bs, sizeof(kbitset_t) + n * sizeof(unsigned long));
+    if ( bs==NULL ) return NULL;
+    if ( n > bs->n )
+        memset(bs->b + bs->n, 0, (n - bs->n) * sizeof (unsigned long));
+    bs->n = n;
+    bs->b[n] = ~0UL;
+    return bs;
+}
+
+// Logical AND
+static inline int kbs_logical_and(kbitset_t *bs1, kbitset_t *bs2)
+{
+    // General case, bitsets of unequal size:
+    //  int i, n = bs1->n < bs2->n ? bs1->n : bs2->n;
+    int i, n = bs1->n;
+
+    for (i=0; i<n; i++) if ( bs1->b[i] & bs2->b[i] ) return 1;
+    return 0;
+}
+
+// Bitwise OR, dst will be modified, src will be left unchanged
+static inline void kbs_bitwise_or(kbitset_t *dst, kbitset_t *src)
+{
+    int i;
+    for (i=0; i<dst->n; i++) dst->b[i] |= src->b[i];
+}
+
+
+static void bcf_sr_init_scores(sr_sort_t *srt)
+{
+    int i,jbit,kbit;
+
+    // lower number = lower priority, zero means forbidden
+
+    if ( srt->pair & BCF_SR_PAIR_ANY ) srt->pair |= (BCF_SR_PAIR_SNPS | BCF_SR_PAIR_INDELS | BCF_SR_PAIR_SNP_REF | BCF_SR_PAIR_INDEL_REF);
+    if ( srt->pair & BCF_SR_PAIR_SNPS ) SR_SCORE(srt,SR_SNP,SR_SNP) = 3;
+    if ( srt->pair & BCF_SR_PAIR_INDELS ) SR_SCORE(srt,SR_INDEL,SR_INDEL) = 3;
+    if ( srt->pair & BCF_SR_PAIR_SNP_REF ) 
+    {
+        SR_SCORE(srt,SR_SNP,SR_REF) = 2;
+        SR_SCORE(srt,SR_REF,SR_SNP) = 2;
+    }
+    if ( srt->pair & BCF_SR_PAIR_INDEL_REF ) 
+    {
+        SR_SCORE(srt,SR_INDEL,SR_REF) = 2;
+        SR_SCORE(srt,SR_REF,SR_INDEL) = 2;
+    }
+    if ( srt->pair & BCF_SR_PAIR_ANY )
+    {
+        for (i=0; i<256; i++)
+            if ( !srt->score[i] ) srt->score[i] = 1;
+    }
+
+    // set all combinations
+    for (i=0; i<256; i++)
+    {
+        if ( srt->score[i] ) continue;      // already set
+        int max = 0;
+        for (jbit=0; jbit<4; jbit++)        // high bits
+        {
+            int j = 1<<jbit;
+            if ( !(i & (j<<4)) ) continue;
+            for (kbit=0; kbit<4; kbit++)    // low bits
+            {
+                int k = 1<<kbit;
+                if ( !(i & k) ) continue;
+                if ( max < SR_SCORE(srt,j,k) ) max = SR_SCORE(srt,j,k);
+            }
+        }
+        srt->score[i] = max;
+    }
+}
+static int multi_is_exact(var_t *avar, var_t *bvar)
+{
+    if ( avar->nalt != bvar->nalt ) return 0;
+
+    int alen = strlen(avar->str);
+    int blen = strlen(bvar->str);
+    if ( alen != blen ) return 0;
+
+    char *abeg = avar->str;
+    while ( *abeg )
+    {
+        char *aend = abeg;
+        while ( *aend && *aend!=',' ) aend++;
+
+        char *bbeg = bvar->str;
+        while ( *bbeg )
+        {
+            char *bend = bbeg;
+            while ( *bend && *bend!=',' ) bend++;
+            if ( bend - bbeg == aend - abeg && !strncasecmp(abeg,bbeg,bend-bbeg) ) break;
+            bbeg = *bend ? bend+1 : bend;
+        }
+        if ( !*bbeg ) return 0;
+
+        abeg = *aend ? aend+1 : aend;
+    }
+    return 1;
+}
+static int multi_is_subset(var_t *avar, var_t *bvar)
+{
+    char *abeg = avar->str;
+    while ( *abeg )
+    {
+        char *aend = abeg;
+        while ( *aend && *aend!=',' ) aend++;
+
+        char *bbeg = bvar->str;
+        while ( *bbeg )
+        {
+            char *bend = bbeg;
+            while ( *bend && *bend!=',' ) bend++;
+            if ( bend - bbeg == aend - abeg && !strncasecmp(abeg,bbeg,bend-bbeg) ) return 1;
+            bbeg = *bend ? bend+1 : bend;
+        }
+        abeg = *aend ? aend+1 : aend;
+    }
+    return 0;
+}
+int32_t pairing_score(sr_sort_t *srt, int ivset, int jvset)
+{
+    varset_t *iv = &srt->vset[ivset];
+    varset_t *jv = &srt->vset[jvset];
+
+    // Restrictive logic: the strictest type from a group is selected,
+    // so that, for example, snp+ref does not lead to the inclusion of an indel
+    int i,j;
+    uint32_t min = UINT32_MAX;
+    for (i=0; i<iv->nvar; i++)
+    {
+        var_t *ivar = &srt->var[iv->var[i]];
+        for (j=0; j<jv->nvar; j++)
+        {
+            var_t *jvar = &srt->var[jv->var[j]];
+            if ( srt->pair & BCF_SR_PAIR_EXACT )
+            {
+                if ( ivar->type != jvar->type ) continue;
+                if ( !strcmp(ivar->str,jvar->str) ) return UINT32_MAX;  // exact match, best possibility
+                if ( multi_is_exact(ivar,jvar) ) return UINT32_MAX; // identical alleles
+                continue;
+            }
+            if ( ivar->type==jvar->type && !strcmp(ivar->str,jvar->str) ) return UINT32_MAX;  // exact match, best possibility
+            if ( ivar->type & jvar->type && multi_is_subset(ivar,jvar) ) return UINT32_MAX; // one of the alleles is identical
+
+            uint32_t score = SR_SCORE(srt,ivar->type,jvar->type);
+            if ( !score ) return 0;     // some of the varsets in the two groups are not compatible, will not pair
+            if ( min>score ) min = score;
+        }
+    }
+    if ( srt->pair & BCF_SR_PAIR_EXACT ) return 0;
+
+    assert( min!=UINT32_MAX );
+
+    uint32_t cnt = 0;
+    for (i=0; i<iv->nvar; i++) cnt += srt->var[iv->var[i]].nvcf;
+    for (j=0; j<jv->nvar; j++) cnt += srt->var[jv->var[j]].nvcf;
+
+    return (1<<(28+min)) + cnt;
+}
+void remove_vset(sr_sort_t *srt, int jvset)
+{
+    if ( jvset+1 < srt->nvset )
+    {
+        varset_t tmp = srt->vset[jvset];
+        memmove(&srt->vset[jvset], &srt->vset[jvset+1], sizeof(varset_t)*(srt->nvset - jvset - 1));
+        srt->vset[srt->nvset-1] = tmp;
+
+        int *jmat = srt->pmat + jvset*srt->ngrp;
+        memmove(jmat, &jmat[srt->ngrp],sizeof(int)*(srt->nvset - jvset - 1)*srt->ngrp);
+
+        memmove(&srt->cnt[jvset], &srt->cnt[jvset+1], sizeof(int)*(srt->nvset - jvset - 1));
+    }
+    srt->nvset--;
+}
+int merge_vsets(sr_sort_t *srt, int ivset, int jvset)
+{
+    int i,j;
+    if ( ivset > jvset ) { i = ivset; ivset = jvset; jvset = i; }
+
+    varset_t *iv = &srt->vset[ivset];
+    varset_t *jv = &srt->vset[jvset];
+
+    kbs_bitwise_or(iv->mask,jv->mask);
+
+    i = iv->nvar;
+    iv->nvar += jv->nvar;
+    hts_expand(int, iv->nvar, iv->mvar, iv->var);
+    for (j=0; j<jv->nvar; j++,i++) iv->var[i] = jv->var[j];
+
+    int *imat = srt->pmat + ivset*srt->ngrp;
+    int *jmat = srt->pmat + jvset*srt->ngrp;
+    for (i=0; i<srt->ngrp; i++) imat[i] += jmat[i];
+    srt->cnt[ivset] += srt->cnt[jvset];
+
+    remove_vset(srt, jvset);
+
+    return ivset;
+}
+void push_vset(sr_sort_t *srt, int ivset)
+{
+    varset_t *iv = &srt->vset[ivset];
+    int i,j;
+    for (i=0; i<srt->sr->nreaders; i++)
+    {
+        vcf_buf_t *buf = &srt->vcf_buf[i];
+        buf->nrec++;
+        hts_expand(bcf1_t*,buf->nrec,buf->mrec,buf->rec);
+        buf->rec[buf->nrec-1] = NULL;
+    }
+    for (i=0; i<iv->nvar; i++)
+    {
+        var_t *var = &srt->var[ iv->var[i] ];
+        for (j=0; j<var->nvcf; j++)
+        {
+            int jvcf = var->vcf[j];
+            vcf_buf_t *buf = &srt->vcf_buf[jvcf];
+            buf->rec[buf->nrec-1] = var->rec[j];
+        }
+    }
+    remove_vset(srt, ivset);
+}
+
+static int cmpstringp(const void *p1, const void *p2)
+{
+    return strcmp(* (char * const *) p1, * (char * const *) p2);
+}
+void debug_vsets(sr_sort_t *srt)
+{
+    int i,j,k;
+    for (i=0; i<srt->nvset; i++)
+    {
+        fprintf(stderr,"dbg_vset %d:", i);
+        for (j=0; j<srt->vset[i].mask->n; j++) fprintf(stderr,"%c%lu",j==0?' ':':',srt->vset[i].mask->b[j]);
+        fprintf(stderr,"\t");
+        for (j=0; j<srt->vset[i].nvar; j++)
+        {
+            var_t *var = &srt->var[srt->vset[i].var[j]];
+            fprintf(stderr,"\t%s",var->str);
+            for (k=0; k<var->nvcf; k++)
+                fprintf(stderr,"%c%d", k==0?':':',',var->vcf[k]);
+        }
+        fprintf(stderr,"\n");
+    }
+}
+void debug_vbuf(sr_sort_t *srt)
+{
+    int i, j;
+    for (j=0; j<srt->vcf_buf[0].nrec; j++)
+    {
+        fprintf(stderr,"dbg_vbuf %d:\t", j);
+        for (i=0; i<srt->sr->nreaders; i++)
+        {
+            vcf_buf_t *buf = &srt->vcf_buf[i];
+            fprintf(stderr,"\t%d", buf->rec[j] ? buf->rec[j]->pos+1 : 0);
+        }
+        fprintf(stderr,"\n");
+    }
+}
+char *grp_create_key(sr_sort_t *srt)
+{
+    if ( !srt->str.l ) return strdup("");
+    int i;
+    hts_expand(char*,srt->noff,srt->mcharp,srt->charp);
+    for (i=0; i<srt->noff; i++)
+    {
+        srt->charp[i] = srt->str.s + srt->off[i];
+        if ( i>0 ) srt->charp[i][-1] = 0;
+    }
+    qsort(srt->charp, srt->noff, sizeof(*srt->charp), cmpstringp);
+    char *ret = (char*) malloc(srt->str.l + 1), *ptr = ret;
+    for (i=0; i<srt->noff; i++)
+    {
+        int len = strlen(srt->charp[i]);
+        memcpy(ptr, srt->charp[i], len);
+        ptr += len + 1;
+        ptr[-1] = i+1==srt->noff ? 0 : ';';
+    }
+    return ret;
+}
+static void bcf_sr_sort_set(bcf_srs_t *readers, sr_sort_t *srt, const char *chr, int min_pos)
+{
+    if ( !srt->grp_str2int )
+    {
+        // first time here, initialize
+        if ( !srt->pair )
+        {
+            if ( readers->collapse==COLLAPSE_NONE ) readers->collapse = BCF_SR_PAIR_EXACT;
+            bcf_sr_set_opt(readers, BCF_SR_PAIR_LOGIC, readers->collapse);
+        }
+        bcf_sr_init_scores(srt);
+        srt->grp_str2int = khash_str2int_init();
+        srt->var_str2int = khash_str2int_init();
+    }
+    int k;
+    khash_t(str2int) *hash;
+    hash = srt->grp_str2int;
+    for (k=0; k < kh_end(hash); k++)
+        if ( kh_exist(hash,k) ) free((char*)kh_key(hash,k));
+    hash = srt->var_str2int;
+    for (k=0; k < kh_end(hash); k++)
+        if ( kh_exist(hash,k) ) free((char*)kh_key(hash,k));
+    kh_clear(str2int, srt->grp_str2int);
+    kh_clear(str2int, srt->var_str2int);
+    srt->ngrp = srt->nvar = srt->nvset = 0;
+
+    grp_t grp;
+    memset(&grp,0,sizeof(grp_t));
+
+    // group VCFs into groups, each with a unique combination of variants in the duplicate lines
+    int ireader,ivar,irec,igrp,ivset;
+    for (ireader=0; ireader<readers->nreaders; ireader++)
+    {
+        srt->vcf_buf[ireader].nrec = 0;
+
+        bcf_sr_t *reader = &readers->readers[ireader];
+        int rid   = bcf_hdr_name2id(reader->header, chr);
+        grp.nvar  = 0;
+        hts_expand(int,reader->nbuffer,srt->moff,srt->off);
+        srt->noff  = 0;
+        srt->str.l = 0;
+        for (irec=1; irec<=reader->nbuffer; irec++)
+        {
+            bcf1_t *line = reader->buffer[irec];
+            if ( line->rid!=rid || line->pos!=min_pos ) break;
+            
+            if ( srt->str.l ) kputc(';',&srt->str);
+            srt->off[srt->noff++] = srt->str.l;
+            size_t beg = srt->str.l;
+            for (ivar=1; ivar<line->n_allele; ivar++)
+            {
+                if ( ivar>1 ) kputc(',',&srt->str);
+                kputs(line->d.allele[0],&srt->str);
+                kputc('>',&srt->str);
+                kputs(line->d.allele[ivar],&srt->str);
+            }
+            if ( line->n_allele==1 )
+            {
+                kputs(line->d.allele[0],&srt->str);
+                kputsn(">.",2,&srt->str);
+            }
+
+            // Create new variant or attach to existing one. But careful, there can be duplicate
+            // records with the same POS,REF,ALT (e.g. in dbSNP-b142)
+            char *var_str = beg + srt->str.s;
+            int ret, var_idx = 0, var_end = srt->str.l;
+            while ( 1 )
+            {
+                ret = khash_str2int_get(srt->var_str2int, var_str, &ivar);
+                if ( ret==-1 ) break;
+
+                var_t *var = &srt->var[ivar];
+                if ( var->vcf[var->nvcf-1] != ireader ) break;
+
+                srt->str.l = var_end;
+                kputw(var_idx, &srt->str);
+                var_str = beg + srt->str.s;
+                var_idx++;
+            }
+            if ( ret==-1 )
+            {
+                ivar = srt->nvar++;
+                hts_expand0(var_t,srt->nvar,srt->mvar,srt->var);
+                srt->var[ivar].nvcf = 0;
+                khash_str2int_set(srt->var_str2int, strdup(var_str), ivar);
+                free(srt->var[ivar].str);   // possible left-over from the previous position
+            }
+            var_t *var = &srt->var[ivar];
+            var->nalt = line->n_allele - 1;
+            var->type = bcf_get_variant_types(line);
+            srt->str.s[var_end] = 0;
+            if ( ret==-1 )
+                var->str = strdup(var_str);
+
+            int mvcf = var->mvcf;
+            var->nvcf++;
+            hts_expand0(int*, var->nvcf, var->mvcf, var->vcf);
+            if ( mvcf != var->mvcf ) var->rec = (bcf1_t **) realloc(var->rec,sizeof(bcf1_t*)*var->mvcf);
+            var->vcf[var->nvcf-1] = ireader;
+            var->rec[var->nvcf-1] = line;
+
+            grp.nvar++;
+            hts_expand(var_t,grp.nvar,grp.mvar,grp.var);
+            grp.var[grp.nvar-1] = ivar;
+        }
+        char *grp_key = grp_create_key(srt);
+        int ret = khash_str2int_get(srt->grp_str2int, grp_key, &igrp);
+        if ( ret==-1 )
+        {
+            igrp = srt->ngrp++;
+            hts_expand0(grp_t, srt->ngrp, srt->mgrp, srt->grp);
+            free(srt->grp[igrp].var);
+            srt->grp[igrp] = grp;
+            srt->grp[igrp].key = grp_key;
+            khash_str2int_set(srt->grp_str2int, grp_key, igrp);
+            memset(&grp,0,sizeof(grp_t));
+        }
+        else
+            free(grp_key);
+        srt->grp[igrp].nvcf++;
+    }
+    free(grp.var);
+
+    // initialize bitmask - which groups is the variant present in
+    for (ivar=0; ivar<srt->nvar; ivar++)
+    {
+        srt->var[ivar].mask = kbs_resize(srt->var[ivar].mask, srt->ngrp);
+        kbs_clear(srt->var[ivar].mask);
+    }
+    for (igrp=0; igrp<srt->ngrp; igrp++)
+    {
+        for (ivar=0; ivar<srt->grp[igrp].nvar; ivar++)
+        {
+            int i = srt->grp[igrp].var[ivar];
+            kbs_insert(srt->var[i].mask, igrp);
+        }
+    }
+
+    // create the initial list of variant sets
+    for (ivar=0; ivar<srt->nvar; ivar++) 
+    {
+        ivset = srt->nvset++;
+        hts_expand0(varset_t, srt->nvset, srt->mvset, srt->vset);
+
+        varset_t *vset = &srt->vset[ivset];
+        vset->nvar = 1;
+        hts_expand0(var_t, vset->nvar, vset->mvar, vset->var);
+        vset->var[vset->nvar-1] = ivar;
+        var_t *var  = &srt->var[ivar];
+        vset->cnt   = var->nvcf;
+        vset->mask  = kbs_resize(vset->mask, srt->ngrp);
+        kbs_clear(vset->mask);
+        kbs_bitwise_or(vset->mask, var->mask);
+
+        int type = 0;
+        if ( var->type==VCF_REF ) type |= SR_REF;
+        else
+        {
+            if ( var->type & VCF_SNP ) type |= SR_SNP;
+            if ( var->type & VCF_MNP ) type |= SR_SNP;
+            if ( var->type & VCF_INDEL ) type |= SR_INDEL;
+            if ( var->type & VCF_OTHER ) type |= SR_OTHER;
+        }
+        var->type = type;
+    }
+    // debug_vsets(srt);
+
+    // initialize the pairing matrix
+    hts_expand(int, srt->ngrp*srt->nvset, srt->mpmat, srt->pmat);
+    hts_expand(int, srt->nvset, srt->mcnt, srt->cnt);
+    memset(srt->pmat, 0, sizeof(*srt->pmat)*srt->ngrp*srt->nvset);
+    for (ivset=0; ivset<srt->nvset; ivset++)
+    {
+        varset_t *vset = &srt->vset[ivset];
+        for (igrp=0; igrp<srt->ngrp; igrp++) srt->pmat[ivset*srt->ngrp+igrp] = 0;
+        srt->cnt[ivset] = vset->cnt;
+    }
+
+    // pair the lines
+    while ( srt->nvset )
+    {
+        // fprintf(stderr,"\n"); debug_vsets(srt);
+
+        int imax = 0;
+        for (ivset=1; ivset<srt->nvset; ivset++)
+            if ( srt->cnt[imax] < srt->cnt[ivset] ) imax = ivset;
+
+        int ipair = -1;
+        uint32_t max_score = 0;
+        for (ivset=0; ivset<srt->nvset; ivset++)
+        {
+            if ( kbs_logical_and(srt->vset[imax].mask,srt->vset[ivset].mask) ) continue;   // cannot be merged
+            uint32_t score = pairing_score(srt, imax, ivset);
+            // fprintf(stderr,"score: %d %d, logic=%d \t..\t %u\n", imax,ivset,srt->pair,score);
+            if ( max_score < score ) { max_score = score; ipair = ivset; }
+        }
+
+        // merge rows creating a new variant set this way
+        if ( ipair!=-1 && ipair!=imax )
+        {
+            imax = merge_vsets(srt, imax, ipair);
+            continue;
+        }
+
+        push_vset(srt, imax);
+    }
+
+    srt->chr = chr;
+    srt->pos = min_pos;
+}
+
+int bcf_sr_sort_next(bcf_srs_t *readers, sr_sort_t *srt, const char *chr, int min_pos)
+{
+    int i,j;
+    if ( readers->nreaders == 1 )
+    {
+        srt->nsr = 1;
+        if ( !srt->msr )
+        {
+            srt->vcf_buf = (vcf_buf_t*) calloc(1,sizeof(vcf_buf_t));   // first time here
+            srt->msr = 1;
+        }
+        bcf_sr_t *reader = &readers->readers[0];
+        assert( reader->buffer[1]->pos==min_pos );
+        bcf1_t *tmp = reader->buffer[0];
+        for (j=1; j<=reader->nbuffer; j++) reader->buffer[j-1] = reader->buffer[j];
+        reader->buffer[ reader->nbuffer ] = tmp;
+        reader->nbuffer--;
+        readers->has_line[0] = 1;
+        return 1;
+    }
+    if ( srt->nsr != readers->nreaders )
+    {
+        srt->sr = readers;
+        if ( srt->nsr < readers->nreaders )
+        {
+            srt->vcf_buf = (vcf_buf_t*) realloc(srt->vcf_buf,readers->nreaders*sizeof(vcf_buf_t));
+            memset(srt->vcf_buf + srt->nsr, 0, sizeof(vcf_buf_t)*(readers->nreaders - srt->nsr));
+            if ( srt->msr < srt->nsr ) srt->msr = srt->nsr;
+        }
+        srt->nsr = readers->nreaders;
+        srt->chr = NULL;
+    }
+    if ( !srt->chr || srt->pos!=min_pos || strcmp(srt->chr,chr) ) bcf_sr_sort_set(readers, srt, chr, min_pos);
+
+    if ( !srt->vcf_buf[0].nrec ) return 0;
+
+    // debug_vbuf(srt);
+
+    int nret = 0;
+    for (i=0; i<srt->sr->nreaders; i++)
+    {
+        vcf_buf_t *buf = &srt->vcf_buf[i];
+
+        if ( buf->rec[0] ) 
+        {
+            bcf_sr_t *reader = &srt->sr->readers[i];
+            for (j=1; j<=reader->nbuffer; j++)
+                if ( reader->buffer[j] == buf->rec[0] ) break;
+
+            assert( j<=reader->nbuffer );
+
+            bcf1_t *tmp = reader->buffer[0];
+            reader->buffer[0] = reader->buffer[j++];
+            for (; j<=reader->nbuffer; j++) reader->buffer[j-1] = reader->buffer[j];
+            reader->buffer[ reader->nbuffer ] = tmp;
+            reader->nbuffer--;
+
+            nret++;
+            srt->sr->has_line[i] = 1;
+        }
+        else
+            srt->sr->has_line[i] = 0; 
+
+        buf->nrec--;
+        if ( buf->nrec > 0 )
+            memmove(buf->rec, &buf->rec[1], buf->nrec*sizeof(bcf1_t*));
+    }
+    return nret;
+}
+void bcf_sr_sort_remove_reader(bcf_srs_t *readers, sr_sort_t *srt, int i)
+{
+    free(srt->vcf_buf[i].rec);
+    if ( i+1 < srt->nsr )
+        memmove(&srt->vcf_buf[i], &srt->vcf_buf[i+1], (srt->nsr - i - 1)*sizeof(vcf_buf_t));
+    memset(srt->vcf_buf + srt->nsr - 1, 0, sizeof(vcf_buf_t));
+}
+sr_sort_t *bcf_sr_sort_init(sr_sort_t *srt)
+{
+    if ( !srt ) return calloc(1,sizeof(sr_sort_t));
+    memset(srt,0,sizeof(sr_sort_t));
+    return srt;
+}
+void bcf_sr_sort_destroy(sr_sort_t *srt)
+{
+    if ( srt->var_str2int ) khash_str2int_destroy_free(srt->var_str2int);
+    if ( srt->grp_str2int ) khash_str2int_destroy_free(srt->grp_str2int);
+    int i;
+    for (i=0; i<srt->nsr; i++) free(srt->vcf_buf[i].rec);
+    free(srt->vcf_buf);
+    for (i=0; i<srt->mvar; i++)
+    {
+        free(srt->var[i].str);
+        free(srt->var[i].vcf);
+        free(srt->var[i].rec);
+        kbs_destroy(srt->var[i].mask);
+    }
+    free(srt->var);
+    for (i=0; i<srt->mgrp; i++)
+        free(srt->grp[i].var);
+    free(srt->grp);
+    for (i=0; i<srt->mvset; i++)
+    {
+        kbs_destroy(srt->vset[i].mask);
+        free(srt->vset[i].var);
+    }
+    free(srt->vset);
+    free(srt->str.s);
+    free(srt->off);
+    free(srt->charp);
+    free(srt->cnt);
+    free(srt->pmat);
+    memset(srt,0,sizeof(*srt));
+}
+

--- a/bcf_sr_sort.h
+++ b/bcf_sr_sort.h
@@ -1,0 +1,103 @@
+/* 
+    Copyright (C) 2017 Genome Research Ltd.
+
+    Author: Petr Danecek <pd3@sanger.ac.uk>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+/*
+    Reorder duplicate lines so that compatible variant types are
+    returned together by bcf_sr_next_line()
+
+    - readers grouped by variants. Even with many readers there will be
+      typically only several groups
+
+*/
+
+#ifndef __BCF_SR_SORT_H__
+#define __BCF_SR_SORT_H__
+
+#include "htslib/synced_bcf_reader.h"
+#include "htslib/kbitset.h"
+
+typedef struct
+{
+    int nrec, mrec;
+    bcf1_t **rec;
+}
+vcf_buf_t;
+
+typedef struct
+{
+    char *str;      // "A>C" for biallelic records or "A>C,A>CC" for multiallelic records
+    int type;       // VCF_SNP, VCF_REF, etc.
+    int nalt;       // number of alternate alleles in this record
+    int nvcf, mvcf, *vcf;   // the list of readers with the same variants
+    bcf1_t **rec;           // list of VCF records in the readers
+    kbitset_t *mask;        // which groups contain the variant
+}
+var_t;
+
+typedef struct
+{
+    char *key;              // only for debugging
+    int nvar, mvar, *var;   // the variants and their type
+    int nvcf;               // number of readers with the same variants
+}
+grp_t;
+
+typedef struct
+{
+    int nvar, mvar, *var;   // list of compatible variants that can be output together
+    int cnt;                // number of readers in this group
+    kbitset_t *mask;        // which groups are populated in this set (replace with expandable bitmask)
+}
+varset_t;
+
+typedef struct
+{
+    uint8_t score[256];
+    int nvar, mvar;
+    var_t *var;             // list of all variants from all readers
+    int nvset, mvset;
+    int mpmat, *pmat;       // pairing matrix, i-th vset and j-th group accessible as i*ngrp+j
+    int ngrp, mgrp;
+    int mcnt, *cnt;         // number of VCF covered by a varset
+    grp_t *grp;             // list of VCF representatives, each with a unique combination of duplicate lines
+    varset_t *vset;         // list of variant sets - combinations of compatible variants across multiple groups ready for output
+    vcf_buf_t *vcf_buf;     // records sorted in output order, for each VCF
+    bcf_srs_t *sr;
+    void *grp_str2int;
+    void *var_str2int;
+    kstring_t str;
+    int moff, noff, *off, mcharp;
+    char **charp;
+    const char *chr;
+    int pos, nsr, msr;
+    int pair;
+}
+sr_sort_t;
+
+sr_sort_t *bcf_sr_sort_init(sr_sort_t *srt);
+int bcf_sr_sort_next(bcf_srs_t *readers, sr_sort_t *srt, const char *chr, int pos);
+void bcf_sr_sort_destroy(sr_sort_t *srt);
+void bcf_sr_sort_remove_reader(bcf_srs_t *readers, sr_sort_t *srt, int i);
+
+#endif

--- a/htslib.mk
+++ b/htslib.mk
@@ -74,6 +74,8 @@ HTSLIB_PUBLIC_HEADERS = \
 
 HTSLIB_ALL = \
 	$(HTSLIB_PUBLIC_HEADERS) \
+	$(HTSDIR)/bcf_sr_sort.c \
+	$(HTSDIR)/bcf_sr_sort.h \
 	$(HTSDIR)/bgzf.c \
 	$(HTSDIR)/config.h \
 	$(HTSDIR)/errmod.c \

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -35,6 +35,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/khash_str2int.h"
 #include "htslib/bgzf.h"
 #include "htslib/thread_pool.h"
+#include "bcf_sr_sort.h"
 
 #define MAX_CSI_COOR 0x7fffffff     // maximum indexable coordinate of .csi
 
@@ -50,6 +51,13 @@ typedef struct _region_t
     int nregs, mregs, creg;
 }
 region_t;
+
+#define BCF_SR_AUX(x) ((aux_t*)((x)->aux))
+typedef struct
+{
+    sr_sort_t sort;
+}
+aux_t;
 
 static void _regions_add(bcf_sr_regions_t *reg, const char *chr, int start, int end);
 static bcf_sr_regions_t *_regions_init_string(const char *str);
@@ -81,6 +89,26 @@ char *bcf_sr_strerror(int errnum)
             return "BCF read error"; break;
         default: return "";
     }
+}
+
+int bcf_sr_set_opt(bcf_srs_t *readers, bcf_sr_opt_t opt, ...)
+{
+    va_list args;
+    switch (opt) 
+    {
+        case BCF_SR_REQUIRE_IDX:
+            readers->require_index = 1;
+            return 0;
+
+        case BCF_SR_PAIR_LOGIC: 
+            va_start(args, opt);
+            BCF_SR_AUX(readers)->sort.pair = va_arg(args, int);
+            return 0;
+
+        default:
+            break;
+    }
+    return 1;
 }
 
 static int *init_filters(bcf_hdr_t *hdr, const char *filters, int *nfilters)
@@ -295,6 +323,8 @@ int bcf_sr_add_reader(bcf_srs_t *files, const char *fname)
 bcf_srs_t *bcf_sr_init(void)
 {
     bcf_srs_t *files = (bcf_srs_t*) calloc(1,sizeof(bcf_srs_t));
+    files->aux = (aux_t*) calloc(1,sizeof(aux_t));
+    bcf_sr_sort_init(&BCF_SR_AUX(files)->sort);
     return files;
 }
 
@@ -327,12 +357,15 @@ void bcf_sr_destroy(bcf_srs_t *files)
     if (files->regions) bcf_sr_regions_destroy(files->regions);
     if (files->tmps.m) free(files->tmps.s);
     if (files->n_threads) bcf_sr_destroy_threads(files);
+    bcf_sr_sort_destroy(&BCF_SR_AUX(files)->sort);
+    free(files->aux);
     free(files);
 }
 
 void bcf_sr_remove_reader(bcf_srs_t *files, int i)
 {
     assert( !files->samples );  // not ready for this yet
+    bcf_sr_sort_remove_reader(files, &BCF_SR_AUX(files)->sort, i);
     bcf_sr_destroy1(&files->readers[i]);
     if ( i+1 < files->nreaders )
     {
@@ -342,52 +375,6 @@ void bcf_sr_remove_reader(bcf_srs_t *files, int i)
     files->nreaders--;
 }
 
-
-/*
-   Removes duplicate records from the buffer. The meaning of "duplicate" is
-   controlled by the $collapse variable, which can cause that from multiple
-   <indel|snp|any> lines only the first is considered and the rest is ignored.
-   The removal is done by setting the redundant lines' positions to -1 and
-   moving these lines at the end of the buffer.
- */
-static void collapse_buffer(bcf_srs_t *files, bcf_sr_t *reader)
-{
-    int irec,jrec, has_snp=0, has_indel=0, has_any=0;
-    for (irec=1; irec<=reader->nbuffer; irec++)
-    {
-        bcf1_t *line = reader->buffer[irec];
-        if ( line->pos != reader->buffer[1]->pos ) break;
-        if ( files->collapse&COLLAPSE_ANY )
-        {
-            if ( !has_any ) has_any = 1;
-            else line->pos = -1;
-        }
-        int line_type = bcf_get_variant_types(line);
-        if ( files->collapse&COLLAPSE_SNPS && line_type&(VCF_SNP|VCF_MNP) )
-        {
-            if ( !has_snp ) has_snp = 1;
-            else line->pos = -1;
-        }
-        if ( files->collapse&COLLAPSE_INDELS && line_type&VCF_INDEL )
-        {
-            if ( !has_indel ) has_indel = 1;
-            else line->pos = -1;
-        }
-    }
-    bcf1_t *tmp;
-    irec = jrec = 1;
-    while ( irec<=reader->nbuffer && jrec<=reader->nbuffer )
-    {
-        if ( reader->buffer[irec]->pos != -1 ) { irec++; continue; }
-        if ( jrec<=irec ) jrec = irec+1;
-        while ( jrec<=reader->nbuffer && reader->buffer[jrec]->pos==-1 ) jrec++;
-        if ( jrec<=reader->nbuffer )
-        {
-            tmp = reader->buffer[irec]; reader->buffer[irec] = reader->buffer[jrec]; reader->buffer[jrec] = tmp;
-        }
-    }
-    reader->nbuffer = irec - 1;
-}
 
 void debug_buffer(FILE *fp, bcf_sr_t *reader)
 {
@@ -565,8 +552,6 @@ static void _reader_fill_buffer(bcf_srs_t *files, bcf_sr_t *reader)
         tbx_itr_destroy(reader->itr);
         reader->itr = NULL;
     }
-    if ( files->collapse && reader->nbuffer>=2 && reader->buffer[1]->pos==reader->buffer[2]->pos )
-        collapse_buffer(files, reader);
 }
 
 /*
@@ -588,85 +573,10 @@ static void _reader_shift_buffer(bcf_sr_t *reader)
         reader->nbuffer = 0;    // no other line
 }
 
-/*
- *  _reader_match_alleles() - from multiple buffered lines selects the one which
- *  corresponds best to the template line. The logic is controlled by COLLAPSE_*
- *  Returns 0 on success or -1 when no good matching line is found.
- */
-static int _reader_match_alleles(bcf_srs_t *files, bcf_sr_t *reader, bcf1_t *tmpl)
-{
-    int i, irec = -1;
-
-    // if no template given, use the first available record
-    if ( !tmpl )
-        irec = 1;
-    else
-    {
-        int tmpl_type = bcf_get_variant_types(tmpl);
-        for (i=1; i<=reader->nbuffer; i++)
-        {
-            bcf1_t *line = reader->buffer[i];
-            if ( line->pos != reader->buffer[1]->pos ) break;  // done with this reader
-
-            // Easiest case: matching by position only
-            if ( files->collapse&COLLAPSE_ANY ) { irec=i; break; }
-
-            int line_type = bcf_get_variant_types(line);
-
-            // No matter what the alleles are, as long as they are both SNPs
-            if ( files->collapse&COLLAPSE_SNPS && tmpl_type&VCF_SNP && line_type&VCF_SNP ) { irec=i; break; }
-            // ... or indels
-            if ( files->collapse&COLLAPSE_INDELS && tmpl_type&VCF_INDEL && line_type&VCF_INDEL ) { irec=i; break; }
-
-            // More thorough checking: REFs must match
-            if ( tmpl->rlen != line->rlen ) continue;  // different length
-            if ( !tmpl->d.allele || !line->d.allele ) continue;   // one of the lines is empty, someone is swapped buffered lines?!
-            if ( strcmp(tmpl->d.allele[0], line->d.allele[0]) ) continue; // the strings do not match
-
-            int ial,jal;
-            if ( files->collapse==COLLAPSE_NONE )
-            {
-                // Exact match, all alleles must be identical
-                if ( tmpl->n_allele!=line->n_allele ) continue;   // different number of alleles, skip
-
-                int nmatch = 1; // REF has been already checked
-                for (ial=1; ial<tmpl->n_allele; ial++)
-                {
-                    for (jal=1; jal<line->n_allele; jal++)
-                        if ( !strcmp(tmpl->d.allele[ial], line->d.allele[jal]) ) { nmatch++; break; }
-                }
-                if ( nmatch==tmpl->n_allele ) { irec=i; break; }    // found: exact match
-                continue;
-            }
-
-            if ( line->n_allele==1 && tmpl->n_allele==1 ) { irec=i; break; }    // both sites are non-variant
-
-            // COLLAPSE_SOME: at least some ALTs must match
-            for (ial=1; ial<tmpl->n_allele; ial++)
-            {
-                for (jal=1; jal<line->n_allele; jal++)
-                    if ( !strcmp(tmpl->d.allele[ial], line->d.allele[jal]) ) { irec=i; break; }
-                if ( irec>=1 ) break;
-            }
-            if ( irec>=1 ) break;
-        }
-        if ( irec==-1 ) return -1;  // no matching line was found
-    }
-
-    // Set the selected line (irec) as active: set it to buffer[0], move the remaining lines forward
-    // and put the old bcf1_t record at the end.
-    bcf1_t *tmp = reader->buffer[0];
-    reader->buffer[0] = reader->buffer[irec];
-    for (i=irec+1; i<=reader->nbuffer; i++) reader->buffer[i-1] = reader->buffer[i];
-    reader->buffer[ reader->nbuffer ] = tmp;
-    reader->nbuffer--;
-
-    return 0;
-}
-
 int _reader_next_line(bcf_srs_t *files)
 {
     int i, min_pos = INT_MAX;
+    const char *chr = NULL;
 
     // Loop until next suitable line is found or all readers have finished
     while ( 1 )
@@ -675,7 +585,6 @@ int _reader_next_line(bcf_srs_t *files)
         if ( files->regions && _readers_next_region(files)<0 ) break;
 
         // Fill buffers
-        const char *chr = NULL;
         for (i=0; i<files->nreaders; i++)
         {
             _reader_fill_buffer(files, &files->readers[i]);
@@ -705,33 +614,16 @@ int _reader_next_line(bcf_srs_t *files)
                     if ( files->readers[i].nbuffer && files->readers[i].buffer[1]->pos==min_pos )
                         _reader_shift_buffer(&files->readers[i]);
                 min_pos = INT_MAX;
+                chr = NULL;
                 continue;
             }
         }
 
-        break;  // done: min_pos is set
+        break;  // done: chr and min_pos are set
     }
+    if ( !chr ) return 0;
 
-    // There can be records with duplicate positions. Set the active line intelligently so that
-    // the alleles match.
-    int nret = 0;   // number of readers sharing the position
-    bcf1_t *first = NULL;   // record which will be used for allele matching
-    for (i=0; i<files->nreaders; i++)
-    {
-        files->has_line[i] = 0;
-
-        // Skip readers with no records at this position
-        if ( !files->readers[i].nbuffer || files->readers[i].buffer[1]->pos!=min_pos ) continue;
-
-        // Until now buffer[0] of all reader was empty and the lines started at buffer[1].
-        // Now lines which are ready to be output will be moved to buffer[0].
-        if ( _reader_match_alleles(files, &files->readers[i], first) < 0 ) continue;
-        if ( !first ) first = files->readers[i].buffer[0];
-
-        nret++;
-        files->has_line[i] = 1;
-    }
-    return nret;
+    return bcf_sr_sort_next(files, &BCF_SR_AUX(files)->sort, chr, min_pos);
 }
 
 int bcf_sr_next_line(bcf_srs_t *files)

--- a/test/test-bcf-sr.c
+++ b/test/test-bcf-sr.c
@@ -1,0 +1,141 @@
+/* 
+    Copyright (C) 2017 Genome Research Ltd.
+
+    Author: Petr Danecek <pd3@sanger.ac.uk>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+/*
+    Test bcf synced reader allele pairing
+*/
+
+#include <config.h>
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <htslib/synced_bcf_reader.h>
+
+void error(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vfprintf(stderr, format, ap);
+    va_end(ap);
+    exit(-1);
+}
+
+void usage(void)
+{
+    fprintf(stderr, "Usage: test-bcf-sr [OPTIONS] vcf-list.txt\n");
+    fprintf(stderr, "Options:\n");
+    fprintf(stderr, "   -p, --pair <logic[+ref]>     logic: snps,indels,both,snps+ref,indels+ref,both+ref,exact,some,all\n");
+    fprintf(stderr, "\n");
+    exit(-1);
+}
+
+int main(int argc, char *argv[])
+{
+    static struct option loptions[] =
+    {
+        {"help",no_argument,NULL,'h'},
+        {"pair",required_argument,NULL,'p'},
+        {NULL,0,NULL,0}
+    };
+
+    int c, pair = 0;
+    while ((c = getopt_long(argc, argv, "p:h", loptions, NULL)) >= 0) 
+    {
+        switch (c)
+        {
+            case 'p': 
+                if ( !strcmp(optarg,"snps") )            pair |= BCF_SR_PAIR_SNPS;
+                else if ( !strcmp(optarg,"snp+ref") )    pair |= BCF_SR_PAIR_SNPS|BCF_SR_PAIR_SNP_REF;
+                else if ( !strcmp(optarg,"snps+ref") )   pair |= BCF_SR_PAIR_SNPS|BCF_SR_PAIR_SNP_REF;
+                else if ( !strcmp(optarg,"indels") )     pair |= BCF_SR_PAIR_INDELS;
+                else if ( !strcmp(optarg,"indel+ref") )  pair |= BCF_SR_PAIR_INDELS|BCF_SR_PAIR_INDEL_REF;
+                else if ( !strcmp(optarg,"indels+ref") ) pair |= BCF_SR_PAIR_INDELS|BCF_SR_PAIR_INDEL_REF;
+                else if ( !strcmp(optarg,"both") )       pair |= BCF_SR_PAIR_BOTH;
+                else if ( !strcmp(optarg,"both+ref") )   pair |= BCF_SR_PAIR_BOTH_REF;
+                else if ( !strcmp(optarg,"any") )        pair |= BCF_SR_PAIR_ANY;
+                else if ( !strcmp(optarg,"all") )        pair |= BCF_SR_PAIR_ANY;
+                else if ( !strcmp(optarg,"some") )       pair |= BCF_SR_PAIR_SOME;
+                else if ( !strcmp(optarg,"exact") )      pair  = BCF_SR_PAIR_EXACT;
+                else error("The --pair logic \"%s\" not recognised.\n", optarg);
+                break;
+            default: usage();
+        }
+    }
+    if ( !pair ) pair = BCF_SR_PAIR_EXACT;
+    if ( optind == argc ) usage();
+
+    int i, j, n, nvcf;
+    char **vcf = hts_readlist(argv[optind], 1, &nvcf);
+    if ( !vcf ) error("Could not parse %s\n", argv[optind]);
+
+    bcf_srs_t *sr = bcf_sr_init();
+    bcf_sr_set_opt(sr, BCF_SR_PAIR_LOGIC, pair);
+    bcf_sr_set_opt(sr, BCF_SR_REQUIRE_IDX);
+    for (i=0; i<nvcf; i++)
+        if ( !bcf_sr_add_reader(sr,vcf[i]) ) error("Failed to open %s: %s\n", vcf[i],bcf_sr_strerror(sr->errnum));
+
+    kstring_t str = {0,0,0};
+    while ( (n=bcf_sr_next_line(sr)) )
+    {
+        for (i=0; i<sr->nreaders; i++)
+        {
+            if ( !bcf_sr_has_line(sr,i) ) continue;
+            bcf1_t *rec = bcf_sr_get_line(sr, i);
+            printf("%s:%d", bcf_seqname(bcf_sr_get_header(sr,i),rec),rec->pos+1);
+            break;
+        }
+
+        for (i=0; i<sr->nreaders; i++)
+        {
+            printf("\t");
+
+            if ( !bcf_sr_has_line(sr,i) )
+            {
+                printf("%s","-");
+                continue;
+            }
+
+            str.l = 0;
+            bcf1_t *rec = bcf_sr_get_line(sr, i);
+            kputs(rec->n_allele > 1 ? rec->d.allele[1] : ".", &str);
+            for (j=2; j<rec->n_allele; j++) 
+            {
+                kputc(',', &str);
+                kputs(rec->d.allele[j], &str);
+            }
+            printf("%s",str.s);
+        }
+        printf("\n");
+    }
+
+    free(str.s);
+    bcf_sr_destroy(sr);
+    for (i=0; i<nvcf; i++)
+        free(vcf[i]);
+    free(vcf);
+
+    return 0;
+}
+

--- a/test/test-bcf-sr.pl
+++ b/test/test-bcf-sr.pl
@@ -134,7 +134,7 @@ sub save_vcf
         print $fh join("\t", (2,100,'.',$ref,join(',',@alts),'.','.','.'))."\n";
     }
     close($fh) or error("close failed: bgzip -c > $fname");
-    cmd("tabix -f $fname");
+    cmd("$FindBin::Bin/../tabix -f $fname");
 }
 
 sub random_alt

--- a/test/test-bcf-sr.pl
+++ b/test/test-bcf-sr.pl
@@ -88,7 +88,7 @@ sub cmd
 sub save_vcf
 {
     my ($opts,$vars,$fname) = @_;
-    open(my $fh,"| bgzip -c > $fname") or error("bgzip -c > $fname: !");
+    open(my $fh,"| $FindBin::Bin/../bgzip -c > $fname") or error("$FindBin::Bin/../bgzip -c > $fname: !");
     print $fh qq[##fileformat=VCFv4.3\n];
     print $fh qq[##FILTER=<ID=PASS,Description="All filters passed">\n];
     print $fh qq[##contig=<ID=1>\n];

--- a/test/test-bcf-sr.pl
+++ b/test/test-bcf-sr.pl
@@ -1,0 +1,546 @@
+#!/usr/bin/env perl
+#
+# Author: petr.danecek@sanger
+#
+# Test bcf synced reader's allele pairing
+#
+
+use strict;
+use warnings;
+use Carp;
+use Data::Dumper;
+use List::Util 'shuffle';
+use File::Temp qw/ tempfile tempdir /;
+use FindBin;
+use lib "$FindBin::Bin";
+
+my $opts = parse_params();
+run_test($opts);
+
+exit;
+
+#--------------------------------
+
+sub error
+{
+    my (@msg) = @_;
+    if ( scalar @msg ) { confess @msg; }
+    print 
+        "Usage: test-bcf-sr.pl [OPTIONS]\n",
+        "Options:\n",
+        "   -s, --seed <int>        Random seed\n",
+        "   -t, --temp-dir <dir>    When given, temporary files will not be removed\n",
+        "   -v, --verbose           \n",
+        "   -h, -?, --help          This help message\n",
+        "\n";
+    exit -1;
+}
+sub parse_params
+{
+    my $opts = {};
+    while (defined(my $arg=shift(@ARGV)))
+    {
+        if ( $arg eq '-t' || $arg eq '--temp-dir' ) { $$opts{keep_files}=shift(@ARGV); next }
+        if ( $arg eq '-v' || $arg eq '--verbose' ) { $$opts{verbose}=1; next }
+        if ( $arg eq '-s' || $arg eq '--seed' ) { $$opts{seed}=shift(@ARGV); next }
+        if ( $arg eq '-?' || $arg eq '-h' || $arg eq '--help' ) { error(); }
+        error("Unknown parameter \"$arg\". Run -h for help.\n");
+    }
+    $$opts{tmp} = exists($$opts{keep_files}) ? $$opts{keep_files} : tempdir(CLEANUP=>1);
+    if ( $$opts{keep_files} ) { cmd("mkdir -p $$opts{keep_files}"); }
+    if ( !exists($$opts{seed}) )
+    {
+        $$opts{seed} = time();
+        print STDERR "Random seed is $$opts{seed}\n";
+    }
+    srand($$opts{seed});
+    return $opts;
+}
+
+sub _cmd
+{
+    my ($cmd) = @_;
+    my $kid_io;
+    my @out;
+    my $pid = open($kid_io, "-|");
+    if ( !defined $pid ) { error("Cannot fork: $!"); }
+    if ($pid)
+    {
+        # parent
+        @out = <$kid_io>;
+        close($kid_io);
+    }
+    else
+    {
+        # child
+        exec('bash', '-o','pipefail','-c', $cmd) or error("Cannot execute the command [/bin/sh -o pipefail -c $cmd]: $!");
+    }
+    return ($? >> 8, join('',@out));
+}
+sub cmd
+{
+    my ($cmd) = @_;
+    my ($ret,$out) = _cmd($cmd);
+    if ( $ret ) { error("The command failed [$ret]: $cmd\n", $out); }
+    return $out;
+}
+
+sub save_vcf
+{
+    my ($opts,$vars,$fname) = @_;
+    open(my $fh,"| bgzip -c > $fname") or error("bgzip -c > $fname: !");
+    print $fh qq[##fileformat=VCFv4.3\n];
+    print $fh qq[##FILTER=<ID=PASS,Description="All filters passed">\n];
+    print $fh qq[##contig=<ID=1>\n];
+    print $fh qq[##contig=<ID=2>\n];
+    print $fh '#'. join("\t", qw(CHROM POS ID  REF ALT QUAL    FILTER  INFO))."\n";
+    for my $var (@$vars)
+    {
+        my @als = split(/,/,$var);
+        my @alts = ();
+        my $ref;
+        for my $al (@als)
+        {
+            my ($xref,$alt) = split(/>/,$al);
+            $ref = $xref;
+            push @alts,$alt;
+        }
+        print $fh join("\t", (1,100,'.',$ref,join(',',@alts),'.','.','.'))."\n";
+    }
+    for my $var (@$vars)
+    {
+        my @als = split(/,/,$var);
+        my @alts = ();
+        my $ref;
+        for my $al (@als)
+        {
+            my ($xref,$alt) = split(/>/,$al);
+            $ref = $xref;
+            push @alts,$alt;
+        }
+        print $fh join("\t", (1,300,'.',$ref,join(',',@alts),'.','.','.'))."\n";
+    }
+    for my $var (@$vars)
+    {
+        my @als = split(/,/,$var);
+        my @alts = ();
+        my $ref;
+        for my $al (@als)
+        {
+            my ($xref,$alt) = split(/>/,$al);
+            $ref = $xref;
+            push @alts,$alt;
+        }
+        print $fh join("\t", (2,100,'.',$ref,join(',',@alts),'.','.','.'))."\n";
+    }
+    close($fh) or error("close failed: bgzip -c > $fname");
+    cmd("tabix -f $fname");
+}
+
+sub random_alt
+{
+    my ($ref,$is_snp) = @_;
+    my @acgt = qw(A C G T);
+    my $alt = $acgt[rand @acgt];
+    if ( $ref eq $alt ) { return '.'; }   # ref
+    if ( !$is_snp ) { $alt = $ref.$alt; }
+    return $alt;
+}
+
+sub check_outputs
+{
+    my ($fname_bin,$fname_perl) = @_;
+    my %out = ();
+    open(my $fh,'<',$fname_bin) or error("$fname_bin: $!");
+    while (my $line=<$fh>)
+    {
+        my ($pos,@vals) = split(/\t/,$line);
+        chomp($vals[-1]);
+        push @{$out{$pos}},join("\t",@vals);
+    }
+    close($fh) or error("close failed: $fname_bin");
+    if ( keys %out != 3 ) { error("Expected 3 positions, found ",scalar keys %out,": $fname_bin\n"); }
+    my $n;
+    for my $pos (keys %out)
+    {
+        if ( !defined $n ) { $n = scalar @{$out{$pos}}; }
+        if ( @{$out{$pos}} != $n ) { error("Expected $n positions, found ",scalar keys %{$out{$pos}},"\n"); }
+    }
+    my @blines = @{$out{(keys %out)[0]}};
+
+    my @plines = ();
+    open($fh,'<',$fname_perl) or error("$fname_perl: $!");
+    while (my $line=<$fh>)
+    {
+        chomp($line);
+        push @plines,$line;
+    }
+    close($fh) or error("close failed: $fname_perl");
+    if ( @blines != @plines ) { error("Different number of lines: ",scalar @blines," vs ",scalar @plines," in $fname_bin vs $fname_perl\n"); }
+    @blines = sort @blines;
+    @plines = sort @plines;
+    for (my $i=0; $i<@plines; $i++)
+    {
+        if ( $blines[$i] ne $plines[$i] ) 
+        { 
+            #error("Different lines in $fname_bin vs $fname_perl:\n\t$blines[$i].\nvs\n\t$plines[$i].\n"); 
+            error("Different lines in $fname_bin vs $fname_perl:\n\t".join("\n\t",@blines)."\nvs\n\t".join("\n\t",@plines)."\n"); 
+        }
+    }
+}
+
+sub run_test
+{
+    my ($opts) = @_;
+    my @acgt = qw(A C G T);
+    my $ref  = $acgt[rand @acgt];
+    my @vcfs = ();
+    my $nvcf = 1 + int(rand(10));
+    for (my $i=0; $i<$nvcf; $i++)
+    {
+        my %vars  = ();
+        my $nvars = 1 + int(rand(6));
+        for (my $j=0; $j<$nvars; $j++)
+        {
+            my $snp = int(rand(2));
+            my $alt = random_alt($ref,$snp);
+            my $var = "$ref>$alt";
+            if ( $alt ne '.' && !int(rand(5)) )    # create multiallelic site
+            {
+                my $alt2 = random_alt($ref,$snp);
+                if ( $alt2 ne '.' && $alt ne $alt2 )
+                {
+                    $var .= ",$ref>$alt2"; 
+                }
+            }
+            $vars{$var} = 1;
+        }
+        my $ndup = 1 + int(rand(4));
+        for (my $j=0; $j<$ndup; $j++)
+        {
+            my @keys = shuffle keys %vars;
+            push @vcfs, \@keys;
+        }
+    }
+    @vcfs = shuffle @vcfs;
+    open(my $fh,'>',"$$opts{tmp}/list.txt") or error("$$opts{tmp}/list.txt: $!");
+    my %groups = ();
+    my @group_list = ();
+    for (my $i=0; $i<@vcfs; $i++)
+    {
+        my $vcf = $vcfs[$i];
+        my $key = join(';',sort @$vcf);
+        if ( !exists($groups{$key}) )
+        {
+            push @group_list,$key;
+            $groups{$key}{vars} = [@$vcf];
+            $groups{$key}{key} = $key;
+        }
+        push @{$groups{$key}{vcfs}},$i;
+        save_vcf($opts,$vcf,"$$opts{tmp}/$i.vcf.gz");
+        print $fh "$$opts{tmp}/$i.vcf.gz\n";
+    }
+    close($fh);
+
+    my @groups = ();
+    for my $group (@group_list) { push @groups, $groups{$group}; }
+    for my $logic (qw(snps indels both snps+ref indels+ref both+ref exact some all))
+    #for my $logic (qw(snps))
+    {
+        print STDERR "$FindBin::Bin/test-bcf-sr $$opts{tmp}/list.txt -p $logic > $$opts{tmp}/rmme.bin.out\n" unless !$$opts{verbose};
+        cmd("$FindBin::Bin/test-bcf-sr $$opts{tmp}/list.txt -p $logic > $$opts{tmp}/rmme.bin.out");
+
+        open(my $fh,'>',"$$opts{tmp}/rmme.perl.out") or error("$$opts{tmp}/rmme.perl.out: $!");
+        $$opts{fh} = $fh;
+        $$opts{logic} = $logic;
+        pair_lines($opts,\@groups);
+        close($fh) or error("close failed: $$opts{tmp}/rmme.perl.out");
+
+        check_outputs("$$opts{tmp}/rmme.bin.out","$$opts{tmp}/rmme.perl.out");
+    }
+}
+
+sub pair_lines
+{
+    my ($opts,$groups) = @_;
+
+    #print 'groups: '.Dumper($groups);
+
+    # get a list of all unique variants and their groups
+    my %vars = ();
+    my @var_list = ();
+    for (my $igrp=0; $igrp<@$groups; $igrp++)
+    {
+        my $grp = $$groups[$igrp];
+        for (my $ivar=0; $ivar<@{$$grp{vars}}; $ivar++)
+        {
+            my $var = $$grp{vars}[$ivar];
+            if ( !exists($vars{$var}) ) { push @var_list,$var; }  # just to keep the order
+            push @{$vars{$var}}, { igrp=>$igrp, ivar=>$ivar, cnt=>scalar @{$$grp{vcfs}} };
+        }
+    }
+
+    # each variant has a list of groups that it is present in
+    my @vars = ();
+    for my $var (@var_list) { push @vars, $vars{$var}; }
+
+    #print STDERR 'unique variants: '.Dumper(\@var_list);
+    # for (my $i=0; $i<@vars; $i++)
+    # {
+    #     my $igrp = $vars[$i][0]{igrp};
+    #     my $jvar = $vars[$i][0]{ivar};
+    #     my $var  = $$groups[$igrp]{vars}[$jvar];
+    #     print STDERR "$i: $var\n"; 
+    # }
+
+    # initialize variant sets - combinations of compatible variants across multiple reader groups
+    my @var_sets = ();
+    for (my $i=0; $i<@vars; $i++) { push @var_sets,[$i]; }
+
+    my @bitmask = ();
+    my @pmatrix = ();
+    for (my $iset=0; $iset<@var_sets; $iset++)
+    {
+        $pmatrix[$iset] = [(0) x (scalar @$groups)];
+        $bitmask[$iset] = 0;
+    }
+    my @max;
+    for (my $iset=0; $iset<@var_sets; $iset++)
+    {
+        my $tmp_max = 0;
+        for my $ivar (@{$var_sets[$iset]})
+        {
+            my $var = $vars[$ivar];
+            for my $grp (@$var)
+            {
+                my $igrp = $$grp{igrp};
+                $pmatrix[$iset][$igrp] += $$grp{cnt};
+                if ( $bitmask[$iset] & (1<<$igrp) ) { error("Uh!"); }
+                $bitmask[$iset] |= 1<<$igrp;
+                $tmp_max += $$grp{cnt};
+            }
+        }
+        push @max, $tmp_max;
+    }
+
+    # pair the lines
+    while ( @var_sets )
+    {
+        my $imax = 0;
+        for (my $iset=1; $iset<@var_sets; $iset++)
+        {
+            if ( $max[$iset] > $max[$imax] ) { $imax = $iset; }
+        }
+        # if ( @var_sets == @vars ) { dump_pmatrix($groups,\@vars,\@var_sets,\@pmatrix,\@bitmask); }
+
+        my $ipair = undef;
+        my $max_score = 0;
+        for (my $iset=0; $iset<@var_sets; $iset++)
+        {
+            if ( $bitmask[$imax] & $bitmask[$iset] ) { next; }     # cannot merge
+            my $score = pairing_score($opts,$groups,\@vars,$var_sets[$imax],$var_sets[$iset]);
+            if ( $max_score < $score ) { $max_score = $score; $ipair = $iset; }
+        }
+
+        # merge rows thus creating a new variant set
+        if ( defined $ipair && $ipair != $imax )
+        {
+            $imax = merge_rows($groups,\@vars,\@var_sets,\@pmatrix,\@bitmask,\@max,$imax,$ipair);
+            next;
+        }
+
+        output_row($opts,$groups,\@vars,\@var_sets,\@pmatrix,\@bitmask,\@max,$imax);
+        # dump_pmatrix($groups,\@vars,\@var_sets,\@pmatrix,\@bitmask);
+    }
+}
+
+sub merge_rows
+{
+    my ($grps,$vars,$var_sets,$pmat,$bitmask,$max,$ivset,$jvset) = @_;
+    if ( $ivset > $jvset ) { my $tmp = $ivset; $ivset = $jvset; $jvset = $tmp; }
+    push @{$$var_sets[$ivset]}, @{$$var_sets[$jvset]};
+    for (my $igrp=0; $igrp<@{$$pmat[$ivset]}; $igrp++)
+    {
+        $$pmat[$ivset][$igrp] += $$pmat[$jvset][$igrp];
+    }
+    $$max[$ivset] += $$max[$jvset];
+    $$bitmask[$ivset] |= $$bitmask[$jvset];
+    splice(@$var_sets,$jvset,1);
+    splice(@$pmat,$jvset,1);
+    splice(@$bitmask,$jvset,1);
+    splice(@$max,$jvset,1);
+    return $ivset;
+}
+
+sub output_row
+{
+    my ($opts,$grps,$vars,$var_sets,$pmat,$bitmask,$max,$ivset) = @_;
+    my $varset = $$var_sets[$ivset];
+    my @tmp = ();
+    for my $grp (@$grps)
+    {
+        for my $vcf (@{$$grp{vcfs}}) { push @tmp, '-'; }
+    }
+    for my $idx (@$varset)
+    {
+        for my $var (@{$$vars[$idx]})
+        {
+            my $igrp = $$var{igrp};
+            my $jvar = $$var{ivar};
+            my $str  = $$grps[$igrp]{vars}[$jvar];
+            $str =~ s/[^>]>//g;
+            for my $ivcf (@{$$grps[$igrp]{vcfs}}) { $tmp[$ivcf] = $str; }
+        }
+    }
+    print {$$opts{fh}} join("\t",@tmp)."\n";
+    splice(@$var_sets,$ivset,1);
+    splice(@$pmat,$ivset,1);
+    splice(@$bitmask,$ivset,1);
+    splice(@$max,$ivset,1);
+}
+
+sub dump_pmatrix
+{
+    my ($grps,$vars,$var_sets,$pmat,$bitmask) = @_;
+    for (my $ivset=0; $ivset<@$var_sets; $ivset++)
+    {
+        my $varset = $$var_sets[$ivset];
+        my @tmp = ();
+        for my $ivar (@$varset)
+        {
+            my $igrp = $$vars[$ivar][0]{igrp};
+            my $jvar = $$vars[$ivar][0]{ivar};
+            push @tmp, $$grps[$igrp]{vars}[$jvar];
+        }
+        printf STDERR "%-10s",join(',',@tmp);
+        for (my $igrp=0; $igrp<@{$$pmat[0]}; $igrp++)
+        {
+            print STDERR "\t$$pmat[$ivset][$igrp]";
+        }
+        print STDERR "\n";
+    }
+    print STDERR "\n";
+}
+
+sub var_type
+{
+    my ($vars) = @_;
+    my %type = ();
+    for my $var (split(/,/,$vars))
+    {
+        my ($ref,$alt) = split(/>/,$var);
+        if ( $ref eq $alt or $alt eq '.' ) { $type{ref} = 1; }
+        elsif ( length($ref)==length($alt) && length($ref)==1 ) { $type{snp} = 1; }
+        else { $type{indel} = 1; }
+    }
+    return keys %type;
+}
+sub multi_is_subset
+{
+    my ($avar,$bvar) = @_;
+    my %avars = ();
+    my %bvars = ();
+    for my $var (split(/,/,$avar)) { $avars{$var} = 1; }
+    for my $var (split(/,/,$bvar)) { $bvars{$var} = 1; }
+    for my $var (keys %avars)
+    {
+        if ( exists($bvars{$var}) ) { return 1; }
+    }
+    for my $var (keys %bvars)
+    {
+        if ( exists($avars{$var}) ) { return 1; }
+    }
+    return 0;
+}
+sub multi_is_exact
+{
+    my ($avar,$bvar) = @_;
+    my %avars = ();
+    my %bvars = ();
+    for my $var (split(/,/,$avar)) { $avars{$var} = 1; }
+    for my $var (split(/,/,$bvar)) { $bvars{$var} = 1; }
+    for my $var (keys %avars)
+    {
+        if ( !exists($bvars{$var}) ) { return 0; }
+    }
+    for my $var (keys %bvars)
+    {
+        if ( !exists($avars{$var}) ) { return 0; }
+    }
+    return 1;
+}
+sub pairing_score
+{
+    my ($opts,$grps,$vars,$avset,$bvset) = @_;
+
+    my $score = {};
+    if ( $$opts{logic}=~/both/ or $$opts{logic}=~/snps/ or $$opts{logic}=~/all/ ) 
+    { 
+        $$score{snp}{snp} = 3;
+        if ( $$opts{logic}=~/ref/ or $$opts{logic}=~/all/ ) { $$score{snp}{ref} = 2; }
+    }
+    if ( $$opts{logic}=~/both/ or $$opts{logic}=~/indels/ or $$opts{logic}=~/all/ ) 
+    {
+        $$score{indel}{indel} = 3; 
+        if ( $$opts{logic}=~/ref/ or $$opts{logic}=~/all/ ) { $$score{indel}{ref} = 2; }
+    }
+    if ( $$opts{logic}=~/all/ )
+    {
+        $$score{snp}{indel} = 1;
+        $$score{indel}{snp} = 1;
+    }
+    for my $a (keys %$score)
+    {
+        for my $b (keys %{$$score{$a}})
+        {
+            $$score{$b}{$a} = $$score{$a}{$b};
+        }
+    }
+
+    my $max_int = 0xFFFFFFFF;
+    my $min = $max_int;
+    for my $ia (@$avset)
+    {
+        for my $ib (@$bvset)
+        {
+            my $avar = $$grps[ $$vars[$ia][0]{igrp} ]{vars}[ $$vars[$ia][0]{ivar} ];
+            my $bvar = $$grps[ $$vars[$ib][0]{igrp} ]{vars}[ $$vars[$ib][0]{ivar} ];
+
+            if ( $avar eq $bvar ) { return $max_int; }
+            if ( $$opts{logic} eq 'exact' )
+            {
+                if ( multi_is_exact($avar,$bvar) ) { return $max_int; }
+                next;
+            }
+            elsif ( multi_is_subset($avar,$bvar) ) { return $max_int; }
+
+            my @atype = var_type($avar);
+            my @btype = var_type($bvar);
+            my $max = 0;
+            for my $a (@atype)
+            {
+                for my $b (@btype)
+                {
+                    if ( !exists($$score{$a}{$b}) ) { next; }
+                    if ( $max < $$score{$a}{$b} ) { $max = $$score{$a}{$b}; }
+                }
+            }
+            if ( !$max ) { return 0; }      # some of the variants in the two groups are not compatible
+            if ( $min > $max ) { $min = $max; }
+        }
+    }
+    if ( $$opts{logic} eq 'exact' ) { return 0; }
+
+    my $cnt = 0;
+    for my $ivar (@$avset,@$bvset)
+    {
+        my $var = $$vars[$ivar];
+        for my $grp (@$var)
+        {
+            $cnt += $$grp{cnt};
+        }
+    }
+    return (1<<(28+$min)) + $cnt;
+}
+
+

--- a/test/test.pl
+++ b/test/test.pl
@@ -39,6 +39,7 @@ test_view($opts,4);
 test_vcf_api($opts,out=>'test-vcf-api.out');
 test_vcf_sweep($opts,out=>'test-vcf-sweep.out');
 test_vcf_various($opts);
+test_bcf_sr_sort($opts);
 test_convert_padded_header($opts);
 test_rebgzip($opts);
 
@@ -340,3 +341,20 @@ sub test_convert_padded_header
             cmd => "$$opts{path}/test_view -t ce.fa -C $nulsbam");
     }
 }
+
+sub test_bcf_sr_sort
+{
+    my ($opts, %args) = @_;
+    for (my $i=0; $i<10; $i++)
+    {
+        my $seed = int(rand(time));
+        my $test = 'test-bcf-sr';
+        my $cmd  = "$$opts{path}/test-bcf-sr.pl -t $$opts{tmp} -s $seed";
+        print "$test:\n";
+        print "\t$cmd\n";
+        my ($ret,$out) = _cmd($cmd);
+        if ( $ret ) { failed($opts,$test); }
+        else { passed($opts,$test); }
+    }
+}
+


### PR DESCRIPTION
The original version of allele matching was too simplistic and handled
records with duplicate positions by removing ("collapsing") them by
type - if requested so via the bcf_srs_t.collapse option. This behavior
is changed by this commit, records will never be discarded by the
reader. Instead, compatible records will be paired intelligently
based on user criteria. If duplicate positions are not desired, they
must be removed by the caller or by an external tool, such as `bcftools norm`.

Notes:

- the usage of the old "collapse" is discouraged, but backward-compatible
  at the API level, with behavior changed as described above

- bcf_sr_set_opt() call was introduced to avoid the need to access reader's
  internal structures directly. Ideally at some point it should became
  an opaque struct, to minimize the need for API/ABI breaking changes in
  future

- the allele pairing is still not perfect, it does not try to resolve
  ambiguous representations of identical alleles, such as multiallelic
  indels AA>A vs AAA>AA,AAA>A

- the new implementation slows the reader by 40-20%. This was measured
  with `bcftools isec`, which has no significant overhead: the original
  version took 113 seconds to process, the new reader took 157 seconds
  (two sites-only BCFs with 35M sites). In real life this never is a
  bottleneck, for example the difference in speed was not measurable when
  176 gBCFs with 64M sites are merged.