### PR TITLE
NaN issue

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -651,10 +651,11 @@ typedef struct {
      *  @dst:       *dst is pointer to a memory location, can point to NULL
      *  @ndst:      pointer to the size of allocated memory
      *
-     *  Returns negative value on error or the number of written values on
-     *  success. bcf_get_info_string() returns on success the number of
-     *  characters written excluding the null-terminating byte. bcf_get_info_flag()
-     *  returns 1 when flag is set or 0 if not.
+     *  Returns negative value on error or the number of written values
+     *  (including missing values) on success. bcf_get_info_string() returns
+     *  on success the number of characters written excluding the null-
+     *  terminating byte. bcf_get_info_flag() returns 1 when flag is set or 0
+     *  if not.
      *
      *  List of return codes:
      *      -1 .. no such INFO tag defined in the header

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -310,7 +310,7 @@ void test_get_info_values(const char *fname)
     hts_close(fp);
 }
 
-void write_format_values(char *fname)
+void write_format_values(const char *fname)
 {
     // Init
     htsFile *fp = hts_open(fname, "wb");
@@ -318,7 +318,6 @@ void write_format_values(char *fname)
     bcf1_t *rec = bcf_init1();
 
     // Create VCF header
-    kstring_t str = { 0,0,0 };
     bcf_hdr_append(hdr, "##contig=<ID=1>");
     bcf_hdr_append(hdr, "##FORMAT=<ID=TF,Number=1,Type=Float,Description=\"Test Float\">");
     bcf_hdr_add_sample(hdr, "S");

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -357,8 +357,8 @@ void check_format_values(const char *fname)
 
         // NOTE the return value from bcf_get_format_float is different from
         // bcf_get_info_float in the sense that vector-end markers also count.
-        if (ret != 4 || 
-            count < ret || 
+        if (ret != 4 ||
+            count < ret ||
             !bcf_float_is_missing(values[0]) ||
             values[1] != 47.11f ||
             !bcf_float_is_vector_end(values[2]) ||
@@ -386,14 +386,16 @@ int main(int argc, char **argv)
 {
     char *fname = argc>1 ? argv[1] : "rmme.bcf";
 
+    // format test. quiet unless there's a failure
+    test_get_format_values(fname);
+
     // main test. writes to stdout
     write_bcf(fname);
     bcf_to_vcf(fname);
+    iterator(fname);
 
     // additional tests. quiet unless there's a failure.
-    iterator(fname);
     test_get_info_values(fname);
-    test_get_format_values(fname);
 
     return 0;
 }

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -273,7 +273,7 @@ void iterator(const char *fname)
     }
 }
 
-void info_values(const char *fname)
+void test_get_info_values(const char *fname)
 {
     htsFile *fp = hts_open(fname, "r");
     bcf_hdr_t *hdr = bcf_hdr_read(fp);
@@ -284,14 +284,10 @@ void info_values(const char *fname)
         float *afs = 0;
         int count = 0;
         int ret = bcf_get_info_float(hdr, line, "AF", &afs, &count);
-        if (ret < 1)
-        {
-            fprintf(stderr, "bcf_get_info_float failed\n");
-        }
 
         if (line->pos == 14369)
         {
-            if (count != 1 || afs[0] != 0.5f)
+            if (ret != 1 || afs[0] != 0.5f)
             {
                 fprintf(stderr, "AF on position 14370 should be 0.5\n");
                 exit(-1);
@@ -299,7 +295,7 @@ void info_values(const char *fname)
         }
         else
         {
-            if (count != 2 || afs[0] != 0.333f || !bcf_float_is_missing(afs[1]))
+            if (ret != 2 || afs[0] != 0.333f || !bcf_float_is_missing(afs[1]))
             {
                 fprintf(stderr, "AF on position 1110696 should be 0.333, missing\n");
                 exit(-1);
@@ -314,12 +310,91 @@ void info_values(const char *fname)
     hts_close(fp);
 }
 
+void write_format_values(char *fname)
+{
+    // Init
+    htsFile *fp = hts_open(fname, "wb");
+    bcf_hdr_t *hdr = bcf_hdr_init("w");
+    bcf1_t *rec = bcf_init1();
+
+    // Create VCF header
+    kstring_t str = { 0,0,0 };
+    bcf_hdr_append(hdr, "##contig=<ID=1>");
+    bcf_hdr_append(hdr, "##FORMAT=<ID=TF,Number=1,Type=Float,Description=\"Test Float\">");
+    bcf_hdr_add_sample(hdr, "S");
+    bcf_hdr_add_sample(hdr, NULL); // to update internal structures
+    bcf_hdr_write(fp, hdr);
+
+    // Add a record
+    // .. FORMAT
+    float test[4];
+    bcf_float_set_missing(test[0]);
+    test[1] = 47.11f;
+    bcf_float_set_vector_end(test[2]);
+    bcf_update_format_float(hdr, rec, "TF", test, 4);
+    bcf_write1(fp, hdr, rec);
+
+    bcf_destroy1(rec);
+    bcf_hdr_destroy(hdr);
+    int ret;
+    if ((ret = hts_close(fp)))
+    {
+        fprintf(stderr, "hts_close(%s): non-zero status %d\n", fname, ret);
+        exit(ret);
+    }
+}
+
+void check_format_values(const char *fname)
+{
+    htsFile *fp = hts_open(fname, "r");
+    bcf_hdr_t *hdr = bcf_hdr_read(fp);
+    bcf1_t *line = bcf_init();
+
+    while (bcf_read(fp, hdr, line) == 0)
+    {
+        float *values = 0;
+        int count = 0;
+        int ret = bcf_get_format_float(hdr, line, "TF", &values, &count);
+
+        // NOTE the return value from bcf_get_format_float is different from
+        // bcf_get_info_float in the sense that vector-end markers also count.
+        if (ret != 4 || 
+            count < ret || 
+            !bcf_float_is_missing(values[0]) ||
+            values[1] != 47.11f ||
+            !bcf_float_is_vector_end(values[2]) ||
+            !bcf_float_is_vector_end(values[3]))
+        {
+            fprintf(stderr, "bcf_get_format_float didn't produce the expected output.\n");
+            exit(-1);
+        }
+
+        free(values);
+    }
+
+    bcf_destroy(line);
+    bcf_hdr_destroy(hdr);
+    hts_close(fp);
+}
+
+void test_get_format_values(const char *fname)
+{
+    write_format_values(fname);
+    check_format_values(fname);
+}
+
 int main(int argc, char **argv)
 {
     char *fname = argc>1 ? argv[1] : "rmme.bcf";
+
+    // main test. writes to stdout
     write_bcf(fname);
     bcf_to_vcf(fname);
+
+    // additional tests. quiet unless there's a failure.
     iterator(fname);
-    info_values(fname);
+    test_get_info_values(fname);
+    test_get_format_values(fname);
+
     return 0;
 }

--- a/vcf.c
+++ b/vcf.c
@@ -1799,7 +1799,7 @@ void bcf_fmt_array(kstring_t *s, int n, int type, void *data)
             case BCF_BT_INT8:  BRANCH(int8_t,  le_to_i8, v==bcf_int8_missing,  v==bcf_int8_vector_end,  kputw(v, s)); break;
             case BCF_BT_INT16: BRANCH(int16_t, le_to_i16, v==bcf_int16_missing, v==bcf_int16_vector_end, kputw(v, s)); break;
             case BCF_BT_INT32: BRANCH(int32_t, le_to_i32, v==bcf_int32_missing, v==bcf_int32_vector_end, kputw(v, s)); break;
-            case BCF_BT_FLOAT: BRANCH(float,   le_to_float, bcf_float_is_missing(v), bcf_float_is_vector_end(v), kputd(v, s)); break;
+            case BCF_BT_FLOAT: BRANCH(uint32_t, le_to_u32, v==bcf_float_missing, v==bcf_float_vector_end, kputd(le_to_float(p), s)); break;
             default: fprintf(stderr,"todo: type %d\n", type); exit(1); break;
         }
         #undef BRANCH

--- a/vcf.c
+++ b/vcf.c
@@ -2178,7 +2178,7 @@ int vcf_parse(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v)
             }
         } else if (i == 5) { // QUAL
             if (strcmp(p, ".")) v->qual = atof(p);
-            else memcpy(&v->qual, &bcf_float_missing, 4);
+            else bcf_float_set_missing(v->qual);
             if ( v->max_unpack && !(v->max_unpack>>1) ) return 0; // BCF_UN_STR
         } else if (i == 6) { // FILTER
             if (strcmp(p, ".")) {

--- a/vcf.c
+++ b/vcf.c
@@ -3635,12 +3635,11 @@ int bcf_get_info_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, voi
         *dst  = realloc(*dst, *ndst * size1);
     }
 
-#define BRANCH(type_t, convert, is_missing, is_vector_end, set_missing, set_regular, out_type_t) { \
+    #define BRANCH(type_t, convert, is_missing, is_vector_end, set_missing, set_regular, out_type_t) { \
         out_type_t *tmp = (out_type_t *) *dst; \
         for (j=0; j<info->len; j++) \
         { \
-            uint8_t *ps = info->vptr + j * sizeof(type_t); \
-            type_t p = convert(ps); \
+            type_t p = convert(info->vptr + j * sizeof(type_t)); \
             if ( is_vector_end ) return j; \
             if ( is_missing ) set_missing; \
             else set_regular; \
@@ -3652,7 +3651,7 @@ int bcf_get_info_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, voi
         case BCF_BT_INT8:  BRANCH(int8_t,  le_to_i8,  p==bcf_int8_missing,  p==bcf_int8_vector_end,  *tmp=bcf_int32_missing, *tmp=p, int32_t); break;
         case BCF_BT_INT16: BRANCH(int16_t, le_to_i16, p==bcf_int16_missing, p==bcf_int16_vector_end, *tmp=bcf_int32_missing, *tmp=p, int32_t); break;
         case BCF_BT_INT32: BRANCH(int32_t, le_to_i32, p==bcf_int32_missing, p==bcf_int32_vector_end, *tmp=bcf_int32_missing, *tmp=p, int32_t); break;
-        case BCF_BT_FLOAT: BRANCH(uint32_t, le_to_u32, p==bcf_float_missing, p==bcf_float_vector_end, bcf_float_set_missing(*tmp), *tmp=le_to_float(ps), float); break;
+        case BCF_BT_FLOAT: BRANCH(uint32_t, le_to_u32, p==bcf_float_missing, p==bcf_float_vector_end, bcf_float_set_missing(*tmp), bcf_float_set(tmp, p), float); break;
         default: fprintf(stderr,"TODO: %s:%d .. info->type=%d\n", __FILE__,__LINE__, info->type); exit(1);
     }
     #undef BRANCH
@@ -3740,15 +3739,14 @@ int bcf_get_format_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, v
         if ( !dst ) return -4;     // could not alloc
     }
 
-#define BRANCH(type_t, convert, is_missing, is_vector_end, set_missing, set_vector_end, set_regular, out_type_t) { \
+    #define BRANCH(type_t, convert, is_missing, is_vector_end, set_missing, set_vector_end, set_regular, out_type_t) { \
         out_type_t *tmp = (out_type_t *) *dst; \
         uint8_t *fmt_p = fmt->p; \
         for (i=0; i<nsmpl; i++) \
         { \
             for (j=0; j<fmt->n; j++) \
             { \
-                uint8_t *ps = fmt_p + j * sizeof(type_t); \
-                type_t p = convert(ps); \
+                type_t p = convert(fmt_p + j * sizeof(type_t)); \
                 if ( is_missing ) set_missing; \
                 else if ( is_vector_end ) { set_vector_end; break; } \
                 else set_regular; \
@@ -3760,9 +3758,9 @@ int bcf_get_format_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, v
     }
     switch (fmt->type) {
         case BCF_BT_INT8:  BRANCH(int8_t,  le_to_i8, p==bcf_int8_missing,  p==bcf_int8_vector_end,  *tmp=bcf_int32_missing, *tmp=bcf_int32_vector_end, *tmp=p, int32_t); break;
-        case BCF_BT_INT16: BRANCH(int16_t, le_to_i16, p==bcf_int16_missing, p==bcf_int16_vector_end, *tmp=bcf_int32_missing, *tmp=bcf_int32_vector_end, *tmp = p, int32_t); break;
-        case BCF_BT_INT32: BRANCH(int32_t, le_to_i32, p==bcf_int32_missing, p==bcf_int32_vector_end, *tmp=bcf_int32_missing, *tmp=bcf_int32_vector_end, *tmp = p, int32_t); break;
-        case BCF_BT_FLOAT: BRANCH(uint32_t, le_to_u32, p==bcf_float_missing, p==bcf_float_vector_end, bcf_float_set_missing(*tmp), bcf_float_set_vector_end(*tmp), *tmp=le_to_float(ps), float); break;
+        case BCF_BT_INT16: BRANCH(int16_t, le_to_i16, p==bcf_int16_missing, p==bcf_int16_vector_end, *tmp=bcf_int32_missing, *tmp=bcf_int32_vector_end, *tmp=p, int32_t); break;
+        case BCF_BT_INT32: BRANCH(int32_t, le_to_i32, p==bcf_int32_missing, p==bcf_int32_vector_end, *tmp=bcf_int32_missing, *tmp=bcf_int32_vector_end, *tmp=p, int32_t); break;
+        case BCF_BT_FLOAT: BRANCH(uint32_t, le_to_u32, p==bcf_float_missing, p==bcf_float_vector_end, bcf_float_set_missing(*tmp), bcf_float_set_vector_end(*tmp), bcf_float_set(tmp, p), float); break;
         default: fprintf(stderr,"TODO: %s:%d .. fmt->type=%d\n", __FILE__,__LINE__, fmt->type); exit(1);
     }
     #undef BRANCH


### PR DESCRIPTION
Fixed a problem with allele frequencies in VCF files that should be missing values, but showed up as garbage. The cause of the bug turned out to be a very unlikely one: automatic conversion between signaling and quiet NaN when a float is returned from a function on the FPU register stack. Solved it for the cases I could find by keeping the data as uint32 while testing for special values. 

Added test cases for bcf_get_info_values and bcf_get_format_values.

Turned out to be a known problem: https://github.com/samtools/hts-specs/issues/145