### PR TITLE
Avoid memory double-free on vhopen_libcurl failure

### DIFF
--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -870,9 +870,6 @@ static hFILE *vhopen_libcurl(const char *url, const char *modes, va_list args)
         fp = libcurl_open(url, modes, &headers);
     }
 
-    if (!fp) {
-        free_headers(&headers.fixed, 1);
-    }
     return fp;
 }
 


### PR DESCRIPTION
libcurl_open cleans up headers completely on failure (see hfile_libcurl.c:761).
So, its not required to call free_headers on failure in vhopen_libcurl.