### PR TITLE
Fixes the finished flag usage.

### DIFF
--- a/kstring.c
+++ b/kstring.c
@@ -174,28 +174,29 @@ int ksprintf(kstring_t *s, const char *fmt, ...)
 	return l;
 }
 
-char *kstrtok(const char *str, const char *sep, ks_tokaux_t *aux)
+char *kstrtok(const char *str, const char *sep_in, ks_tokaux_t *aux)
 {
-	const char *p, *start;
+	const unsigned char *p, *start, *sep = (unsigned char *) sep_in;
 	if (sep) { // set up the table
 		if (str == 0 && aux->finished) return 0; // no need to set up if we have finished
 		aux->finished = 0;
-		if (sep[1]) {
+		if (sep[0] && sep[1]) {
 			aux->sep = -1;
 			aux->tab[0] = aux->tab[1] = aux->tab[2] = aux->tab[3] = 0;
 			for (p = sep; *p; ++p) aux->tab[*p>>6] |= 1ull<<(*p&0x3f);
 		} else aux->sep = sep[0];
 	}
 	if (aux->finished) return 0;
-	else if (str) aux->p = str - 1, aux->finished = 0;
+	else if (str) start = (unsigned char *) str, aux->finished = 0;
+	else start = (unsigned char *) aux->p + 1;
 	if (aux->sep < 0) {
-		for (p = start = aux->p + 1; *p; ++p)
+		for (p = start; *p; ++p)
 			if (aux->tab[*p>>6]>>(*p&0x3f)&1) break;
 	} else {
-		for (p = start = aux->p + 1; *p; ++p)
+		for (p = start; *p; ++p)
 			if (*p == aux->sep) break;
 	}
-	aux->p = p; // end of token
+	aux->p = (const char *) p; // end of token
 	if (*p == 0) aux->finished = 1; // no more tokens
 	return (char*)start;
 }

--- a/kstring.c
+++ b/kstring.c
@@ -178,7 +178,7 @@ char *kstrtok(const char *str, const char *sep, ks_tokaux_t *aux)
 {
 	const char *p, *start;
 	if (sep) { // set up the table
-		if (str == 0 && (aux->tab[0]&1)) return 0; // no need to set up if we have finished
+		if (str == 0 && aux->finished) return 0; // no need to set up if we have finished
 		aux->finished = 0;
 		if (sep[1]) {
 			aux->sep = -1;


### PR DESCRIPTION
In a previous implementation of `kstrtok`, the LSB of `tab[0]` was used as a flag to indicate that the tokenization process had ended. However, a new dedicated flag (`finished`) was later added to the `aux` structure, but the change to the new flag hasn't been completely carried out.
  