### PR TITLE
Error on seek failure when iterating over reads

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -452,6 +452,7 @@ off_t hseek(hFILE *fp, off_t offset, int whence)
     // Seeking succeeded, so discard any non-empty read buffer
     fp->begin = fp->end = fp->buffer;
     fp->at_eof = 0;
+    fp->has_errno = 0;
 
     fp->offset = pos;
     return pos;

--- a/hts.c
+++ b/hts.c
@@ -2214,7 +2214,7 @@ int hts_itr_next(BGZF *fp, hts_itr_t *iter, void *r, void *data)
     if (iter == NULL || iter->finished) return -1;
     if (iter->read_rest) {
         if (iter->curr_off) { // seek to the start
-            if (bgzf_seek(fp, iter->curr_off, SEEK_SET) < 0) return -1;
+            if (bgzf_seek(fp, iter->curr_off, SEEK_SET) < 0) return -2;
             iter->curr_off = 0; // only seek once
         }
         ret = iter->readrec(fp, data, r, &tid, &beg, &end);
@@ -2230,7 +2230,7 @@ int hts_itr_next(BGZF *fp, hts_itr_t *iter, void *r, void *data)
         if (iter->curr_off == 0 || iter->curr_off >= iter->off[iter->i].v) { // then jump to the next chunk
             if (iter->i == iter->n_off - 1) { ret = -1; break; } // no more chunks
             if (iter->i < 0 || iter->off[iter->i].v != iter->off[iter->i+1].u) { // not adjacent chunks; then seek
-                if (bgzf_seek(fp, iter->off[iter->i+1].u, SEEK_SET) < 0) return -1;
+                if (bgzf_seek(fp, iter->off[iter->i+1].u, SEEK_SET) < 0) return -2;
                 iter->curr_off = bgzf_tell(fp);
             }
             ++iter->i;

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -201,6 +201,9 @@ int main(int argc, char *argv[])
                     break;
             }
             hts_itr_destroy(iter);
+            if (r < -1) {
+              break;
+            }
         }
         hts_idx_destroy(idx);
     } else while ((r = sam_read1(in, h, b)) >= 0) {


### PR DESCRIPTION
Reference #604 

libcurl_seek can fail for several reasons and frequently a retry is required (eg. the remote server is under high load).

Currently, errno is set to ESPIPE and any further seeks are disabled indiscriminately. Instead, ESPIPE should be set on errors where Range requests are unsupported (and perhaps other curated scenarios). This would allow application logic to handle the error appropriately.