### PR TITLE
Logging improvements 4

### DIFF
--- a/bcf_sr_sort.c
+++ b/bcf_sr_sort.c
@@ -267,6 +267,8 @@ static int cmpstringp(const void *p1, const void *p2)
 {
     return strcmp(* (char * const *) p1, * (char * const *) p2);
 }
+
+#if DEBUG_VSETS
 void debug_vsets(sr_sort_t *srt)
 {
     int i,j,k;
@@ -285,6 +287,9 @@ void debug_vsets(sr_sort_t *srt)
         fprintf(stderr,"\n");
     }
 }
+#endif
+
+#if DEBUG_VBUF
 void debug_vbuf(sr_sort_t *srt)
 {
     int i, j;
@@ -299,6 +304,8 @@ void debug_vbuf(sr_sort_t *srt)
         fprintf(stderr,"\n");
     }
 }
+#endif
+
 char *grp_create_key(sr_sort_t *srt)
 {
     if ( !srt->str.l ) return strdup("");
@@ -485,7 +492,9 @@ static void bcf_sr_sort_set(bcf_srs_t *readers, sr_sort_t *srt, const char *chr,
         }
         var->type = type;
     }
-    // debug_vsets(srt);
+#if DEBUG_VSETS
+    debug_vsets(srt);
+#endif
 
     // initialize the pairing matrix
     hts_expand(int, srt->ngrp*srt->nvset, srt->mpmat, srt->pmat);
