### PR TITLE
Add Bearer token support to hfile_libcurl (for htsget)

### DIFF
--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -365,6 +365,12 @@ static int add_callback_headers(hFILE_libcurl *fp) {
     return -1;
 }
 
+/*
+ * Read an OAUTH2-style Bearer access token (see
+ * https://tools.ietf.org/html/rfc6750#section-4).
+ * Returns 'v' for valid; 'i' for invalid (token missing or wrong sort);
+ * '?' for a JSON parse error; 'm' if it runs out of memory.
+ */
 static int read_auth_json(auth_token *tok, hFILE *auth_fp) {
     hts_json_token t;
     kstring_t str = {0, 0, NULL};

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -1103,8 +1103,6 @@ error:
     return NULL;
 
 early_error:
-    save = errno;
-    errno = save;
     return NULL;
 }
 

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -45,6 +45,10 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <curl/curl.h>
 
+// Number of seconds to take off auth_token expiry, to allow for clock skew
+// and slow servers
+#define AUTH_REFRESH_EARLY_SECS 60
+
 typedef struct {
     char *path;
     char *token;
@@ -464,7 +468,7 @@ static int renew_auth_token(auth_token *tok, int *changed) {
     ssize_t len;
 
     *changed = 0;
-    if (tok->expiry == 0 || time(NULL) < tok->expiry)
+    if (tok->expiry == 0 || time(NULL) + AUTH_REFRESH_EARLY_SECS < tok->expiry)
         return 0; // Still valid
 
     if (tok->failed)

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -758,7 +758,6 @@ error:
     save = errno;
     if (fp->easy) curl_easy_cleanup(fp->easy);
     if (fp->multi) curl_multi_cleanup(fp->multi);
-    free_headers(&fp->headers.fixed, 1);
     free_headers(&fp->headers.extra, 1);
     hfile_destroy((hFILE *) fp);
     errno = save;

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -540,7 +540,7 @@ static int add_auth_header(hFILE_libcurl *fp) {
                 fp->headers.fixed.list[fp->headers.fixed.num - 1].next = NULL;
             }
         }
-    } else {
+    } else if (fp->headers.auth->token) {
         // Add new header and remember where it is
         if (append_header(&fp->headers.extra,
                           fp->headers.auth->token, 1) < 0) {

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -32,15 +32,29 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef _WIN32
 # include <sys/select.h>
 #endif
+#include <assert.h>
 
+#include "hts_internal.h"
 #include "hfile_internal.h"
 #ifdef ENABLE_PLUGINS
 #include "version.h"
 #endif
 #include "htslib/hts.h"  // for hts_version() and hts_verbose
 #include "htslib/kstring.h"
+#include "htslib/khash.h"
 
 #include <curl/curl.h>
+
+typedef struct {
+    char *path;
+    char *token;
+    time_t expiry;
+    int failed;
+    pthread_mutex_t lock;
+} auth_token;
+
+// For the authorization header cache
+KHASH_MAP_INIT_STR(auth_map, auth_token *);
 
 // Curl-compatible header linked list
 typedef struct {
@@ -54,6 +68,8 @@ typedef struct {
     hdrlist extra;                   // List of headers from callback
     hts_httphdr_callback callback;   // Callback to get more headers
     void *callback_data;             // Data to pass to callback
+    auth_token *auth;                // Authentication token
+    int auth_hdr_num;                // Authorization header list position + 1
 } http_headers;
 
 typedef struct {
@@ -73,6 +89,7 @@ typedef struct {
     unsigned perform_again : 1;
     unsigned is_read : 1;   // Opened in read mode
     unsigned can_seek : 1;  // Can (attempt to) seek on this handle
+    unsigned is_recursive:1; // Opened by hfile_libcurl itself
     int nrunning;
     http_headers headers;
 } hFILE_libcurl;
@@ -198,22 +215,33 @@ static int multi_errno(CURLMcode errm)
     }
 }
 
-
 static struct {
     kstring_t useragent;
     CURLSH *share;
-    pthread_mutex_t lock;
-} curl = { { 0, 0, NULL }, NULL, PTHREAD_MUTEX_INITIALIZER };
+    char *auth_path;
+    khash_t(auth_map) *auth_map;
+    int allow_unencrypted_auth_header;
+    pthread_mutex_t auth_lock;
+    pthread_mutex_t share_lock;
+} curl = { { 0, 0, NULL }, NULL, NULL, NULL, 0, PTHREAD_MUTEX_INITIALIZER,
+           PTHREAD_MUTEX_INITIALIZER };
 
 static void share_lock(CURL *handle, curl_lock_data data,
                        curl_lock_access access, void *userptr) {
-    pthread_mutex_lock(&curl.lock);
+    pthread_mutex_lock(&curl.share_lock);
 }
 
 static void share_unlock(CURL *handle, curl_lock_data data, void *userptr) {
-    pthread_mutex_unlock(&curl.lock);
+    pthread_mutex_unlock(&curl.share_lock);
 }
 
+static void free_auth(auth_token *tok) {
+    if (!tok) return;
+    if (pthread_mutex_destroy(&tok->lock)) abort();
+    free(tok->path);
+    free(tok->token);
+    free(tok);
+}
 
 static void libcurl_exit()
 {
@@ -222,6 +250,21 @@ static void libcurl_exit()
 
     free(curl.useragent.s);
     curl.useragent.l = curl.useragent.m = 0; curl.useragent.s = NULL;
+
+    free(curl.auth_path);
+    curl.auth_path = NULL;
+
+    if (curl.auth_map) {
+        khiter_t i;
+        for (i = kh_begin(curl.auth_map); i != kh_end(curl.auth_map); ++i) {
+            if (kh_exist(curl.auth_map, i)) {
+                free_auth(kh_value(curl.auth_map, i));
+                kh_value(curl.auth_map, i) = NULL;
+            }
+        }
+        kh_destroy(auth_map, curl.auth_map);
+        curl.auth_map = NULL;
+    }
 
     curl_global_cleanup();
 }
@@ -268,6 +311,10 @@ static struct curl_slist * get_header_list(hFILE_libcurl *fp) {
     return 0;
 }
 
+static inline int is_authorization(const char *hdr) {
+    return (strncasecmp("authorization:", hdr, 14) == 0);
+}
+
 static int add_callback_headers(hFILE_libcurl *fp) {
     char **hdrs = NULL, **hdr;
 
@@ -289,11 +336,17 @@ static int add_callback_headers(hFILE_libcurl *fp) {
     }
     free_headers(&fp->headers.extra, 0);
 
+    if (fp->headers.auth_hdr_num < 0
+        || fp->headers.auth_hdr_num > fp->headers.fixed.num)
+        fp->headers.auth_hdr_num = 0; // Just removed it...
+
     // Convert to libcurl-suitable form
     for (hdr = hdrs; *hdr; hdr++) {
         if (append_header(&fp->headers.extra, *hdr, 0) < 0) {
             goto cleanup;
         }
+        if (is_authorization(*hdr))
+            fp->headers.auth_hdr_num = fp->headers.fixed.num + fp->headers.extra.num;
     }
     for (hdr = hdrs; *hdr; hdr++) *hdr = NULL;
 
@@ -309,6 +362,265 @@ static int add_callback_headers(hFILE_libcurl *fp) {
         free(*hdr);
         *hdr = NULL;
     }
+    return -1;
+}
+
+static int read_auth_json(auth_token *tok, hFILE *auth_fp) {
+    hts_json_token t;
+    kstring_t str = {0, 0, NULL};
+    char *token = NULL, *type = NULL, *expiry = NULL;
+    int ret = 'i';
+
+    if ((ret = hts_json_fnext(auth_fp, &t, &str)) != '{') goto error;
+    while (hts_json_fnext(auth_fp, &t, &str) != '}') {
+        if (t.type != 's') {
+            ret = '?';
+            goto error;
+        }
+        if (strcmp(t.str, "access_token") == 0) {
+            if ((ret = hts_json_fnext(auth_fp, &t, &str)) != 's') goto error;
+            token = ks_release(&str);
+        } else if (strcmp(t.str, "token_type") == 0) {
+            if ((ret = hts_json_fnext(auth_fp, &t, &str)) != 's') goto error;
+            type = ks_release(&str);
+        } else if (strcmp(t.str, "expires_in") == 0) {
+            if ((ret = hts_json_fnext(auth_fp, &t, &str)) != 'n') goto error;
+            expiry = ks_release(&str);
+        } else if (hts_json_fskip_value(auth_fp, '\0') != 'v') {
+            ret = '?';
+            goto error;
+        }
+    }
+
+    if (!token || (type && strcmp(type, "Bearer") != 0)) {
+        ret = 'i';
+        goto error;
+    }
+
+    ret = 'm';
+    str.l = 0;
+    if (kputs("Authorization: Bearer ", &str) < 0) goto error;
+    if (kputs(token, &str) < 0) goto error;
+    free(tok->token);
+    tok->token = ks_release(&str);
+    if (expiry) {
+        long exp = strtol(expiry, NULL, 10);
+        if (exp < 0) exp = 0;
+        tok->expiry = time(NULL) + exp;
+    } else {
+        tok->expiry = 0;
+    }
+    ret = 'v';
+
+ error:
+    free(token);
+    free(type);
+    free(expiry);
+    free(str.s);
+    return ret;
+}
+
+static int read_auth_plain(auth_token *tok, hFILE *auth_fp) {
+    kstring_t line = {0, 0, NULL};
+    kstring_t token = {0, 0, NULL};
+    const char *start, *end;
+
+    if (kgetline(&line, (char * (*)(char *, int, void *)) hgets, auth_fp) < 0) goto error;
+    if (kputc('\0', &line) < 0) goto error;
+
+    for (start = line.s; *start && isspace(*start); start++) {}
+    for (end = start; *end && !isspace(*end); end++) {}
+
+    if (end > start) {
+        if (kputs("Authorization: Bearer ", &token) < 0) goto error;
+        if (kputsn(start, end - start, &token) < 0) goto error;
+    }
+
+    free(tok->token);
+    tok->token = ks_release(&token);
+    tok->expiry = 0;
+    free(line.s);
+    return 0;
+
+ error:
+    free(line.s);
+    free(token.s);
+    return -1;
+}
+
+static int renew_auth_token(auth_token *tok, int *changed) {
+    hFILE *auth_fp = NULL;
+    char buffer[16];
+    ssize_t len;
+
+    *changed = 0;
+    if (tok->expiry == 0 || time(NULL) < tok->expiry)
+        return 0; // Still valid
+
+    if (tok->failed)
+        return -1;
+
+    *changed = 1;
+    auth_fp = hopen(tok->path, "rR");
+    if (!auth_fp) {
+        // Not worried about missing files; other errors are bad.
+        if (errno != ENOENT)
+            goto fail;
+
+        tok->expiry = 0; // Prevent retry
+        free(tok->token); // Just in case it was set
+        return 0;
+    }
+
+    len = hpeek(auth_fp, buffer, sizeof(buffer));
+    if (len < 0)
+        goto fail;
+
+    if (memchr(buffer, '{', len) != NULL) {
+        if (read_auth_json(tok, auth_fp) != 'v')
+            goto fail;
+    } else {
+        if (read_auth_plain(tok, auth_fp) < 0)
+            goto fail;
+    }
+
+    return hclose(auth_fp) < 0 ? -1 : 0;
+
+ fail:
+    tok->failed = 1;
+    if (auth_fp) hclose_abruptly(auth_fp);
+    return -1;
+}
+
+static int add_auth_header(hFILE_libcurl *fp) {
+    int changed = 0;
+
+    if (fp->headers.auth_hdr_num > 0)
+        return 0; // Have an Authorization header from open or header callback
+
+    if (!fp->headers.auth)
+        return 0; // Nothing to add
+
+    pthread_mutex_lock(&fp->headers.auth->lock);
+    if (renew_auth_token(fp->headers.auth, &changed) < 0)
+        goto unlock_fail;
+
+    if (!changed) {
+        pthread_mutex_unlock(&fp->headers.auth->lock);
+        return 0;
+    }
+
+    if (fp->headers.auth_hdr_num < 0) {
+        // Had a previous header, so swap in the new one
+        char *header = fp->headers.auth->token;
+        char *header_copy = header ? strdup(header) : NULL;
+        int idx = -fp->headers.auth_hdr_num - 1;
+        if (header && !header_copy)
+            goto unlock_fail;
+        assert(idx >= fp->headers.fixed.num);
+        idx -= fp->headers.fixed.num;
+        assert(idx < fp->headers.extra.num);
+
+        if (header_copy) {
+            free(fp->headers.extra.list[idx].data);
+            fp->headers.extra.list[idx].data = header_copy;
+        } else {
+            unsigned int j;
+            // More complicated case - need to get rid of the old header
+            // and tidy up linked lists
+            free(fp->headers.extra.list[idx].data);
+            for (j = idx + 1; j < fp->headers.extra.num; j++) {
+                fp->headers.extra.list[j - 1] = fp->headers.extra.list[j];
+                fp->headers.extra.list[j - 1].next = &fp->headers.extra.list[j];
+            }
+            fp->headers.extra.num--;
+            if (fp->headers.extra.num > 0) {
+                fp->headers.extra.list[fp->headers.extra.num-1].next = NULL;
+            } else if (fp->headers.fixed.num > 0) {
+                fp->headers.fixed.list[fp->headers.fixed.num - 1].next = NULL;
+            }
+        }
+    } else {
+        // Add new header and remember where it is
+        if (append_header(&fp->headers.extra,
+                          fp->headers.auth->token, 1) < 0) {
+            goto unlock_fail;
+        }
+        fp->headers.auth_hdr_num = -(fp->headers.fixed.num + fp->headers.extra.num);
+    }
+
+    pthread_mutex_unlock(&fp->headers.auth->lock);
+    return 0;
+
+ unlock_fail:
+    pthread_mutex_unlock(&fp->headers.auth->lock);
+    return -1;
+}
+
+static int get_auth_token(hFILE_libcurl *fp, const char *url) {
+    const char *host = NULL, *p, *q;
+    kstring_t name = {0, 0, NULL};
+    size_t host_len = 0;
+    khiter_t idx;
+    auth_token *tok = NULL;
+
+    // Nothing to do if:
+    //   curl.auth_path has not been set
+    //   fp was made by hfile_libcurl (e.g. auth_path is a http:// url)
+    //   we already have an Authorization header
+    if (!curl.auth_path || fp->is_recursive || fp->headers.auth_hdr_num != 0)
+        return 0;
+
+    // Insist on having a secure connection unless the user insists harder
+    if (!curl.allow_unencrypted_auth_header && strncmp(url, "https://", 8) != 0)
+        return 0;
+
+    host = strstr(url, "://");
+    if (host) {
+        host += 3;
+        host_len = strcspn(host, "/");
+    }
+
+    p = curl.auth_path;
+    while ((q = strstr(p, "%h")) != NULL) {
+        if (q - p > INT_MAX || host_len > INT_MAX) goto error;
+        if (kputsn_(p, q - p, &name) < 0) goto error;
+        if (kputsn_(host, host_len, &name) < 0) goto error;
+        p = q + 2;
+    }
+    if (kputs(p, &name) < 0) goto error;
+
+    pthread_mutex_lock(&curl.auth_lock);
+    idx = kh_get(auth_map, curl.auth_map, name.s);
+    if (idx < kh_end(curl.auth_map)) {
+        tok = kh_value(curl.auth_map, idx);
+    } else {
+        tok = calloc(1, sizeof(*tok));
+        if (tok && pthread_mutex_init(&tok->lock, NULL) != 0) {
+            free(tok);
+            tok = NULL;
+        }
+        if (tok) {
+            int ret = -1;
+            tok->path = ks_release(&name);
+            tok->token = NULL;
+            tok->expiry = 1; // Force refresh
+            idx = kh_put(auth_map, curl.auth_map, tok->path, &ret);
+            if (ret < 0) {
+                free_auth(tok);
+                tok = NULL;
+            }
+        }
+    }
+    pthread_mutex_unlock(&curl.auth_lock);
+
+    fp->headers.auth = tok;
+    free(name.s);
+
+    return add_auth_header(fp);
+
+ error:
+    free(name.s);
     return -1;
 }
 
@@ -462,6 +774,7 @@ static off_t libcurl_seek(hFILE *fpv, off_t offset, int whence)
     CURLcode err;
     CURLMcode errm;
     off_t origin, pos;
+    int update_headers = 0;
 
     if (!fp->is_read || !fp->can_seek) {
         // Cowardly refuse to seek when writing or a previous seek failed.
@@ -503,10 +816,17 @@ static off_t libcurl_seek(hFILE *fpv, off_t offset, int whence)
     // sent by now.
 
     if (fp->headers.callback) {
-        struct curl_slist *list;
         if (add_callback_headers(fp) != 0)
             return -1;
-        list = get_header_list(fp);
+        update_headers = 1;
+    }
+    if (fp->headers.auth_hdr_num <= 0 && fp->headers.auth) {
+        if (add_auth_header(fp) != 0)
+            return -1;
+        update_headers = 1;
+    }
+    if (update_headers) {
+        struct curl_slist *list = get_header_list(fp);
         if (list) {
             err = curl_easy_setopt(fp->easy, CURLOPT_HTTPHEADER, list);
             if (err != CURLE_OK) {
@@ -639,6 +959,7 @@ static int libcurl_close(hFILE *fpv)
         fp->headers.callback(fp->headers.callback_data, NULL);
     free_headers(&fp->headers.fixed, 1);
     free_headers(&fp->headers.extra, 1);
+    free(fp->headers.auth);
 
     if (save_errno) { errno = save_errno; return -1; }
     else return 0;
@@ -658,7 +979,9 @@ libcurl_open(const char *url, const char *modes, http_headers *headers)
     const char *s;
     CURLcode err;
     CURLMcode errm;
-    int save;
+    int save, is_recursive;
+
+    is_recursive = strchr(modes, 'R') != NULL;
 
     if ((s = strpbrk(modes, "rwa+")) != NULL) {
         mode = *s;
@@ -676,12 +999,14 @@ libcurl_open(const char *url, const char *modes, http_headers *headers)
     } else {
         memset(&fp->headers, 0, sizeof(fp->headers));
     }
+
     fp->file_size = -1;
     fp->buffer.ptr.rd = NULL;
     fp->buffer.len = 0;
     fp->final_result = (CURLcode) -1;
     fp->paused = fp->closing = fp->finished = fp->perform_again = 0;
     fp->can_seek = 1;
+    fp->is_recursive = is_recursive;
     fp->nrunning = 0;
     fp->easy = NULL;
 
@@ -716,6 +1041,8 @@ libcurl_open(const char *url, const char *modes, http_headers *headers)
     if (fp->headers.callback) {
         if (add_callback_headers(fp) != 0) goto error;
     }
+    if (get_auth_token(fp, url) < 0)
+        goto error;
     if ((list = get_header_list(fp)) != NULL)
         err |= curl_easy_setopt(fp->easy, CURLOPT_HTTPHEADER, list);
     err |= curl_easy_setopt(fp->easy, CURLOPT_FOLLOWLOCATION, 1L);
@@ -784,6 +1111,8 @@ static int parse_va_list(http_headers *headers, va_list args)
             for (hdr = va_arg(args, const char **); *hdr; hdr++) {
                 if (append_header(&headers->fixed, *hdr, 1) < 0)
                     return -1;
+                if (is_authorization(*hdr))
+                    headers->auth_hdr_num = headers->fixed.num;
             }
         }
         else if (strcmp(argtype, "httphdr:l") == 0) {
@@ -791,6 +1120,8 @@ static int parse_va_list(http_headers *headers, va_list args)
             while ((hdr = va_arg(args, const char *)) != NULL) {
                 if (append_header(&headers->fixed, hdr, 1) < 0)
                     return -1;
+                if (is_authorization(hdr))
+                    headers->auth_hdr_num = headers->fixed.num;
             }
         }
         else if (strcmp(argtype, "httphdr") == 0) {
@@ -798,6 +1129,8 @@ static int parse_va_list(http_headers *headers, va_list args)
             if (hdr) {
                 if (append_header(&headers->fixed, hdr, 1) < 0)
                     return -1;
+                if (is_authorization(hdr))
+                    headers->auth_hdr_num = headers->fixed.num;
             }
         }
         else if (strcmp(argtype, "httphdr_callback") == 0) {
@@ -891,6 +1224,7 @@ int PLUGIN_GLOBAL(hfile_plugin_init,_libcurl)(struct hFILE_plugin *self)
 #endif
     const curl_version_info_data *info;
     const char * const *protocol;
+    const char *auth;
     CURLcode err;
     CURLSHcode errsh;
 
@@ -907,6 +1241,24 @@ int PLUGIN_GLOBAL(hfile_plugin_init,_libcurl)(struct hFILE_plugin *self)
         curl_global_cleanup();
         errno = EIO;
         return -1;
+    }
+
+    if ((auth = getenv("HTS_AUTH_LOCATION")) != NULL) {
+        curl.auth_path = strdup(auth);
+        curl.auth_map = kh_init(auth_map);
+        if (!curl.auth_path || !curl.auth_map) {
+            int save_errno = errno;
+            free(curl.auth_path);
+            kh_destroy(auth_map, curl.auth_map);
+            curl_share_cleanup(curl.share);
+            curl_global_cleanup();
+            errno = save_errno;
+            return -1;
+        }
+    }
+    if ((auth = getenv("HTS_ALLOW_UNENCRYPTED_AUTHORIZATION_HEADER")) != NULL
+        && strcmp(auth, "I understand the risks") == 0) {
+        curl.allow_unencrypted_auth_header = 1;
     }
 
     info = curl_version_info(CURLVERSION_NOW);

--- a/multipart.c
+++ b/multipart.c
@@ -83,8 +83,10 @@ open_next:
                 (strlen(p->url) > 120)? "..." : "");
 
             fp->currentfp = p->headers?
-                  hopen(p->url, "r:", "httphdr:v", p->headers, NULL)
-                : hopen(p->url, "r");
+                  hopen(p->url, "r:",
+                        "httphdr:v", p->headers,
+                        "auth_token_enabled", "false", NULL)
+                : hopen(p->url, "r:", "auth_token_enabled", "false", NULL);
 
             if (fp->currentfp == NULL) return -1;
         }


### PR DESCRIPTION
Allows you to set `HTS_AUTH_LOCATION` to point to a file or URL where HTSlib can find an OAUTH2 Bearer token (see [RFC 6750](https://tools.ietf.org/html/rfc6750).  `%h` in `HTS_AUTH_LOCATION` will be substituted with the host (and currently port) part of the URL, so that tokens can be sent to specific sites.

The file can either contain just the token (e.g. `mF_9.B5f-4.1JqM`) or an OAUTH2 access token response:
```JSON
{
       "access_token":"mF_9.B5f-4.1JqM",
       "token_type":"Bearer",
       "expires_in":3600,
       "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA"
}
```

`HTS_AUTH_LOCATION` can be a URL as well as file path.  For URLs, care is taken to avoid trying to read an access token for them (otherwise infinite recursion could result).  Allowing URLs enables a way of implementing authentication agents that handle issues like token refresh.
