### PR TITLE
Prevent bgzf assert on reading empty VCF/BCF files

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -837,6 +837,12 @@ bcf_hdr_t *bcf_hdr_read(htsFile *hfp)
     if (hfp->format.format == vcf)
         return vcf_hdr_read(hfp);
 
+    if (!hfp->is_bin)
+    {
+        fprintf(stderr,"[%s:%d %s] Failed to read the header\n", __FILE__,__LINE__,__FUNCTION__);
+        return NULL;
+    }
+
     BGZF *fp = hfp->fp.bgzf;
     uint8_t magic[5];
     bcf_hdr_t *h;


### PR DESCRIPTION
Empty files are not recognised as VCF by hts_open and therefore bcf_hdr_read()
attempts to call bgzf_read() and the program fails with

    bcftools: bgzf.c:879: bgzf_read: Assertion `fp->is_write == 0' failed.

This probably a good place for the fix, fp->bgzf should not be accessed before
fp->is_bin is checked.