### PR TITLE
Add return value documentation to sam_read1()

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -379,6 +379,10 @@ int sam_index_build3(const char *fn, const char *fnidx, int min_shift, int nthre
 
     int sam_parse1(kstring_t *s, bam_hdr_t *h, bam1_t *b) HTS_RESULT_USED;
     int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str) HTS_RESULT_USED;
+
+    /*!
+     *  @return >= 0 on successfully reading a new record, -1 on end of stream, < -1 on error
+     **/
     int sam_read1(samFile *fp, bam_hdr_t *h, bam1_t *b) HTS_RESULT_USED;
     int sam_write1(samFile *fp, const bam_hdr_t *h, const bam1_t *b) HTS_RESULT_USED;
 


### PR DESCRIPTION
For `sam_read1`, it appears that a return value of -1 indicates a non-erroneous end-of-file/stream, and other negative values indicate various errors, but there are no docs on this return value in `htslib/sam.h`.

If this function is part of the stable api, could this interface be documented? I submitted the following line as a minimum starting point.