### PR TITLE
Fixed improper dynamic library dependencies in s3 plugin

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -77,7 +77,7 @@ plugin_OBJS += hfile_s3.o
 
 CRYPTO_LIBS = @CRYPTO_LIBS@
 noplugin_LIBS += $(CRYPTO_LIBS)
-hfile_s3$(PLUGIN_EXT): LIBS += $(CRYPTO_LIBS)
+hfile_s3$(PLUGIN_EXT): LIBS += $(LIBCURL_LIBS)
 endif
 
 ifeq "plugins-@enable_plugins@" "plugins-yes"


### PR DESCRIPTION
Fixes issue [263](https://github.com/pysam-developers/pysam/issues/263) on pysam. s3 plugin was not properly linked to libhts.so and didn't have all the require files when used by pysam. Current work around that fixed the issue was to change the dependencies of the s3 plugin to be exactly like the libcurl plugin which links hfile_s3.so to libhts.so. 