### PR TITLE
Don't override the cURL CURLOPT_CAINFO option if env var is unset.

### DIFF
--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -1048,7 +1048,10 @@ libcurl_open(const char *url, const char *modes, http_headers *headers)
 
     err |= curl_easy_setopt(fp->easy, CURLOPT_SHARE, curl.share);
     err |= curl_easy_setopt(fp->easy, CURLOPT_URL, url);
-    err |= curl_easy_setopt(fp->easy, CURLOPT_CAINFO, getenv("CURL_CA_BUNDLE"));
+    char* env_curl_ca_bundle = getenv("CURL_CA_BUNDLE");
+    if (env_curl_ca_bundle) {
+      err |= curl_easy_setopt(fp->easy, CURLOPT_CAINFO, env_curl_ca_bundle);
+    }
     err |= curl_easy_setopt(fp->easy, CURLOPT_USERAGENT, curl.useragent.s);
     if (fp->headers.callback) {
         if (add_callback_headers(fp) != 0) goto error;


### PR DESCRIPTION
If the env var was unset, passing NULL on to curl_easy_setopt here
clobbered access to the system certificates, evidenced by libcurl
error CURLE_SSL_CACERT on access to public BAM files on GCS.