@@ -501,7 +510,10 @@ static void bcf_sr_sort_set(bcf_srs_t *readers, sr_sort_t *srt, const char *chr,
     // pair the lines
     while ( srt->nvset )
     {
-        // fprintf(stderr,"\n"); debug_vsets(srt);
+#if DEBUG_VSETS
+	fprintf(stderr,"\n");
+	debug_vsets(srt);
+#endif
 
         int imax = 0;
         for (ivset=1; ivset<srt->nvset; ivset++)
@@ -567,7 +579,9 @@ int bcf_sr_sort_next(bcf_srs_t *readers, sr_sort_t *srt, const char *chr, int mi
 
     if ( !srt->vcf_buf[0].nrec ) return 0;
 
-    // debug_vbuf(srt);
+#if DEBUG_VBUF
+    debug_vbuf(srt);
+#endif
 
     int nret = 0;
     for (i=0; i<srt->sr->nreaders; i++)

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -558,7 +558,7 @@ cram_codec *cram_beta_decode_init(char *data, int size,
     else if (option == E_BYTE_ARRAY || option == E_BYTE)
 	c->decode = cram_beta_decode_char;
     else {
-	fprintf(stderr, "BYTE_ARRAYs not supported by this codec\n");
+	hts_log_error("BYTE_ARRAYs not supported by this codec");
 	return NULL;
     }
     c->free   = cram_beta_decode_free;
@@ -748,7 +748,7 @@ cram_codec *cram_subexp_decode_init(char *data, int size,
     char *cp = data;
 
     if (option != E_INT) {
-	fprintf(stderr, "This codec only supports INT encodings\n");
+	hts_log_error("This codec only supports INT encodings");
 	return NULL;
     }
 
@@ -764,7 +764,7 @@ cram_codec *cram_subexp_decode_init(char *data, int size,
     cp += safe_itf8_get(cp, data + size, &c->subexp.k);
 
     if (cp - data != size || c->subexp.k < 0) {
-	fprintf(stderr, "Malformed subexp header stream\n");
+	hts_log_error("Malformed subexp header stream");
 	free(c);
 	return NULL;
     }
@@ -814,7 +814,7 @@ cram_codec *cram_gamma_decode_init(char *data, int size,
     char *cp = data;
 
     if (option != E_INT) {
-	fprintf(stderr, "This codec only supports INT encodings\n");
+	hts_log_error("This codec only supports INT encodings");
 	return NULL;
     }
 
@@ -985,13 +985,13 @@ cram_codec *cram_huffman_decode_init(char *data, int size,
     int l;
 
     if (option == E_BYTE_ARRAY_BLOCK) {
-	fprintf(stderr, "BYTE_ARRAYs not supported by this codec\n");
+	hts_log_error("BYTE_ARRAYs not supported by this codec");
 	return NULL;
     }
 
     cp += safe_itf8_get(cp, data_end, &ncodes);
     if (ncodes < 0) {
-        fprintf(stderr, "Invalid number of symbols in huffman stream\n");
+	hts_log_error("Invalid number of symbols in huffman stream");
         return NULL;
     }
     if (ncodes >= SIZE_MAX / sizeof(*codes)) {
@@ -1023,13 +1023,13 @@ cram_codec *cram_huffman_decode_init(char *data, int size,
     }
 
     if (l < 1) {
-	fprintf(stderr, "Malformed huffman header stream\n");
+	hts_log_error("Malformed huffman header stream");
 	free(h);
 	return NULL;
     }
     cp += safe_itf8_get(cp, data_end, &i);
     if (i != ncodes) {
-	fprintf(stderr, "Malformed huffman header stream\n");
+	hts_log_error("Malformed huffman header stream");
 	free(h);
 	return NULL;
     }
@@ -1051,7 +1051,7 @@ cram_codec *cram_huffman_decode_init(char *data, int size,
 	    max_len = codes[i].len;
     }
     if (l < 1 || cp - data != size || max_len >= ncodes) {
-	fprintf(stderr, "Malformed huffman header stream\n");
+	hts_log_error("Malformed huffman header stream");
 	free(h);
 	return NULL;
     }
@@ -1511,7 +1511,7 @@ cram_codec *cram_byte_array_len_decode_init(char *data, int size,
     return c;
 
  malformed:
-    fprintf(stderr, "Malformed byte_array_len header stream\n");
+    hts_log_error("Malformed byte_array_len header stream");
  no_codec:
     free(c);
     return NULL;
@@ -1855,7 +1855,7 @@ cram_codec *cram_decoder_init(enum cram_encoding codec,
     if (codec >= E_NULL && codec < E_NUM_CODECS && decode_init[codec]) {
 	return decode_init[codec](data, size, option, version);
     } else {
-	fprintf(stderr, "Unimplemented codec of type %s\n", cram_encoding2str(codec));
+	hts_log_error("Unimplemented codec of type %s", cram_encoding2str(codec));
 	return NULL;
     }
 }
@@ -1890,7 +1890,7 @@ cram_codec *cram_encoder_init(enum cram_encoding codec,
 	    r->out = NULL;
 	return r;
     } else {
-	fprintf(stderr, "Unimplemented codec of type %s\n", cram_encoding2str(codec));
+	hts_log_error("Unimplemented codec of type %s", cram_encoding2str(codec));
 	abort();
     }
 }
@@ -1928,7 +1928,7 @@ int cram_codec_to_id(cram_codec *c, int *id2) {
 	bnum1 = -2;
 	break;
     default:
-	fprintf(stderr, "Unknown codec type %d\n", c->codec);
+	hts_log_error("Unknown codec type %d", c->codec);
 	bnum1 = -1;
     }
 

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -239,7 +239,7 @@ static inline unsigned int get_bits_MSB(cram_block *block, int nbits) {
  * for it elsewhere.)
  */
 static int store_bits_MSB(cram_block *block, unsigned int val, int nbits) {
-    /* fprintf(stderr, " store_bits: %02x %d\n", val, nbits); */
+    //fprintf(stderr, " store_bits: %02x %d\n", val, nbits);
 
     /*
      * Use slow mode until we tweak the huffman generator to never generate

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2741,11 +2741,11 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
     // As we grow blocks we overallocate by up to 50%. So shrink
     // back to their final sizes here.
     //
-//    fprintf(stderr, "%d %d // %d %d // %d %d // %d %d\n",
-//    	    (int)s->seqs_blk->byte, (int)s->seqs_blk->alloc, 
-//    	    (int)s->qual_blk->byte, (int)s->qual_blk->alloc, 
-//    	    (int)s->name_blk->byte, (int)s->name_blk->alloc, 
-//    	    (int)s->aux_blk->byte,  (int)s->aux_blk->alloc);
+    //fprintf(stderr, "%d %d // %d %d // %d %d // %d %d\n",
+    //	    (int)s->seqs_blk->byte, (int)s->seqs_blk->alloc,
+    //	    (int)s->qual_blk->byte, (int)s->qual_blk->alloc,
+    //	    (int)s->name_blk->byte, (int)s->name_blk->alloc,
+    //	    (int)s->aux_blk->byte,  (int)s->aux_blk->alloc);
     BLOCK_RESIZE_EXACT(s->seqs_blk, BLOCK_SIZE(s->seqs_blk)+1);
     BLOCK_RESIZE_EXACT(s->qual_blk, BLOCK_SIZE(s->qual_blk)+1);
     BLOCK_RESIZE_EXACT(s->name_blk, BLOCK_SIZE(s->name_blk)+1);
@@ -3121,9 +3121,9 @@ static cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
 	hts_tpool_result *res;
 	cram_decode_job *j;
 	
-//	fprintf(stderr, "Thread pool len = %d, %d\n",
-//		hts_tpool_results_queue_len(fd->rqueue),
-//		hts_tpool_results_queue_sz(fd->rqueue));
+	//fprintf(stderr, "Thread pool len = %d, %d\n",
+	//	hts_tpool_results_queue_len(fd->rqueue),
+	//	hts_tpool_results_queue_sz(fd->rqueue));
 
 	if (fd->ooc && hts_tpool_process_empty(fd->rqueue))
 	    return NULL;

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1446,7 +1446,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
     h->codecs[DS_CF] = cram_encoder_init(cram_stats_encoding(fd, c->stats[DS_CF]),
 					 c->stats[DS_CF], E_INT, NULL,
 					 fd->version);
-//    fprintf(stderr, "=== RN ===\n");
+    //fprintf(stderr, "=== RN ===\n");
 //    h->codecs[DS_RN] = cram_encoder_init(cram_stats_encoding(fd, c->stats[DS_RN]),
 //				    c->stats[DS_RN], E_BYTE_ARRAY, NULL,
 //				    fd->version);

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -499,9 +499,7 @@ cram_block *cram_encode_compression_header(cram_fd *fd, cram_container *c,
     itf8_put_blk(cb, mc);    
     BLOCK_APPEND(cb, BLOCK_DATA(map), BLOCK_SIZE(map));
 
-    if (fd->verbose)
-	hts_log_info("Wrote compression block header in %d bytes",
-		(int)BLOCK_SIZE(cb));
+    hts_log_info("Wrote compression block header in %d bytes", (int)BLOCK_SIZE(cb));
 
     BLOCK_UPLEN(cb);
 
@@ -1405,8 +1403,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
     multi_ref = c->stats[DS_RI]->nvals > 1;
 
     if (multi_ref) {
-	if (fd->verbose)
-	    hts_log_info("Multi-ref container");
+	hts_log_info("Multi-ref container");
 	c->ref_seq_id = -2;
 	c->ref_seq_start = 0;
 	c->ref_seq_span = 0;
@@ -1640,8 +1637,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
 
     /* Encode slices */
     for (i = 0; i < c->curr_slice; i++) {
-	if (fd->verbose)
-	    hts_log_info("Encode slice %d", i);
+	hts_log_info("Encode slice %d", i);
 
 	if (cram_encode_slice(fd, c, h, c->slices[i]) != 0)
 	    return -1;
@@ -2445,10 +2441,9 @@ static cram_container *cram_next_container(cram_fd *fd, bam_seq_t *b) {
     if (c->curr_slice == c->max_slice ||
 	(bam_ref(b) != c->curr_ref && !c->multi_seq)) {
 	c->ref_seq_span = fd->last_base - c->ref_seq_start + 1;
-	if (fd->verbose)
-	    hts_log_info("Flush container %d/%d..%d",
-		    c->ref_seq_id, c->ref_seq_start,
-		    c->ref_seq_start + c->ref_seq_span -1);
+	hts_log_info("Flush container %d/%d..%d",
+		c->ref_seq_id, c->ref_seq_start,
+		c->ref_seq_start + c->ref_seq_span -1);
 
 	/* Encode slices */
 	if (fd->pool) {
@@ -3085,7 +3080,7 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
 	if (fd->multi_seq == -1 && c->curr_rec < c->max_rec/4+10 &&
 	    fd->last_slice && fd->last_slice < c->max_rec/4+10 &&
 	    !fd->embed_ref) {
-	    if (fd->verbose && !c->multi_seq)
+	    if (!c->multi_seq)
 		hts_log_info("Multi-ref enabled for this container");
 	    multi_seq = 1;
 	}

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -239,7 +239,7 @@ cram_block *cram_encode_compression_header(cram_fd *fd, cram_container *c,
 	    }
 
 	    default:
-		fprintf(stderr, "Unknown preservation key '%.2s'\n", key);
+		hts_log_warning("Unknown preservation key '%.2s'", key);
 		break;
 	    }
 
@@ -500,7 +500,7 @@ cram_block *cram_encode_compression_header(cram_fd *fd, cram_container *c,
     BLOCK_APPEND(cb, BLOCK_DATA(map), BLOCK_SIZE(map));
 
     if (fd->verbose)
-	fprintf(stderr, "Wrote compression block header in %d bytes\n",
+	hts_log_info("Wrote compression block header in %d bytes",
 		(int)BLOCK_SIZE(cb));
 
     BLOCK_UPLEN(cb);
@@ -746,8 +746,7 @@ static int cram_encode_slice_read(cram_fd *fd,
 		    
 
 	    default:
-		fprintf(stderr, "unhandled feature code %c\n",
-			f->X.code);
+		hts_log_error("Unhandled feature code %c", f->X.code);
 		return -1;
 	    }
 	}
@@ -1278,7 +1277,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
 
 	ref = cram_get_ref(fd, bam_ref(b), 1, 0);
 	if (!ref && bam_ref(b) >= 0) {
-	    fprintf(stderr, "Failed to load reference #%d\n", bam_ref(b));
+	    hts_log_error("Failed to load reference #%d", bam_ref(b));
 	    return -1;
 	}
 	if ((c->ref_id = bam_ref(b)) >= 0) {
@@ -1322,8 +1321,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
 			cram_ref_decr(fd->refs, c->ref_seq_id);
 
 		    if (!cram_get_ref(fd, bam_ref(b), 1, 0)) {
-			fprintf(stderr, "Failed to load reference #%d\n",
-				bam_ref(b));
+			hts_log_error("Failed to load reference #%d", bam_ref(b));
 			return -1;
 		    }
 
@@ -1408,7 +1406,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
 
     if (multi_ref) {
 	if (fd->verbose)
-	    fprintf(stderr, "Multi-ref container\n");
+	    hts_log_info("Multi-ref container");
 	c->ref_seq_id = -2;
 	c->ref_seq_start = 0;
 	c->ref_seq_span = 0;
@@ -1643,7 +1641,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
     /* Encode slices */
     for (i = 0; i < c->curr_slice; i++) {
 	if (fd->verbose)
-	    fprintf(stderr, "Encode slice %d\n", i);
+	    hts_log_info("Encode slice %d", i);
 
 	if (cram_encode_slice(fd, c, h, c->slices[i]) != 0)
 	    return -1;
@@ -1970,7 +1968,7 @@ static char *cram_encode_aux_1_0(cram_fd *fd, bam_seq_t *b, cram_container *c,
 	    case 'A': case 'C': case 'c': aux+=4; break;
 	    case 'I': case 'i': case 'f': aux+=7; break;
 	    default:
-		fprintf(stderr, "Unhandled type code for NM tag\n");
+		hts_log_error("Unhandled type code for NM tag");
 		return NULL;
 	    }
 	    continue;
@@ -2040,10 +2038,8 @@ static char *cram_encode_aux_1_0(cram_fd *fd, bam_seq_t *b, cram_container *c,
 		blen = 4*count;
 		break;
 	    default:
-		fprintf(stderr, "Unknown sub-type '%c' for aux type 'B'\n",
-			type);
+		hts_log_error("Unknown sub-type '%c' for aux type 'B'", type);
 		return NULL;
-		    
 	    }
 
 	    tmp += itf8_put(tmp, blen+5);
@@ -2058,7 +2054,7 @@ static char *cram_encode_aux_1_0(cram_fd *fd, bam_seq_t *b, cram_container *c,
 	    break;
 	}
 	default:
-	    fprintf(stderr, "Unknown aux type '%c'\n", aux[2]);
+	    hts_log_error("Unknown aux type '%c'", aux[2]);
 	    return NULL;
 	}
     }
@@ -2117,7 +2113,7 @@ static char *cram_encode_aux(cram_fd *fd, bam_seq_t *b, cram_container *c,
 		case 'S': case 's':           aux+=5; break;
 		case 'I': case 'i': case 'f': aux+=7; break;
 		default:
-		    fprintf(stderr, "Unhandled type code for NM tag\n");
+		    hts_log_error("Unhandled type code for NM tag");
 		    return NULL;
 		}
 		continue;
@@ -2243,8 +2239,7 @@ static char *cram_encode_aux(cram_fd *fd, bam_seq_t *b, cram_container *c,
 	    }
 
 	    default:
-		fprintf(stderr, "Unsupported SAM aux type '%c'\n",
-			aux[2]);
+		hts_log_error("Unsupported SAM aux type '%c'", aux[2]);
 		c = NULL;
 	    }
 
@@ -2355,10 +2350,8 @@ static char *cram_encode_aux(cram_fd *fd, bam_seq_t *b, cram_container *c,
 		blen = 4*count;
 		break;
 	    default:
-		fprintf(stderr, "Unknown sub-type '%c' for aux type 'B'\n",
-			type);
+		hts_log_error("Unknown sub-type '%c' for aux type 'B'", type);
 		return NULL;
-		    
 	    }
 
 	    blen += 5; // sub-type & length
@@ -2368,7 +2361,7 @@ static char *cram_encode_aux(cram_fd *fd, bam_seq_t *b, cram_container *c,
 	    break;
 	}
 	default:
-	    fprintf(stderr, "Unknown aux type '%c'\n", aux[2]);
+	    hts_log_error("Unknown aux type '%c'", aux[2]);
 	    return NULL;
 	}
 	tm->blk->m = tm->m;
@@ -2453,7 +2446,7 @@ static cram_container *cram_next_container(cram_fd *fd, bam_seq_t *b) {
 	(bam_ref(b) != c->curr_ref && !c->multi_seq)) {
 	c->ref_seq_span = fd->last_base - c->ref_seq_start + 1;
 	if (fd->verbose)
-	    fprintf(stderr, "Flush container %d/%d..%d\n",
+	    hts_log_info("Flush container %d/%d..%d",
 		    c->ref_seq_id, c->ref_seq_start,
 		    c->ref_seq_start + c->ref_seq_span -1);
 
@@ -2697,8 +2690,7 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 		    char *rp = &ref[apos];
 		    char *qp = &qual[spos];
 		    if (end > cr->len) {
-			fprintf(stderr, "CIGAR and query sequence are of "
-				"different length\n");
+			hts_log_error("CIGAR and query sequence are of different length");
 			return -1;
 		    }
 		    for (l = 0; l < end; l++) {
@@ -2822,13 +2814,12 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 		break;
 
 	    default:
-		fprintf(stderr, "Unknown CIGAR op code %d\n", cig_op);
+		hts_log_error("Unknown CIGAR op code %d", cig_op);
 		return -1;
 	    }
 	}
 	if (cr->len && spos != cr->len) {
-	    fprintf(stderr, "CIGAR and query sequence are of different "
-		    "length\n");
+	    hts_log_error("CIGAR and query sequence are of different length");
 	    return -1;
 	}
 	fake_qual = spos;
@@ -3095,7 +3086,7 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
 	    fd->last_slice && fd->last_slice < c->max_rec/4+10 &&
 	    !fd->embed_ref) {
 	    if (fd->verbose && !c->multi_seq)
-		fprintf(stderr, "Multi-ref enabled for this container\n");
+		hts_log_info("Multi-ref enabled for this container");
 	    multi_seq = 1;
 	}
 

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -301,8 +301,7 @@ int cram_transcode_rg(cram_fd *in, cram_fd *out,
     cram_block_compression_hdr *ch;
 
     if (nrg != 1) {
-	fprintf(stderr, "[%s] ERROR: not implemented for nrg != 1\n",
-		__func__);
+	hts_log_error("CRAM transcode supports only a single RG");
 	return -2;
     }
 

--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -232,7 +232,7 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
 	//printf("%d/%d..%d\n", e.refid, e.start, e.end);
 
 	if (e.refid < -1) {
-	    fprintf(stderr, "Malformed index file, refid %d\n", e.refid);
+	    hts_log_error("Malformed index file, refid %d", e.refid);
             goto fail;
 	}
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1411,10 +1411,9 @@ int cram_compress_block(cram_fd *fd, cram_block *b, cram_metrics *metrics,
 	b->method = GZIP;
     }
 
-    if (fd->verbose)
-	hts_log_info("Compressed block ID %d from %d to %d by method %s",
-		b->content_id, b->uncomp_size, b->comp_size,
-		cram_block_method2str(b->method));
+    hts_log_info("Compressed block ID %d from %d to %d by method %s",
+	    b->content_id, b->uncomp_size, b->comp_size,
+	    cram_block_method2str(b->method));
 
     if (b->method == RANS1)
 	b->method = RANS0; // Spec just has RANS (not 0/1) with auto-sensing
@@ -2021,8 +2020,7 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
     mFILE *mf;
     int local_path = 0;
 
-    if (fd->verbose)
-	hts_log_info("Running cram_populate_ref on fd %p, id %d", (void *)fd, id);
+    hts_log_info("Running cram_populate_ref on fd %p, id %d", (void *)fd, id);
 
     cache_root[0] = '\0';
 
@@ -2038,8 +2036,7 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
 	    snprintf(cache_root, PATH_MAX, "%s%s/hts-ref", base, extra);
 	    snprintf(cache,PATH_MAX, "%s%s/hts-ref/%%2s/%%2s/%%s", base, extra);
 	    local_cache = cache;
-	    if (fd->verbose)
-		hts_log_info("Populating local cache: %s", local_cache);
+	    hts_log_info("Populating local cache: %s", local_cache);
 	}
     }
 
@@ -2052,8 +2049,7 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
     if (!(tag = sam_hdr_find_key(fd->header, ty, "M5", NULL)))
 	goto no_M5;
 
-    if (fd->verbose)
-	hts_log_info("Querying ref %s", tag->str+3);
+    hts_log_info("Querying ref %s", tag->str+3);
 
     /* Use cache if available */
     if (local_cache && *local_cache) {
@@ -2164,8 +2160,7 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
         }
 
 	expand_cache_path(path, local_cache, tag->str+3);
-	if (fd->verbose)
-	    hts_log_info("Writing cache file '%s'", path);
+	hts_log_info("Writing cache file '%s'", path);
 	mkdir_prefix(path, 01777);
 
 	do {
@@ -4072,7 +4067,6 @@ cram_fd *cram_dopen(hFILE *fp, const char *filename, const char *mode) {
     fd->ref = NULL;
 
     fd->decode_md = 0;
-    fd->verbose = 0;
     fd->seqs_per_slice = SEQS_PER_SLICE;
     fd->bases_per_slice = BASES_PER_SLICE;
     fd->slices_per_container = SLICE_PER_CNT;
@@ -4340,7 +4334,6 @@ int cram_set_voption(cram_fd *fd, enum hts_fmt_option opt, va_list args) {
 	break;
 
     case CRAM_OPT_VERBOSITY:
-	fd->verbose = va_arg(args, int);
 	break;
 
     case CRAM_OPT_SEQS_PER_SLICE:

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -786,7 +786,7 @@ cram_block *cram_read_block(cram_fd *fd) {
     if (-1 == itf8_decode_crc(fd, &b->comp_size, &crc))   { free(b); return NULL; }
     if (-1 == itf8_decode_crc(fd, &b->uncomp_size, &crc)) { free(b); return NULL; }
 
-    //    fprintf(stderr, "  method %d, ctype %d, cid %d, csize %d, ucsize %d\n",
+    //fprintf(stderr, "  method %d, ctype %d, cid %d, csize %d, ucsize %d\n",
     //	    b->method, b->content_type, b->content_id, b->comp_size, b->uncomp_size);
 
     if (b->method == RAW) {

--- a/cram/cram_stats.c
+++ b/cram/cram_stats.c
@@ -87,11 +87,11 @@ void cram_stats_del(cram_stats *st, int32_t val) {
 	    if (--kh_val(st->h, k) == 0)
 		kh_del(m_i2i, st->h, k);
 	} else {
-	    fprintf(stderr, "Failed to remove val %d from cram_stats\n", val);
+	    hts_log_warning("Failed to remove val %d from cram_stats", val);
 	    st->nsamp++;
 	}
     } else {
-	fprintf(stderr, "Failed to remove val %d from cram_stats\n", val);
+	hts_log_warning("Failed to remove val %d from cram_stats", val);
 	st->nsamp++;
     }
 }

--- a/cram/cram_stats.c
+++ b/cram/cram_stats.c
@@ -96,6 +96,7 @@ void cram_stats_del(cram_stats *st, int32_t val) {
     }
 }
 
+#if DEBUG_CRAM_STATS
 void cram_stats_dump(cram_stats *st) {
     int i;
     fprintf(stderr, "cram_stats:\n");
@@ -114,6 +115,7 @@ void cram_stats_dump(cram_stats *st) {
 	}
     }
 }
+#endif
 
 /*
  * Computes entropy from integer frequencies for various encoding methods and
@@ -128,7 +130,9 @@ enum cram_encoding cram_stats_encoding(cram_fd *fd, cram_stats *st) {
     int nvals, i, ntot = 0, max_val = 0, min_val = INT_MAX;
     int *vals = NULL, *freqs = NULL, vals_alloc = 0;
 
-    //cram_stats_dump(st);
+#if DEBUG_CRAM_STATS
+    cram_stats_dump(st);
+#endif
 
     /* Count number of unique symbols */
     for (nvals = i = 0; i < MAX_STAT_VAL; i++) {

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -706,7 +706,6 @@ typedef struct cram_fd {
 
     // options
     int decode_md; // Whether to export MD and NM tags
-    int verbose;
     int seqs_per_slice;
     int bases_per_slice;
     int slices_per_container;

--- a/cram/mFILE.c
+++ b/cram/mFILE.c
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 #include <stdarg.h>
 
+#include "hts_internal.h"
 #include "cram/os.h"
 #include "cram/mFILE.h"
 
@@ -307,7 +308,7 @@ mFILE *mfreopen(const char *path, const char *mode_str, FILE *fp) {
 	mf = mfcreate(NULL, 0);
 	if (NULL == mf) return NULL;
     } else {
-        fprintf(stderr, "Must specify either r, w or a for mode\n");
+	hts_log_error("Must specify either r, w or a for mode");
         return NULL;
     }
     mf->fp = fp;

--- a/cram/sam_header.c
+++ b/cram/sam_header.c
@@ -776,8 +776,7 @@ static enum sam_sort_order sam_hdr_parse_sort_order(SAM_hdr *hdr) {
 		else if (strcmp(tag->str+3, "coordinate") == 0)
 		    so = ORDER_COORD;
 		else if (strcmp(tag->str+3, "unknown") != 0)
-		    fprintf(stderr, "Unknown sort order field: %s\n",
-			    tag->str+3);
+		    hts_log_error("Unknown sort order field: %s", tag->str+3);
 	    }
 	}
     }

--- a/cram/sam_header.c
+++ b/cram/sam_header.c
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <assert.h>
 
+#include "hts_internal.h"
 #include "cram/sam_header.h"
 #include "cram/string_alloc.h"
 
@@ -41,7 +42,7 @@ static void sam_hdr_error(char *msg, char *line, int len, int lno) {
     
     for (j = 0; j < len && line[j] != '\n'; j++)
 	;
-    fprintf(stderr, "%s at line %d: \"%.*s\"\n", msg, lno, j, line);
+    hts_log_error("%s at line %d: \"%.*s\"", msg, lno, j, line);
 }
 
 void sam_hdr_dump(SAM_hdr *hdr) {

--- a/hts.c
+++ b/hts.c
@@ -994,13 +994,14 @@ int hts_set_opt(htsFile *fp, enum hts_fmt_option opt, ...) {
 
         if (hf) {
             va_start(args, opt);
-            if (hfile_set_blksize(hf, va_arg(args, int)) != 0 && hts_verbose >= 2)
-                fprintf(stderr, "[W::%s] Failed to change block size\n", __func__);
+            if (hfile_set_blksize(hf, va_arg(args, int)) != 0)
+                hts_log_warning("Failed to change block size");
             va_end(args);
-        } else if (hts_verbose >= 2)
+        }
+        else {
             // To do - implement for vcf/bcf.
-            fprintf(stderr, "[W::%s] cannot change block size for this format\n", __func__);
-
+            hts_log_warning("Cannot change block size for this format");
+        }
 
         return 0;
     }

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -210,7 +210,7 @@ enum hts_fmt_option {
     // CRAM specific
     CRAM_OPT_DECODE_MD,
     CRAM_OPT_PREFIX,
-    CRAM_OPT_VERBOSITY,  // make general
+    CRAM_OPT_VERBOSITY,  // obsolete, use hts_set_log_level() instead
     CRAM_OPT_SEQS_PER_SLICE,
     CRAM_OPT_SLICES_PER_CONTAINER,
     CRAM_OPT_RANGE,

--- a/realn.c
+++ b/realn.c
@@ -78,7 +78,7 @@ int sam_cap_mapq(bam1_t *b, const char *ref, int ref_len, int thres)
     if (t > thres) return -1;
     if (t < 0) t = 0;
     t = sqrt((thres - t) / thres) * thres;
-//  fprintf(stderr, "%s %lf %d\n", bam_get_qname(b), t, q);
+    //fprintf(stderr, "%s %lf %d\n", bam_get_qname(b), t, q);
     return (int)(t + .499);
 }
 

--- a/sam.c
+++ b/sam.c
@@ -1852,7 +1852,7 @@ static inline int resolve_cigar2(bam_pileup1_t *p, int32_t pos, cstate_t *s)
     uint32_t *cigar = bam_get_cigar(b);
     int k;
     // determine the current CIGAR operation
-//  fprintf(stderr, "%s\tpos=%d\tend=%d\t(%d,%d,%d)\n", bam_get_qname(b), pos, s->end, s->k, s->x, s->y);
+    //fprintf(stderr, "%s\tpos=%d\tend=%d\t(%d,%d,%d)\n", bam_get_qname(b), pos, s->end, s->k, s->x, s->y);
     if (s->k == -1) { // never processed
         if (c->n_cigar == 1) { // just one operation, save a loop
           if (_cop(cigar[0]) == BAM_CMATCH || _cop(cigar[0]) == BAM_CEQUAL || _cop(cigar[0]) == BAM_CDIFF) s->k = 0, s->x = c->pos, s->y = 0;


### PR DESCRIPTION
Replaced fprintf(stderr, ...) calls with hts_log_... calls in the CRAM code. This pull request is part of a series that aims to solve #403 .

Most of the changes are search-and-replace, but there is one change that I'd like to bring up for discussion: I've removed the CRAM-specific verbosity flag. No use with a separate flag for that part of the code, right? And it's not part of the public API. (In case there are actually good reasons to keep it, those changes are isolated in a separate commit and so can be easily reversed.)

I've also put #ifdefs around debugging functions in a few cases. The reason is that I don't think the implementations should be there when the invocations are commented out. After the change, both the implementation and invocation are enabled or disabled by a single define.