### PR TITLE
Fix for #565, failing tests on i386

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -877,23 +877,20 @@ extern uint32_t bcf_float_vector_end;
 extern uint32_t bcf_float_missing;
 static inline void bcf_float_set(float *ptr, uint32_t value)
 {
-    union { uint32_t i; float f; } u;
-    u.i = value;
-    *ptr = u.f;
+    uint32_t *pf = (uint32_t*)ptr;
+    *pf = value;
 }
 #define bcf_float_set_vector_end(x) bcf_float_set(&(x),bcf_float_vector_end)
 #define bcf_float_set_missing(x)    bcf_float_set(&(x),bcf_float_missing)
 static inline int bcf_float_is_missing(float f)
 {
-    union { uint32_t i; float f; } u;
-    u.f = f;
-    return u.i==bcf_float_missing ? 1 : 0;
+    uint32_t *pf = (uint32_t*)&f;
+    return *pf==bcf_float_missing ? 1 : 0;
 }
 static inline int bcf_float_is_vector_end(float f)
 {
-    union { uint32_t i; float f; } u;
-    u.f = f;
-    return u.i==bcf_float_vector_end ? 1 : 0;
+    uint32_t *pf = (uint32_t*)&f;
+    return *pf==bcf_float_vector_end ? 1 : 0;
 }
 
 static inline void bcf_format_gt(bcf_fmt_t *fmt, int isample, kstring_t *str)

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -882,15 +882,12 @@ static inline void bcf_float_set(float *ptr, uint32_t value)
 }
 #define bcf_float_set_vector_end(x) bcf_float_set(&(x),bcf_float_vector_end)
 #define bcf_float_set_missing(x)    bcf_float_set(&(x),bcf_float_missing)
-static inline int bcf_float_is_missing(float f)
+#define bcf_float_is_vector_end(x) bcf_float_equals(&(x),bcf_float_vector_end)
+#define bcf_float_is_missing(x)    bcf_float_equals(&(x),bcf_float_missing)
+static inline int bcf_float_equals(const float *ptr, uint32_t value)
 {
-    uint32_t *pf = (uint32_t*)&f;
-    return *pf==bcf_float_missing ? 1 : 0;
-}
-static inline int bcf_float_is_vector_end(float f)
-{
-    uint32_t *pf = (uint32_t*)&f;
-    return *pf==bcf_float_vector_end ? 1 : 0;
+    uint32_t *pf = (uint32_t*)ptr;
+    return *pf==value ? 1 : 0;
 }
 
 static inline void bcf_format_gt(bcf_fmt_t *fmt, int isample, kstring_t *str)

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -330,6 +330,7 @@ void write_format_values(const char *fname)
     bcf_float_set_missing(test[0]);
     test[1] = 47.11f;
     bcf_float_set_vector_end(test[2]);
+    bcf_float_set_vector_end(test[3]);
     bcf_update_format_float(hdr, rec, "TF", test, 4);
     bcf_write1(fp, hdr, rec);
 


### PR DESCRIPTION
Fixes #565 by keeping the special NaN values used to indicate missing values and end-of-vector as integers instead of converting them to floats. The change is similar to #485 but in a different part of the code base.

After this change, the int/float union mechanism for type punning remains only in the le_to_float/float_to_le pair. I'm not sure if those functions are ever exposed to the special NaN values, but if they are, then I expect them to have the same problem, too.