### PR TITLE
Work-around for CIGARs with >64k operations in BAM files

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -485,13 +485,13 @@ int bam_write1(BGZF *fp, const bam1_t *b)
         cigar_st = (uint8_t*)bam_get_cigar(b) - b->data;
         cigar_en = cigar_st + c->n_cigar * 4;
         if (ok) ok = (bgzf_write(fp, &b->data[cigar_en], b->l_data - cigar_en) >= 0); // write data after CIGAR
-		if (ok) ok = (bgzf_write(fp, "CGBI", 4) >= 0); // write CG:B,I
-		if (fp->is_be) {
-			y = c->n_cigar;
-			if (ok) ok = (bgzf_write(fp, ed_swap_4p(&y), 4) >= 0);
-		} else {
-			if (ok) ok = (bgzf_write(fp, &c->n_cigar, 4) >= 0);
-		}
+        if (ok) ok = (bgzf_write(fp, "CGBI", 4) >= 0); // write CG:B,I
+        if (fp->is_be) {
+            y = c->n_cigar;
+            if (ok) ok = (bgzf_write(fp, ed_swap_4p(&y), 4) >= 0);
+        } else {
+            if (ok) ok = (bgzf_write(fp, &c->n_cigar, 4) >= 0);
+        }
         if (ok) ok = (bgzf_write(fp, &b->data[cigar_st], c->n_cigar * 4) >= 0); // write the real CIGAR
     }
     if (fp->is_be) swap_data(c, b->l_data, b->data, 0);

--- a/sam.c
+++ b/sam.c
@@ -362,7 +362,7 @@ static int bam_tag2cigar(bam1_t *b)
     if (c->n_cigar == 0 || c->tid < 0 || c->pos < 0) return 0;
     cigar0 = bam_get_cigar(b);
     if (bam_cigar_op(cigar0[0]) != BAM_CSOFT_CLIP || bam_cigar_oplen(cigar0[0]) != c->l_qseq) return 0;
-	fake_bytes = c->n_cigar * 4;
+    fake_bytes = c->n_cigar * 4;
     if ((CG = bam_aux_get(b, "CG")) == 0) return 0; // no CG tag
     if (CG[0] != 'B' || CG[1] != 'I') return 0; // not of type B,I
     CG_len = le_to_u32(CG + 2);

--- a/sam.c
+++ b/sam.c
@@ -387,6 +387,7 @@ static int bam_tag2cigar(bam1_t *b)
     if (ori_len > CG_en) // move data after the CG tag
       memmove(b->data + CG_st + n_cigar4 - 4, b->data + CG_en + n_cigar4 - 4, ori_len - CG_en);
     b->l_data -= n_cigar4 + 8; // 8: CGBI (4 bytes) and CGBI length (4)
+	b->core.bin = hts_reg2bin(b->core.pos, b->core.pos + bam_cigar2rlen(b->core.n_cigar, bam_get_cigar(b)), 14, 5);
     return 1;
 }
 

--- a/sam.c
+++ b/sam.c
@@ -387,7 +387,7 @@ static int bam_tag2cigar(bam1_t *b)
     if (ori_len > CG_en) // move data after the CG tag
       memmove(b->data + CG_st + n_cigar4 - 4, b->data + CG_en + n_cigar4 - 4, ori_len - CG_en);
     b->l_data -= n_cigar4 + 8; // 8: CGBI (4 bytes) and CGBI length (4)
-	b->core.bin = hts_reg2bin(b->core.pos, b->core.pos + bam_cigar2rlen(b->core.n_cigar, bam_get_cigar(b)), 14, 5);
+    b->core.bin = hts_reg2bin(b->core.pos, b->core.pos + bam_cigar2rlen(b->core.n_cigar, bam_get_cigar(b)), 14, 5);
     return 1;
 }
 

