### PR TITLE
Allow overriding the cURL CA bundle path

### DIFF
--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -711,6 +711,7 @@ libcurl_open(const char *url, const char *modes, http_headers *headers)
 
     err |= curl_easy_setopt(fp->easy, CURLOPT_SHARE, curl.share);
     err |= curl_easy_setopt(fp->easy, CURLOPT_URL, url);
+    err |= curl_easy_setopt(fp->easy, CURLOPT_CAINFO, getenv("CURL_CA_BUNDLE"));
     err |= curl_easy_setopt(fp->easy, CURLOPT_USERAGENT, curl.useragent.s);
     if (fp->headers.callback) {
         if (add_callback_headers(fp) != 0) goto error;


### PR DESCRIPTION
Allow overriding the cURL CA bundle via the CURL_CA_BUNDLE environment
variable. This allows users to specify a new CA root certificate to use
when communicating with a host (such as an htsget server using a
self-signed certificate).