### PR TITLE
Fixed return value of cram_get_bam_seq and fixed a bug in required_fields option.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1798,6 +1798,9 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 		}
 		ref_pos += cr->len - seq_pos + 1;
 	    }
+	} else if (cr->ref_id >= 0) {
+	    // So alignment end can be computed even when not decoding sequence
+	    ref_pos += cr->len - seq_pos + 1;
 	}
 
 	if (ncigar+1 >= cigar_alloc) {
@@ -1950,7 +1953,7 @@ static int cram_decode_aux_1_0(cram_container *c, cram_slice *s,
 
 	cr->aux_size += out_sz + 3;
     }
-    
+
     return r;
 }
 
@@ -1961,7 +1964,7 @@ static int cram_decode_aux(cram_container *c, cram_slice *s,
     int32_t TL = 0;
     unsigned char *TN;
     uint32_t ds = c->comp_hdr->data_series;
-	    
+
     if (!(ds & (CRAM_TL|CRAM_aux))) {
 	cr->aux = 0;
 	cr->aux_size = 0;
@@ -3225,7 +3228,7 @@ cram_record *cram_get_seq(cram_fd *fd) {
 /*
  * Read the next cram record and convert it to a bam_seq_t struct.
  *
- * Returns 0 on success
+ * Returns >= 0 success (number of bytes written to *bam)
  *        -1 on EOF or failure (check fd->err)
  */
 int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam) {

--- a/cram/cram_samtools.c
+++ b/cram/cram_samtools.c
@@ -124,7 +124,7 @@ int bam_construct_seq(bam_seq_t **bp, size_t extra_len,
     else
 	memset(cp, '\xff', len);
 
-    return 0;
+    return bam_len;
 }
 
 bam_hdr_t *cram_header_to_bam(SAM_hdr *h) {


### PR DESCRIPTION
1. bam_construct_seq returned 0 instead of number of bytes written to
the bam_seq_t struct.  This in turn bubbled up to cram_get_seq
returning only the number of auxiliary bytes written to instead of the
total record size.

Under specific circumstances (no RG tag, no NM/MD requested, and no
other aux fields), this meant cram_get_bam_seq returned 0 on a
successful read.  This in turn was interpreted as EOF by the iterator.
Given bam_read1 returns the size of the bam structure it feels
appropriate for the cram version to mirror it, as originally intended.

2. If we use the required_fields option to exclude sequence data, then
we also exclude loading of the reference (which is a useful
optimisation).  However this then also meant the cram_decode_seq
function wasn't correctly modifying the alignment end, leaving it set
to alignment start.

The consequence is range queries combined with required_fields usage
could miss reads which start before the range and end within it.

Fixes #640