### PR TITLE
Make bcf_set_variant_type() aware of breakends

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -137,6 +137,7 @@ extern uint8_t bcf_type_shift[];
 #define VCF_MNP   2
 #define VCF_INDEL 4
 #define VCF_OTHER 8
+#define VCF_BND   16    // breakend
 
 typedef struct {
     int type, n;    // variant type and the number of bases affected, negative for deletions

--- a/vcf.c
+++ b/vcf.c
@@ -3144,6 +3144,7 @@ static void bcf_set_variant_type(const char *ref, const char *alt, variant_t *va
 
     if ( *a && !*r )
     {
+        if ( *a==']' || *a=='[' ) { var->type = VCF_BND; return; }
         while ( *a ) a++;
         var->n = (a-alt)-(r-ref); var->type = VCF_INDEL; return;
     }


### PR DESCRIPTION
Alternatively, the function could return VCF_OTHER instead, which would not require changes in `vcf.h`