### PR TITLE
Update multipart to work with revised htsget specification

### DIFF
--- a/hts_internal.h
+++ b/hts_internal.h
@@ -159,7 +159,7 @@ typedef struct hts_cram_idx_t {
 
 
 // Entry point to hFILE_multipart backend.
-struct hFILE *hopen_json_redirect(struct hFILE *hfile, const char *mode);
+struct hFILE *hopen_htsget_redirect(struct hFILE *hfile, const char *mode);
 
 
 struct hts_path_itr {

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -138,7 +138,8 @@ enum htsExactFormat {
     unknown_format,
     binary_format, text_format,
     sam, bam, bai, cram, crai, vcf, bcf, csi, gzi, tbi, bed,
-    json,
+    htsget,
+    json HTS_DEPRECATED_ENUM("Use htsExactFormat 'htsget' instead") = htsget,
     format_maximum = 32767
 };
 

--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -69,6 +69,12 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_DEPRECATED(message)
 #endif
 
+#if HTS_COMPILER_HAS(__deprecated__) || HTS_GCC_AT_LEAST(6,4)
+#define HTS_DEPRECATED_ENUM(message) __attribute__ ((__deprecated__ (message)))
+#else
+#define HTS_DEPRECATED_ENUM(message)
+#endif
+
 // On mingw the "printf" format type doesn't work.  It needs "gnu_printf"
 // in order to check %lld and %z, otherwise it defaults to checking against
 // the Microsoft library printf format options despite linking against the

--- a/multipart.c
+++ b/multipart.c
@@ -144,8 +144,8 @@ static const struct hFILE_backend multipart_backend =
 // not the type expected for a particular GA4GH field, or it may be '?' or
 // '\0' which should be propagated.
 static char
-parse_ga4gh_redirect_json(hFILE_multipart *fp, hFILE *json,
-                          kstring_t *b, kstring_t *header)
+parse_ga4gh_body_json(hFILE_multipart *fp, hFILE *json,
+                      kstring_t *b, kstring_t *header)
 {
     hts_json_token t;
 
@@ -205,12 +205,37 @@ parse_ga4gh_redirect_json(hFILE_multipart *fp, hFILE *json,
         else if (hts_json_fskip_value(json, '\0') != 'v') return '?';
     }
 
+    return 'v';
+}
+
+// Returns 'v' (valid value), 'i' (invalid; required GA4GH field missing),
+// or upon encountering an unexpected token, that token's type.
+// Explicit `return '?'` means a JSON parsing error, typically a member key
+// that is not a string.  An unexpected token may be a valid token that was
+// not the type expected for a particular GA4GH field, or it may be '?' or
+// '\0' which should be propagated.
+static char
+parse_ga4gh_redirect_json(hFILE_multipart *fp, hFILE *json,
+                          kstring_t *b, kstring_t *header) {
+    hts_json_token t;
+
+    if (hts_json_fnext(json, &t, b) != '{') return t.type;
+    while (hts_json_fnext(json, &t, b) != '}') {
+        if (t.type != 's') return '?';
+
+        if (strcmp(t.str, "htsget") == 0) {
+            char ret = parse_ga4gh_body_json(fp, json, b, header);
+            if (ret != 'v') return ret;
+        }
+        else return '?';
+    }
+
     if (hts_json_fnext(json, &t, b) != '\0') return '?';
 
     return 'v';
 }
 
-hFILE *hopen_json_redirect(hFILE *hfile, const char *mode)
+hFILE *hopen_htsget_redirect(hFILE *hfile, const char *mode)
 {
     hFILE_multipart *fp;
     kstring_t s1 = { 0, 0, NULL }, s2 = { 0, 0, NULL };


### PR DESCRIPTION
PR samtools/hts-specs#230 updates the htsget specification so that all htsget JSON starts with a protocol identifier.  This is implemented by wrapping the payload inside a JSON object with the single key "htsget".  Update multipart.c and hts_detect_format() in hts.c to understand the revised format.

As the protocol now has an official name, change some mentions of 'json' to 'htsget'.  One of these is in the htsExactFormat enumerated type, which is in htslib/hts.h.  This is left in place for API compatibility, but marked as deprecated (if using a compiler that supports this).