### PR TITLE
Fix bcf_translate to skip deleted INFO and FORMAT fields to avoid segfaults

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -2929,11 +2929,12 @@ int bcf_translate(const bcf_hdr_t *dst_hdr, bcf_hdr_t *src_hdr, bcf1_t *line)
         int src_id = line->d.info[i].key;
         int dst_id = src_hdr->transl[BCF_DT_ID][src_id];
         if ( dst_id<0 ) continue;
+        line->d.info[i].key = dst_id;
+        if ( !line->d.info[i].vptr ) continue;  // skip deleted
         int src_size = src_id>>7 ? ( src_id>>15 ? BCF_BT_INT32 : BCF_BT_INT16) : BCF_BT_INT8;
         int dst_size = dst_id>>7 ? ( dst_id>>15 ? BCF_BT_INT32 : BCF_BT_INT16) : BCF_BT_INT8;
         if ( src_size==dst_size )   // can overwrite
         {
-            line->d.info[i].key = dst_id;
             uint8_t *vptr = line->d.info[i].vptr - line->d.info[i].vptr_off;
             if ( dst_size==BCF_BT_INT8 ) { vptr[1] = (uint8_t)dst_id; }
             else if ( dst_size==BCF_BT_INT16 ) { *(uint16_t*)vptr = (uint16_t)dst_id; }
@@ -2950,7 +2951,6 @@ int bcf_translate(const bcf_hdr_t *dst_hdr, bcf_hdr_t *src_hdr, bcf1_t *line)
             kputsn((char*)info->vptr, info->vptr_len, &str);
             info->vptr = (uint8_t*)str.s + info->vptr_off;
             info->vptr_free = 1;
-            info->key = dst_id;
             line->d.shared_dirty |= BCF1_DIRTY_INF;
         }
     }

--- a/vcf.c
+++ b/vcf.c
@@ -2961,11 +2961,12 @@ int bcf_translate(const bcf_hdr_t *dst_hdr, bcf_hdr_t *src_hdr, bcf1_t *line)
         int src_id = line->d.fmt[i].id;
         int dst_id = src_hdr->transl[BCF_DT_ID][src_id];
         if ( dst_id<0 ) continue;
+        line->d.fmt[i].id = dst_id;
+        if( !line->d.fmt[i].p ) continue;  // skip deleted
         int src_size = src_id>>7 ? ( src_id>>15 ? BCF_BT_INT32 : BCF_BT_INT16) : BCF_BT_INT8;
         int dst_size = dst_id>>7 ? ( dst_id>>15 ? BCF_BT_INT32 : BCF_BT_INT16) : BCF_BT_INT8;
         if ( src_size==dst_size )   // can overwrite
         {
-            line->d.fmt[i].id = dst_id;
             uint8_t *p = line->d.fmt[i].p - line->d.fmt[i].p_off;    // pointer to the vector size (4bits) and BT type (4bits)
             if ( dst_size==BCF_BT_INT8 ) { p[1] = dst_id; }
             else if ( dst_size==BCF_BT_INT16 ) { uint8_t *x = (uint8_t*) &dst_id; p[1] = x[0]; p[2] = x[1]; }
@@ -2982,7 +2983,6 @@ int bcf_translate(const bcf_hdr_t *dst_hdr, bcf_hdr_t *src_hdr, bcf1_t *line)
             kputsn((char*)fmt->p, fmt->p_len, &str);
             fmt->p = (uint8_t*)str.s + fmt->p_off;
             fmt->p_free = 1;
-            fmt->id = dst_id;
             line->d.indiv_dirty = 1;
         }
     }

--- a/vcf.c
+++ b/vcf.c
@@ -2943,12 +2943,13 @@ int bcf_translate(const bcf_hdr_t *dst_hdr, bcf_hdr_t *src_hdr, bcf1_t *line)
         else    // must realloc
         {
             bcf_info_t *info = &line->d.info[i];
-            assert( !info->vptr_free );
             kstring_t str = {0,0,0};
             bcf_enc_int1(&str, dst_id);
             bcf_enc_size(&str, info->len,info->type);
-            info->vptr_off = str.l;
+            uint32_t vptr_off = str.l;
             kputsn((char*)info->vptr, info->vptr_len, &str);
+            if( info->vptr_free ) free(info->vptr - info->vptr_off);
+            info->vptr_off = vptr_off;
             info->vptr = (uint8_t*)str.s + info->vptr_off;
             info->vptr_free = 1;
             line->d.shared_dirty |= BCF1_DIRTY_INF;
@@ -2975,12 +2976,13 @@ int bcf_translate(const bcf_hdr_t *dst_hdr, bcf_hdr_t *src_hdr, bcf1_t *line)
         else    // must realloc
         {
             bcf_fmt_t *fmt = &line->d.fmt[i];
-            assert( !fmt->p_free );
             kstring_t str = {0,0,0};
             bcf_enc_int1(&str, dst_id);
             bcf_enc_size(&str, fmt->n, fmt->type);
-            fmt->p_off = str.l;
+            uint32_t p_off = str.l;
             kputsn((char*)fmt->p, fmt->p_len, &str);
+            if( fmt->p_free ) free(fmt->p - fmt->p_off);
+            fmt->p_off = p_off;
             fmt->p = (uint8_t*)str.s + fmt->p_off;
             fmt->p_free = 1;
             line->d.indiv_dirty = 1;


### PR DESCRIPTION
## Background

`bcf_translate` works correctly on newly created or loaded BCF records, but it does not properly account for records which have been modified by having one or more INFO or FORMAT fields deleted.  This bug has resulted in segmentation faults in real usage.

## Nature of fix

Prior to attempt to update the info value (either in place or after resizing), update the entry's key id (to keep all ids valid) and then check whether `line->d.info[i].vptr` is `NULL`.   This indicates that the key and value have been deleted.  Otherwise, `vptr` is incorrectly assumed to point to a valid value and a segmentation fault results.

The same basic flaw appears to be possible for deleted FORMAT values when `line->d.fmt[i].p` is `NULL` and a similar fix was applied.

The resize cases were also unable to handle when when `p_free` is set.  This was also corrected.

## Other issues not addressed in this PR

`bcf_translate` uses a data structure stored within the source BCF header data structure.  This is a poor design decision, because it presumes that any header will be used to translate to no more than one destination header.  Worse, there is no check to verify that the same destination header is used or that the source and destination have not changed since the translation table was initialized.  Both requirements are unchecked and can cause crashes or write corrupted data.  There is no good reason that the translation data structure is part of the header, except that it would require breaking ABI compatibility.  This suggests adding a `bcf_translate2` function that takes an explicit translation table as a parameter with clear documentation on the assumptions and lifetime of the translation struct.