### PR TITLE
Fix data: urls in multipart requests

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -880,7 +880,7 @@ static hFILE *hopen_unknown_scheme(const char *fname, const char *mode)
 }
 
 /* Returns the appropriate handler, or NULL if the string isn't an URL.  */
-static const struct hFILE_scheme_handler *find_scheme_handler(const char *s)
+const struct hFILE_scheme_handler *find_scheme_handler(const char *s)
 {
     static const struct hFILE_scheme_handler unknown_scheme =
         { hopen_unknown_scheme, hfile_always_local, "built-in", 0 };

--- a/hfile.c
+++ b/hfile.c
@@ -880,7 +880,7 @@ static hFILE *hopen_unknown_scheme(const char *fname, const char *mode)
 }
 
 /* Returns the appropriate handler, or NULL if the string isn't an URL.  */
-const struct hFILE_scheme_handler *find_scheme_handler(const char *s)
+const struct hFILE_scheme_handler *hfile_find_scheme_handler(const char *s)
 {
     static const struct hFILE_scheme_handler unknown_scheme =
         { hopen_unknown_scheme, hfile_always_local, "built-in", 0 };
@@ -908,7 +908,7 @@ const struct hFILE_scheme_handler *find_scheme_handler(const char *s)
 
 hFILE *hopen(const char *fname, const char *mode, ...)
 {
-    const struct hFILE_scheme_handler *handler = find_scheme_handler(fname);
+    const struct hFILE_scheme_handler *handler = hfile_find_scheme_handler(fname);
     if (handler) {
         if (strchr(mode, ':') == NULL) return handler->open(fname, mode);
         else if (handler->priority >= 2000 && handler->vopen) {
@@ -930,6 +930,6 @@ int hfile_always_remote(const char *fname) { return 1; }
 
 int hisremote(const char *fname)
 {
-    const struct hFILE_scheme_handler *handler = find_scheme_handler(fname);
+    const struct hFILE_scheme_handler *handler = hfile_find_scheme_handler(fname);
     return handler? handler->isremote(fname) : 0;
 }

--- a/hfile_internal.h
+++ b/hfile_internal.h
@@ -138,7 +138,7 @@ void hfile_add_scheme_handler(const char *scheme,
                               const struct hFILE_scheme_handler *handler);
 
 /* Returns the appropriate handler, or NULL if the string isn't an URL.  */
-const struct hFILE_scheme_handler *find_scheme_handler(const char *s);
+const struct hFILE_scheme_handler *hfile_find_scheme_handler(const char *s);
 
 struct hFILE_plugin {
     /* On entry, HTSlib's plugin API version (currently 1).  */

--- a/hfile_internal.h
+++ b/hfile_internal.h
@@ -137,6 +137,9 @@ extern int hfile_always_remote(const char *fname);
 void hfile_add_scheme_handler(const char *scheme,
                               const struct hFILE_scheme_handler *handler);
 
+/* Returns the appropriate handler, or NULL if the string isn't an URL.  */
+const struct hFILE_scheme_handler *find_scheme_handler(const char *s);
+
 struct hFILE_plugin {
     /* On entry, HTSlib's plugin API version (currently 1).  */
     int api_version;

--- a/multipart.c
+++ b/multipart.c
@@ -88,7 +88,7 @@ open_next:
                                       "auth_token_enabled", "false", NULL);
             } else {
                 const struct hFILE_scheme_handler *handler;
-                handler = find_scheme_handler(p->url);
+                handler = hfile_find_scheme_handler(p->url);
                 if (handler && strcmp(handler->provider, "libcurl") == 0) {
                     fp->currentfp = hopen(p->url, "r:",
                                           "auth_token_enabled", "false", NULL);

--- a/multipart.c
+++ b/multipart.c
@@ -82,11 +82,20 @@ open_next:
                 fp->current+1, fp->nparts, p->url,
                 (strlen(p->url) > 120)? "..." : "");
 
-            fp->currentfp = p->headers?
-                  hopen(p->url, "r:",
-                        "httphdr:v", p->headers,
-                        "auth_token_enabled", "false", NULL)
-                : hopen(p->url, "r:", "auth_token_enabled", "false", NULL);
+            if (p->headers) {
+                fp->currentfp = hopen(p->url, "r:",
+                                      "httphdr:v", p->headers,
+                                      "auth_token_enabled", "false", NULL);
+            } else {
+                const struct hFILE_scheme_handler *handler;
+                handler = find_scheme_handler(p->url);
+                if (handler && strcmp(handler->provider, "libcurl") == 0) {
+                    fp->currentfp = hopen(p->url, "r:",
+                                          "auth_token_enabled", "false", NULL);
+                } else {
+                    fp->currentfp = hopen(p->url, "r");
+                }
+            }
 
             if (fp->currentfp == NULL) return -1;
         }


### PR DESCRIPTION
Fixes googlegenomics/htsget#16.  Commit 4c6b93cb835 broke data: urls in htsget requests.

Not all URLs accessed by multipart.c go through hfile_libcurl.
As we want to pass an hfile_libcurl-specific hopen() parameter
and there is currently no way to find if a parameter will be
accepted, we check to see if the URL will be handled by
hfile_libcurl before calling hopen().

find_scheme_handler() is made non-static, but not made part of
the public API.