### PR TITLE
Limit subexp and gamma decoders to integer cram_external_type

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -749,8 +749,8 @@ cram_codec *cram_subexp_decode_init(char *data, int size,
     cram_codec *c;
     char *cp = data;
 
-    if (option == E_BYTE_ARRAY_BLOCK) {
-	fprintf(stderr, "BYTE_ARRAYs not supported by this codec\n");
+    if (option != E_INT) {
+	fprintf(stderr, "This codec only supports INT encodings\n");
 	return NULL;
     }
 
@@ -815,8 +815,8 @@ cram_codec *cram_gamma_decode_init(char *data, int size,
     cram_codec *c = NULL;
     char *cp = data;
 
-    if (option == E_BYTE_ARRAY_BLOCK) {
-	fprintf(stderr, "BYTE_ARRAYs not supported by this codec\n");
+    if (option != E_INT) {
+	fprintf(stderr, "This codec only supports INT encodings\n");
 	return NULL;
     }
 


### PR DESCRIPTION
The decoders currently assume that they are writing to an integer array,
and neither htslib nor htsjdk appear to write anything other than
integers using these codecs.  So it should be reasonable to restrict
them to use with only integer data streams.

Fixes #548 (Stack buffer overflows in cram_gamma_decode and
cram_subexp_decode)