### PR TITLE
Add BAM version 2 support

### DIFF
--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -216,6 +216,7 @@ enum hts_fmt_option {
     CRAM_OPT_SLICES_PER_CONTAINER,
     CRAM_OPT_RANGE,
     CRAM_OPT_VERSION,    // rename to cram_version?
+    HTS_OPT_VERSION = CRAM_OPT_VERSION, // Generic name for above
     CRAM_OPT_EMBED_REF,
     CRAM_OPT_IGNORE_MD5,
     CRAM_OPT_REFERENCE,  // make general

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -309,7 +309,7 @@ typedef struct {
     #define bam_itr_destroy(iter) hts_itr_destroy(iter)
     #define bam_itr_queryi(idx, tid, beg, end) sam_itr_queryi(idx, tid, beg, end)
     #define bam_itr_querys(idx, hdr, region) sam_itr_querys(idx, hdr, region)
-    #define bam_itr_next(htsfp, itr, r) hts_itr_next((htsfp)->fp.bgzf, (itr), (r), 0)
+    #define bam_itr_next(htsfp, itr, r) hts_itr_next((htsfp)->fp.bgzf, (itr), (r), (htsfp))
 
 // Load/build .csi or .bai BAM index file.  Does not work with CRAM.
 // It is recommended to use the sam_index_* functions below instead.

--- a/test/test.pl
+++ b/test/test.pl
@@ -256,6 +256,7 @@ sub test_view
         $ref .= ".fa";
 
         my $bam  = "$base.tmp.bam";
+	my $bam2 = "$base.tmp.v2.bam";
         my $cram = "$base.tmp.cram";
 
         my $md = "-nomd";
@@ -270,6 +271,11 @@ sub test_view
         testv $opts, "./test_view $tv_args -S -b $sam > $bam";
         testv $opts, "./test_view $tv_args $bam > $bam.sam_";
         testv $opts, "./compare_sam.pl $sam $bam.sam_";
+
+	# SAM -> BAM2 -> SAM
+	testv $opts, "./test_view $tv_args -S -b -o VERSION=2.0 $sam > $bam2";
+	testv $opts, "./test_view $tv_args $bam2 > $bam2.sam_";
+	testv $opts, "./compare_sam.pl $sam $bam2.sam_";
 
         # SAM -> CRAM -> SAM
         testv $opts, "./test_view $tv_args -t $ref -S -C $sam > $cram";


### PR DESCRIPTION
BAM version 2 increases the size of n_cigar to 32 bits.  It adds `bam2_hdr_flags` and `bam2_flags` (on the alignment records).  These are currently reserved for future extensions so are written as zero and checked to ensure they are zero on reading.

The header magic number is changed to "BAM\2".

To select version 2 when writing, it's necessary to either call `hts_set_opt(fp, HTS_OPT_VERSION, "2.0")` before writing the BAM header, or add a 'BV:2' tag to the SAM `@HD` line.  On reading, the version is set automatically depending on the file magic number.

test.pl is updated to test SAM -> BAM2 -> SAM round trips.