### PR TITLE
Cram iter 625

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -345,6 +345,9 @@ void cram_index_free(cram_fd *fd) {
  * "from" as the last slice we checked to find the next one. Otherwise
  * set "from" to be NULL to find the first one.
  *
+ * Refid can also be any of the special HTS_IDX_ values.
+ * For backwards compatibility, refid -1 is equivalent to HTS_IDX_NOCOOR.
+ *
  * Returns the cram_index pointer on success
  *         NULL on failure
  */
@@ -353,8 +356,33 @@ cram_index *cram_index_query(cram_fd *fd, int refid, int pos,
     int i, j, k;
     cram_index *e;
 
-    if (refid+1 < 0 || refid+1 >= fd->index_sz)
+    switch(refid) {
+    case HTS_IDX_NONE:
+    case HTS_IDX_REST:
+	// fail, or already there, dealt with elsewhere.
 	return NULL;
+
+    case HTS_IDX_NOCOOR:
+	refid = -1;
+	break;
+
+    case HTS_IDX_START: {
+	int64_t min_idx = INT64_MAX;
+	for (i = 0, j = -1; i < fd->index_sz; i++) {
+	    if (fd->index[i].e && fd->index[i].e[0].offset < min_idx) {
+		min_idx = fd->index[i].e[0].offset;
+		j = i;
+	    }
+	}
+	if (j < 0)
+	    return NULL;
+	return fd->index[j].e;
+    }
+
+    default:
+	if (refid < HTS_IDX_NONE || refid+1 >= fd->index_sz)
+	    return NULL;
+    }
 
     if (!from)
 	from = &fd->index[refid+1];
@@ -406,6 +434,7 @@ cram_index *cram_index_query(cram_fd *fd, int refid, int pos,
     return e;
 }
 
+// Return the index entry for last slice on a specific reference.
 cram_index *cram_index_last(cram_fd *fd, int refid, cram_index *from) {
     int slice;
 
@@ -441,6 +470,9 @@ cram_index *cram_index_last(cram_fd *fd, int refid, cram_index *from) {
 int cram_seek_to_refpos(cram_fd *fd, cram_range *r) {
     cram_index *e;
 
+    if (r->refid == HTS_IDX_NONE)
+	return -2;
+
     // Ideally use an index, so see if we have one.
     if ((e = cram_index_query(fd, r->refid, r->start, NULL))) {
 	if (0 != cram_seek(fd, e->offset, SEEK_SET))
@@ -450,6 +482,9 @@ int cram_seek_to_refpos(cram_fd *fd, cram_range *r) {
 	// Absent from index, but this most likely means it simply has no data.
 	return -2;
     }
+
+    if (r->refid == HTS_IDX_START || r->refid == HTS_IDX_REST)
+	fd->range.refid = -2; // special case in cram_next_slice
 
     if (fd->ctr) {
 	cram_free_container(fd->ctr);

--- a/hts.c
+++ b/hts.c
@@ -2355,12 +2355,25 @@ hts_itr_multi_t *hts_itr_multi_cram(const hts_idx_t *idx, hts_itr_multi_t *iter)
         } else {
             switch (tid) {
                 case HTS_IDX_NOCOOR:
-                    e = cram_index_query(cidx->cram, -1, 1, NULL);
+                    e = cram_index_query(cidx->cram, tid, 1, NULL);
                     if (e) {
                         iter->nocoor = 1;
                         iter->nocoor_off = e->offset;
                     } else {
                         hts_log_warning("No index entry for NOCOOR region");
+                    }
+                    break;
+                case HTS_IDX_START:
+                    e = cram_index_query(cidx->cram, tid, 1, NULL);
+                    if (e) {
+                        iter->read_rest = 1;
+                        off = (hts_pair64_max_t*)realloc(off, sizeof(hts_pair64_max_t));
+                        off[0].u = e->offset;
+                        off[0].v = 0;
+                        off[0].max = 0;
+                        n_off=1;
+                    } else {
+                        hts_log_warning("No index entries");
                     }
                     break;
                 case HTS_IDX_REST:

--- a/sam.c
+++ b/sam.c
@@ -782,8 +782,8 @@ static hts_itr_t *cram_itr_query(const hts_idx_t *idx, int tid, int beg, int end
     iter->bins.a = NULL;
     iter->readrec = readrec;
 
-    if (tid >= 0 || tid == HTS_IDX_NOCOOR) {
-        cram_range r = { tid == HTS_IDX_NOCOOR ? -1 : tid, beg+1, end };
+    if (tid >= 0 || tid == HTS_IDX_NOCOOR || tid == HTS_IDX_START) {
+        cram_range r = { tid, beg+1, end };
         int ret = cram_set_option(cidx->cram, CRAM_OPT_RANGE, &r);
 
         iter->curr_off = 0;

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -30,6 +30,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <string.h>
 #include <getopt.h>
+#include <stdint.h>
 
 #include "cram/cram.h"
 
@@ -58,8 +59,9 @@ int main(int argc, char *argv[])
     int extra_hdr_nuls = 0;
     int benchmark = 0;
     int nthreads = 0; // shared pool
+    int multi_reg = 0;
 
-    while ((c = getopt(argc, argv, "DSIt:i:bCl:o:N:BZ:@:")) >= 0) {
+    while ((c = getopt(argc, argv, "DSIt:i:bCl:o:N:BZ:@:M")) >= 0) {
         switch (c) {
         case 'D': flag |= READ_CRAM; break;
         case 'S': flag |= READ_COMPRESSED; break;
@@ -73,6 +75,7 @@ int main(int argc, char *argv[])
         case 'N': nreads = atoi(optarg); break;
         case 'B': benchmark = 1; break;
         case 'Z': extra_hdr_nuls = atoi(optarg); break;
+        case 'M': multi_reg = 1; break;
         case '@': nthreads = atoi(optarg); break;
         }
     }
@@ -92,6 +95,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "-N: num_reads: limit the output to the first num_reads reads\n");
         fprintf(stderr, "\n");
         fprintf(stderr, "-B: enable benchmarking\n");
+        fprintf(stderr, "-M: use hts_itr_multi iterator\n");
         fprintf(stderr, "-Z hdr_nuls: append specified number of null bytes to the SAM header\n");
         fprintf(stderr, "-@ num_threads: use thread pool with specified number of threads\n");
         return 1;
@@ -185,13 +189,72 @@ int main(int argc, char *argv[])
             fprintf(stderr, "[E::%s] fail to load the BAM index\n", __func__);
             return 1;
         }
-        for (i = optind + 1; i < argc; ++i) {
-            hts_itr_t *iter;
-            if ((iter = sam_itr_querys(idx, h, argv[i])) == 0) {
-                fprintf(stderr, "[E::%s] fail to parse region '%s'\n", __func__, argv[i]);
-                continue;
+        if (multi_reg) {
+            int reg_count = 0;
+            hts_reglist_t *reg_list = calloc(argc-(optind+1), sizeof(*reg_list));
+            if (!reg_list)
+                return 1;
+
+            // We need a public function somewhere to turn an array of region strings
+            // into a region list, but for testing this will suffice for now.
+            // Consider moving a derivation of this into htslib proper sometime.
+            for (i = optind + 1; i < argc; ++i) {
+                int j;
+                uint32_t beg, end;
+                char *cp = strrchr(argv[i], ':');
+                if (cp) *cp = 0;
+
+                // Does any of this need to be sorted?
+                // For now we assume any such limits are passed onto whoever
+                // is running the command line.
+                for (j = 0; j < reg_count; j++)
+                    if (strcmp(reg_list[j].reg, argv[i]) == 0)
+                        break;
+                if (j == reg_count) {
+                    reg_list[j=reg_count++].reg = argv[i];
+                    if (strcmp(".", argv[i]) == 0) {
+                        reg_list[j].tid = HTS_IDX_START;
+
+                    } else if (strcmp("*", argv[i]) == 0) {
+                        reg_list[j].tid = HTS_IDX_NOCOOR;
+
+                    } else {
+                        int k; // need the header API here!
+                        for (k = 0; k < h->n_targets; k++)
+                            if (strcmp(h->target_name[k], argv[i]) == 0)
+                                break;
+                        if (k == h->n_targets)
+                            return 1;
+                        reg_list[j].tid = k;
+                        reg_list[j].min_beg = h->target_len[k];
+                        reg_list[j].max_end = 0;
+                    }
+                }
+
+                hts_reglist_t *r = &reg_list[j];
+                r->intervals = realloc(r->intervals, ++r->count * sizeof(*r->intervals));
+                if (!r->intervals)
+                    return 1;
+                beg = 1;
+                end = r->tid >= 0 ? h->target_len[r->tid] : 0;
+                if (cp) {
+                    *cp = 0;
+                    // hts_parse_reg() is better, but awkward here
+                    sscanf(cp+1, "%d-%d", &beg, &end);
+                }
+                r->intervals[r->count-1].beg = beg-1; // BED syntax
+                r->intervals[r->count-1].end = end;
+
+                if (r->min_beg > beg)
+                    r->min_beg = beg;
+                if (r->max_end < end)
+                    r->max_end = end;
             }
-            while ((r = sam_itr_next(in, iter, b)) >= 0) {
+
+            hts_itr_multi_t *iter = sam_itr_regions(idx, h, reg_list, reg_count);
+            if (!iter)
+                return 1;
+            while ((r = sam_itr_multi_next(in, iter, b)) >= 0) {
                 if (!benchmark && sam_write1(out, h, b) < 0) {
                     fprintf(stderr, "Error writing output.\n");
                     exit_code = 1;
@@ -200,7 +263,25 @@ int main(int argc, char *argv[])
                 if (nreads && --nreads == 0)
                     break;
             }
-            hts_itr_destroy(iter);
+            hts_itr_multi_destroy(iter, reg_count);
+        } else {
+            for (i = optind + 1; i < argc; ++i) {
+                hts_itr_t *iter;
+                if ((iter = sam_itr_querys(idx, h, argv[i])) == 0) {
+                    fprintf(stderr, "[E::%s] fail to parse region '%s'\n", __func__, argv[i]);
+                    continue;
+                }
+                while ((r = sam_itr_next(in, iter, b)) >= 0) {
+                    if (!benchmark && sam_write1(out, h, b) < 0) {
+                        fprintf(stderr, "Error writing output.\n");
+                        exit_code = 1;
+                        break;
+                    }
+                    if (nreads && --nreads == 0)
+                        break;
+                }
+                hts_itr_destroy(iter);
+            }
         }
         hts_idx_destroy(idx);
     } else while ((r = sam_read1(in, h, b)) >= 0) {


### PR DESCRIPTION
Fixes #625

Modifies cram_index.c to cope with HTS_IDX_* special "tid" values, plus minimal changes to sam.c (normal iterator) and hts.c (multi-region iterator) to permit use of these on CRAM.

The second commit adds a -M option to test/test_view.c to permit command line testing of the new multi-region iterator.  This may be considered separate to this PR if desired.  It also exposes some weaknesses in the new API in that it lacks any way of constructing an hts_reglist_t struct.  Ideally we'd use something like:

```
hts_reglist_t *reglist = NULL;
for (i = optind + 1; i < argc; ++i) {
    if (hts_reglist_add(&reglist, argv[i]) < 0)
        return -1;
}
```

Perhaps with another form for adding BED lines?  However that is a separate issue.