### PR TITLE
Added "make dist" and "make distcheck" targets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.pc.tmp
 *-uninstalled.pc
 /version.h
+/_dist
 
 autom4te.cache
 config.cache

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 dnl Process this file with autoconf to produce a configure script
-AC_INIT([HTSlib], m4_esyscmd_s([make print-version]),
+AC_INIT([HTSlib], m4_esyscmd_s([./version.sh 2>/dev/null]),
         [samtools-help@lists.sourceforge.net], [], [http://www.htslib.org/])
 AC_PREREQ(2.63)  dnl This version introduced 4-argument AC_CHECK_HEADER
 AC_CONFIG_SRCDIR(hts.c)

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Master version, for use in tarballs or non-git source copies
+VERSION=1.4.1
+
+# If we have a git clone, then check against the current tag
+if [ -e .git ]
+then
+    # If we ever get to 10.x this will need to be more liberal
+    VERSION=`git describe --match '[0-9].[0-9]*' --dirty`
+fi
+
+# Numeric version is for use in .dylib or .so libraries
+#
+# Follows the same logic from the Makefile commit c2e93911
+# as non-numeric versions get bumped to patch level 255 to indicate
+# an unknown value.
+if [ "$1" = "numeric" ]
+then
+    v1=`expr "$VERSION" : '\([0-9]*\)'`
+    v2=`expr "$VERSION" : '[0-9]*.\([0-9]*\)'`
+    v3=`expr "$VERSION" : '[0-9]*.[0-9]*.\([0-9]*\)'`
+    if [ -z "`expr "$VERSION" : '^\([0-9.]*\)$'`" ]
+    then
+	VERSION="$v1.$v2.255"
+    else
+	VERSION="$v1.$v2${v3:+.}$v3"
+    fi
+fi
+
+echo $VERSION


### PR DESCRIPTION
This is partly to replace the c-maint repository and additionally to add the ability to validate the tar balls is constructed correctly by unpacking, building and testing.