### PR TITLE
Make hts_test_and_fetch check for fwrite() errors

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -2254,14 +2254,17 @@ int hts_itr_next(BGZF *fp, hts_itr_t *iter, void *r, void *data)
 /**********************
  *** Retrieve index ***
  **********************/
-
-static char *test_and_fetch(const char *fn)
+// Returns -1 if index couldn't be opened.
+//         -2 on other errors
+static int test_and_fetch(const char *fn, const char **local_fn)
 {
+    hFILE *fp_remote;
+    FILE *fp = NULL;
+    uint8_t *buf = NULL;
+    int save_errno;
+
     if (hisremote(fn)) {
         const int buf_size = 1 * 1024 * 1024;
-        hFILE *fp_remote;
-        FILE *fp;
-        uint8_t *buf;
         int l;
         const char *p;
         for (p = fn + strlen(fn) - 1; p >= fn; --p)
@@ -2271,51 +2274,81 @@ static char *test_and_fetch(const char *fn)
         if ((fp = fopen((char*)p, "rb")) != 0)
         {
             fclose(fp);
-            return (char*)p;
+            *local_fn = p;
+            return 0;
         }
         // Attempt to open remote file. Stay quiet on failure, it is OK to fail when trying first .csi then .tbi index.
-        if ((fp_remote = hopen(fn, "r")) == 0) return 0;
+        if ((fp_remote = hopen(fn, "r")) == 0) return -1;
         if ((fp = fopen(p, "w")) == 0) {
             hts_log_error("Failed to create file %s in the working directory", p);
-            hclose_abruptly(fp_remote);
-            return 0;
+            goto fail;
         }
         hts_log_info("Downloading file %s to local directory", fn);
         buf = (uint8_t*)calloc(buf_size, 1);
-        while ((l = hread(fp_remote, buf, buf_size)) > 0) fwrite(buf, 1, l, fp);
+        if (!buf) {
+            hts_log_error("%s", strerror(errno));
+            goto fail;
+        }
+        while ((l = hread(fp_remote, buf, buf_size)) > 0) {
+            if (fwrite(buf, 1, l, fp) != l) {
+                hts_log_error("Failed to write data to %s : %s",
+                              fn, strerror(errno));
+                goto fail;
+            }
+        }
         free(buf);
-        fclose(fp);
+        if (fclose(fp) < 0) {
+            hts_log_error("Error closing %s : %s", fn, strerror(errno));
+            fp = NULL;
+            goto fail;
+        }
         if (hclose(fp_remote) != 0) {
             hts_log_error("Failed to close remote file %s", fn);
         }
-        return (char*)p;
+        *local_fn = p;
+        return 0;
     } else {
         hFILE *fp;
-        if ((fp = hopen(fn, "r")) == 0) return 0;
+        if ((fp = hopen(fn, "r")) == 0) return -1;
         hclose_abruptly(fp);
-        return (char*)fn;
+        *local_fn = fn;
+        return 0;
     }
+
+ fail:
+    save_errno = errno;
+    hclose_abruptly(fp_remote);
+    if (fp) fclose(fp);
+    free(buf);
+    errno = save_errno;
+    return -2;
 }
 
 char *hts_idx_getfn(const char *fn, const char *ext)
 {
-    int i, l_fn, l_ext;
-    char *fnidx, *ret;
+    int i, l_fn, l_ext, ret;
+    char *fnidx;
+    const char *local_fn = NULL;
     l_fn = strlen(fn); l_ext = strlen(ext);
     fnidx = (char*)calloc(l_fn + l_ext + 1, 1);
+    if (!fnidx) return NULL;
+    // First try : append `ext` to `fn`
     strcpy(fnidx, fn); strcpy(fnidx + l_fn, ext);
-    if ((ret = test_and_fetch(fnidx)) == 0) {
+    if ((ret = test_and_fetch(fnidx, &local_fn)) == -1) {
+        // Second try : replace suffix of `fn` with `ext`
         for (i = l_fn - 1; i > 0; --i)
-            if (fnidx[i] == '.') break;
-        strcpy(fnidx + i, ext);
-        ret = test_and_fetch(fnidx);
+            if (fnidx[i] == '.' || fnidx[i] == '/') break;
+        if (fnidx[i] == '.') {
+            strcpy(fnidx + i, ext);
+            ret = test_and_fetch(fnidx, &local_fn);
+        }
     }
-    if (ret == 0) {
+    if (ret < 0) {
         free(fnidx);
-        return 0;
+        return NULL;
     }
-    l_fn = strlen(ret);
-    memmove(fnidx, ret, l_fn + 1);
+    l_fn = strlen(local_fn);
+    memmove(fnidx, local_fn, l_fn + 1);
     return fnidx;
 }
 


### PR DESCRIPTION
Plus a few other changes to make it and hts_idx_getfn() work a bit more sensibly.  For example, the latter will now notice if the input file name doesn't have a '.' in it when trying to remove the suffix.

Fixes issue #580