### PR TITLE
Bug fix to random bgzf cache removal.

### DIFF
--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -55,6 +55,7 @@ struct hFILE;
 struct hts_tpool;
 struct bgzf_mtaux_t;
 typedef struct __bgzidx_t bgzidx_t;
+typedef struct __bgzf_cache_t bgzf_cache_t;
 
 struct BGZF {
     // Reserved bits should be written as 0; read as "don't care"
@@ -65,7 +66,7 @@ struct BGZF {
     int block_length, block_clength, block_offset;
     int64_t block_address, uncompressed_address;
     void *uncompressed_block, *compressed_block;
-    void *cache; // a pointer to a hash table
+    bgzf_cache_t *cache;
     struct hFILE *fp; // actual file handle
     struct bgzf_mtaux_t *mt; // only used for multi-threading
     bgzidx_t *idx;      // BGZF index

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -55,7 +55,7 @@ struct hFILE;
 struct hts_tpool;
 struct bgzf_mtaux_t;
 typedef struct __bgzidx_t bgzidx_t;
-typedef struct __bgzf_cache_t bgzf_cache_t;
+typedef struct bgzf_cache_t bgzf_cache_t;
 
 struct BGZF {
     // Reserved bits should be written as 0; read as "don't care"


### PR DESCRIPTION
An alternative to https://github.com/samtools/htslib/pull/620 for consideration.

Difference here is random removal (via round-robin approach) vs removal of oldest object.  Pros and cons of each.  (Thanks @ramyala for spotting it was bugged and raising the other PR implementation.)