### PR TITLE
Added BGZF CRC32 checking.  Fixes #402.

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -39,6 +39,7 @@
 #include "htslib/bgzf.h"
 #include "htslib/hfile.h"
 #include "htslib/thread_pool.h"
+#include "htslib/hts_endian.h"
 #include "cram/pooled_alloc.h"
 
 #define BGZF_CACHE
@@ -460,6 +461,16 @@ static int inflate_block(BGZF* fp, int block_length)
                               (Bytef*)fp->compressed_block + 18, block_length - 18);
     if (ret < 0) {
         fp->errcode |= BGZF_ERR_ZLIB;
+        return -1;
+    }
+
+    // Check CRC of uncompressed block matches the gzip header.
+    // NB: we may wish to switch out the zlib crc32 for something more performant.
+    // See PR#361 and issue#467
+    uint32_t c1 = crc32(0L, (unsigned char *)fp->uncompressed_block, dlen);
+    uint32_t c2 = le_to_u32((uint8_t *)fp->compressed_block + block_length-8);
+    if (c1 != c2) {
+        fp->errcode |= BGZF_ERR_CRC;
         return -1;
     }
 

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -49,6 +49,7 @@ extern "C" {
 #define BGZF_ERR_IO     4
 #define BGZF_ERR_MISUSE 8
 #define BGZF_ERR_MT     16 // stream cannot be multi-threaded
+#define BGZF_ERR_CRC    32
 
 struct hFILE;
 struct hts_tpool;


### PR DESCRIPTION
Note this normally is an insignificant overhead, but if decoding
uncompressed BAMs it becomes dominant.  Eg perf on samtools flagstat
shows:

 70.47%  samtools.tmp  libz.so.1.2.8       [.] crc32
  8.91%  samtools.tmp  [kernel.kallsyms]   [k] 0xffffffff8104f45a
  8.40%  samtools.tmp  libc-2.19.so        [.] __memcpy_sse2_unaligned
  4.80%  samtools.tmp  samtools.tmp        [.] bgzf_read
  3.95%  samtools.tmp  samtools.tmp        [.] bam_read1

One solution is either to have an option to not check (I don't like
this), or to replace the default zlib crc algorithm with a much more
performant alternative.  See #467 for discussion.  Libdeflate's SSE
crc is around 11x faster, meaning this overhead would be around 20%
instead.

Perhaps it's time we had a build option linking against libdeflate
anyway as it's almost certainly better for all of the work instead of
just this bit.
https://encode.ru/threads/2482-libdeflate-a-new-optimized-DEFLATE-implementation