### PR TITLE
hts_itr_multi_destroy with one argument

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -2435,11 +2435,11 @@ void hts_reglist_free(hts_reglist_t *reglist, int count) {
     }
 }
 
-void hts_itr_multi_destroy(hts_itr_multi_t *iter, int count) {
+void hts_itr_multi_destroy(hts_itr_multi_t *iter) {
 
     if (iter) {
         if (iter->reg_list && iter->n_reg)
-            hts_reglist_free(iter->reg_list, count);
+            hts_reglist_free(iter->reg_list, iter->n_reg);
 
         if (iter->off && iter->n_off)
             free(iter->off);

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -684,7 +684,7 @@ hts_itr_multi_t *hts_itr_multi_cram(const hts_idx_t *idx, hts_itr_multi_t *iter)
 hts_itr_multi_t *hts_itr_regions(const hts_idx_t *idx, hts_reglist_t *reglist, int count, hts_name2id_f getid, void *hdr, hts_itr_multi_query_func *itr_specific, hts_readrec_func *readrec, hts_seek_func *seek, hts_tell_func *tell);
 int hts_itr_multi_next(htsFile *fd, hts_itr_multi_t *iter, void *r);
 void hts_reglist_free(hts_reglist_t *reglist, int count);
-void hts_itr_multi_destroy(hts_itr_multi_t *iter, int n_reg);
+void hts_itr_multi_destroy(hts_itr_multi_t *iter);
 
 
     /**

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -261,7 +261,7 @@ int main(int argc, char *argv[])
                 if (nreads && --nreads == 0)
                     break;
             }
-            hts_itr_multi_destroy(iter, reg_count);
+            hts_itr_multi_destroy(iter);
         } else {
             for (i = optind + 1; i < argc; ++i) {
                 hts_itr_t *iter;


### PR DESCRIPTION
Simplifies the call to `hts_itr_multi_destroy` by removing the second argument, region count, which was already contained in the iterator.