### PR TITLE
Make hfile handlers without vopen ignore extra hopen parameters

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -910,8 +910,12 @@ hFILE *hopen(const char *fname, const char *mode, ...)
 {
     const struct hFILE_scheme_handler *handler = find_scheme_handler(fname);
     if (handler) {
-        if (strchr(mode, ':') == NULL) return handler->open(fname, mode);
-        else if (handler->priority >= 2000 && handler->vopen) {
+        if (strchr(mode, ':') == NULL
+            || handler->priority < 2000
+            || handler->vopen == NULL) {
+            return handler->open(fname, mode);
+        }
+        else {
             hFILE *fp;
             va_list arg;
             va_start(arg, mode);
@@ -919,7 +923,6 @@ hFILE *hopen(const char *fname, const char *mode, ...)
             va_end(arg);
             return fp;
         }
-        else { errno = ENOTSUP; return NULL; }
     }
     else if (strcmp(fname, "-") == 0) return hopen_fd_stdinout(mode);
     else return hopen_fd(fname, mode);


### PR DESCRIPTION
This makes it easier to use the extra parameters when we don't know exactly which handler will be used.  It also makes file:// URLs work the same way as simply specifying the file name.
