### PR TITLE
Fix l_qname overflow

### DIFF
--- a/cram/cram_samtools.c
+++ b/cram/cram_samtools.c
@@ -94,7 +94,7 @@ int bam_construct_seq(bam_seq_t **bp, size_t extra_len,
     b->core.bin     = bam_reg2bin(pos-1, end);
     b->core.qual    = mapq;
     b->core.l_qname = qname_len+qname_nuls;
-    b->core.l_extranul = qname_nuls-1;
+    b->core.l_qname_old = (uint8_t) b->core.l_qname;
     b->core.flag    = flag;
     b->core.n_cigar = ncigar;
     b->core.l_qseq  = len;
@@ -105,8 +105,9 @@ int bam_construct_seq(bam_seq_t **bp, size_t extra_len,
     cp = b->data;
 
     strncpy((char *)cp, qname, qname_len);
-    for (i = 0; i < qname_nuls; i++)
+    for (i = 0; i < qname_nuls-1; i++)
 	cp[qname_len+i] = '\0';
+    cp[qname_len+qname_nuls-1] = qname_nuls-1;
     cp += qname_len+qname_nuls;
     if (ncigar > 0) memcpy(cp, cigar, ncigar*4);
     cp += ncigar*4;

--- a/cram/cram_samtools.h
+++ b/cram/cram_samtools.h
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define bam_flag(b)      (b)->core.flag
 #define bam_bin(b)       (b)->core.bin
 #define bam_map_qual(b)  (b)->core.qual
-#define bam_name_len(b)  ((b)->core.l_qname - (b)->core.l_extranul)
+#define bam_name_len(b)  ((b)->core.l_qname - (b)->data[(b)->core.l_qname-1])
 #define bam_name(b)      bam_get_qname((b))
 #define bam_qual(b)      bam_get_qual((b))
 #define bam_seq(b)       bam_get_seq((b))

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -139,9 +139,8 @@ typedef struct {
  @field  pos     0-based leftmost coordinate
  @field  bin     bin calculated by bam_reg2bin()
  @field  qual    mapping quality
- @field  l_qname length of the query name
  @field  flag    bitwise flag
- @field  l_extranul length of extra NULs between qname & cigar (for alignment)
+ @field  l_qname length of the query name
  @field  n_cigar number of CIGAR operations
  @field  l_qseq  length of the query sequence (read)
  @field  mtid    chromosome ID of next read in template, defined by bam_hdr_t
@@ -152,10 +151,9 @@ typedef struct {
     int32_t pos;
     uint16_t bin;
     uint8_t qual;
-    uint8_t l_qname;
+    uint8_t l_qname_old;
     uint16_t flag;
-    uint8_t unused1;
-    uint8_t l_extranul;
+    uint16_t l_qname;
     uint32_t n_cigar;
     int32_t l_qseq;
     int32_t mtid;
@@ -174,7 +172,8 @@ typedef struct {
 
  1. qname is terminated by one to four NULs, so that the following
  cigar data is 32-bit aligned; core.l_qname includes these trailing NULs,
- while core.l_extranul counts the excess NULs (so 0 <= l_extranul <= 3).
+ while the last NUL byte is in fact a count of the excess "NULs" (thus
+ 0 <= data[l_qname-1] <= 3) rather than necessarily being actually '\0'.
  2. l_qseq is calculated from the total length of an alignment block
  on reading or from CIGAR.
  3. cigar data is encoded 4 bytes per CIGAR operation.


### PR DESCRIPTION
Fixes #520, while maintaining binary compatibility as best one can.  Code compiled against htslib 1.4 will continue to work when running against a libhts.so containing this fix, but will still fail for ≥252 QNAMEs.  Such code would need to be recompiled to benefit from the fix.