--- a/sam.c
+++ b/sam.c
@@ -355,13 +355,14 @@ int32_t bam_endpos(const bam1_t *b)
 static int bam_tag2cigar(bam1_t *b)
 {
     bam1_core_t *c = &b->core;
-    uint32_t cigar_st, n_cigar4, CG_st, CG_en, ori_len = b->l_data, *cigar0, CG_len;
+    uint32_t cigar_st, n_cigar4, CG_st, CG_en, ori_len = b->l_data, *cigar0, CG_len, fake_bytes;
     uint8_t *CG;
 
     // test where there is a real CIGAR in the CG tag to move
-    if (c->n_cigar != 1 || c->tid < 0 || c->pos < 0) return 0;
+    if (c->n_cigar == 0 || c->tid < 0 || c->pos < 0) return 0;
     cigar0 = bam_get_cigar(b);
     if (bam_cigar_op(cigar0[0]) != BAM_CSOFT_CLIP || bam_cigar_oplen(cigar0[0]) != c->l_qseq) return 0;
+	fake_bytes = c->n_cigar * 4;
     if ((CG = bam_aux_get(b, "CG")) == 0) return 0; // no CG tag
     if (CG[0] != 'B' || CG[1] != 'I') return 0; // not of type B,I
     CG_len = le_to_u32(CG + 2);
@@ -373,7 +374,7 @@ static int bam_tag2cigar(bam1_t *b)
     n_cigar4 = c->n_cigar * 4;
     CG_st = CG - b->data - 2;
     CG_en = CG_st + 8 + n_cigar4;
-    b->l_data += n_cigar4 - 4; // we need (c->n_cigar-1)*4 bytes to swap CIGAR to the right place
+    b->l_data += n_cigar4 - fake_bytes; // we need c->n_cigar-fake_bytes bytes to swap CIGAR to the right place
     if (b->m_data < b->l_data) {
         uint8_t *new_data;
         uint32_t new_max = b->l_data;
@@ -382,10 +383,10 @@ static int bam_tag2cigar(bam1_t *b)
         if (new_data == 0) return -1;
         b->m_data = new_max, b->data = new_data;
     }
-    memmove(b->data + cigar_st + n_cigar4, b->data + cigar_st + 4, ori_len - (cigar_st + 4)); // insert 4*(c->n_cigar-1) empty space to make room
-    memcpy(b->data + cigar_st, b->data + (n_cigar4 - 4) + CG_st + 8, n_cigar4); // copy the real CIGAR to the right place; -4 for the fake CIGAR
+    memmove(b->data + cigar_st + n_cigar4, b->data + cigar_st + fake_bytes, ori_len - (cigar_st + fake_bytes)); // insert c->n_cigar-fake_bytes empty space to make room
+    memcpy(b->data + cigar_st, b->data + (n_cigar4 - fake_bytes) + CG_st + 8, n_cigar4); // copy the real CIGAR to the right place; -fake_bytes for the fake CIGAR
     if (ori_len > CG_en) // move data after the CG tag
-      memmove(b->data + CG_st + n_cigar4 - 4, b->data + CG_en + n_cigar4 - 4, ori_len - CG_en);
+      memmove(b->data + CG_st + n_cigar4 - fake_bytes, b->data + CG_en + n_cigar4 - fake_bytes, ori_len - CG_en);
     b->l_data -= n_cigar4 + 8; // 8: CGBI (4 bytes) and CGBI length (4)
     b->core.bin = hts_reg2bin(b->core.pos, b->core.pos + bam_cigar2rlen(b->core.n_cigar, bam_get_cigar(b)), 14, 5);
     return 1;
@@ -480,11 +481,11 @@ int bam_write1(BGZF *fp, const bam1_t *b)
     const bam1_core_t *c = &b->core;
     uint32_t x[8], block_len = b->l_data - c->l_extranul + 32, y;
     int i, ok;
-    if (c->n_cigar > 0xffff) block_len += 12; // "12" for "CGBI", 4-byte tag length and 4-byte fake CIGAR
+    if (c->n_cigar > 0xffff) block_len += 16; // "16" for "CGBI", 4-byte tag length and 8-byte fake CIGAR
     x[0] = c->tid;
     x[1] = c->pos;
     x[2] = (uint32_t)c->bin<<16 | c->qual<<8 | (c->l_qname - c->l_extranul);
-    if (c->n_cigar > 0xffff) x[3] = (uint32_t)c->flag << 16 | 1;
+    if (c->n_cigar > 0xffff) x[3] = (uint32_t)c->flag << 16 | 2;
     else x[3] = (uint32_t)c->flag << 16 | (c->n_cigar & 0xffff);
     x[4] = c->l_qseq;
     x[5] = c->mtid;
@@ -504,13 +505,15 @@ int bam_write1(BGZF *fp, const bam1_t *b)
     if (c->n_cigar <= 0xffff) { // no long CIGAR; write normally
         if (ok) ok = (bgzf_write(fp, b->data + c->l_qname, b->l_data - c->l_qname) >= 0);
     } else { // with long CIGAR, insert a fake CIGAR record and move the real CIGAR to the CG:B,I tag
-        uint8_t buf[4];
-        uint32_t cigar_st, cigar_en, cigar1;
+        uint8_t buf[8];
+        uint32_t cigar_st, cigar_en, cigar[2];
         cigar_st = (uint8_t*)bam_get_cigar(b) - b->data;
         cigar_en = cigar_st + c->n_cigar * 4;
-        cigar1 = (uint32_t)c->l_qseq << 4 | BAM_CSOFT_CLIP;
-        u32_to_le(cigar1, buf);
-        if (ok) ok = (bgzf_write(fp, buf, 4) >= 0); // write cigar: <read_length>S
+        cigar[0] = (uint32_t)c->l_qseq << 4 | BAM_CSOFT_CLIP;
+        cigar[1] = (uint32_t)bam_cigar2rlen(c->n_cigar, bam_get_cigar(b)) << 4 | BAM_CREF_SKIP;
+        u32_to_le(cigar[0], buf);
+        u32_to_le(cigar[1], buf + 4);
+        if (ok) ok = (bgzf_write(fp, buf, 8) >= 0); // write cigar: <read_length>S<ref_length>N
         if (ok) ok = (bgzf_write(fp, &b->data[cigar_en], b->l_data - cigar_en) >= 0); // write data after CIGAR
         if (ok) ok = (bgzf_write(fp, "CGBI", 4) >= 0); // write CG:B,I
         u32_to_le(c->n_cigar, buf);


### PR DESCRIPTION
This PR implements the idea discussed in samtools/hts-specs#40.

EDIT: test data are [available here](http://lh3lh3.users.sourceforge.net/data/cigar-64k/).