### PR TITLE
Add hts_open_cb() interface which allows callback function used as data source

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -658,6 +658,8 @@ hFILE *hcbopen(hFILE_ops ops, const char* mode)
 	if(ret)
 		ret->ops = ops;
 
+	ret->base.backend = &cb_backend;
+
 	return (hFILE*)ret;
 }
 

--- a/hts.c
+++ b/hts.c
@@ -449,7 +449,7 @@ htsFile *hts_open_cb(const hFILE_ops* ops, const char* mode)
 {
 	if(NULL == ops) return NULL;
 	hFILE* fp = hcbopen(*ops, mode);
-	return hts_open_format_impl(NULL, mode, NULL, fp);
+	return hts_open_format_impl("-", mode, NULL, fp);
 }
 
 htsFile *hts_open(const char *fn, const char *mode) {

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -53,6 +53,21 @@ typedef struct hFILE {
     // @endcond
 } hFILE;
 
+/// Defines the operations that used by an IO file
+typedef struct  hFILE_ops {
+	void* cb_data;
+
+	ssize_t (*read)(void* cb_data, void* buf, size_t sz);
+
+	ssize_t (*write)(void* cb_data, const void* buf, size_t sz);
+
+	off_t (*seek)(void* cb_data, off_t ofs, int whence);
+
+	int (*flush)(void* cb_data);
+
+	int (*close)(void* cb_data);
+} hFILE_ops;
+
 /// Open the named file or URL as a stream
 /** @return An hFILE pointer, or `NULL` (with _errno_ set) if an error occurred.
 
@@ -62,6 +77,10 @@ The usual `fopen(3)` _mode_ letters are supported: one of
 `:` (indicates scheme-specific variable arguments follow).
 */
 hFILE *hopen(const char *filename, const char *mode, ...) HTS_RESULT_USED;
+
+/// Wrap a group of operation callbacks into a HFile stream
+/** @return An hFILE pointer */
+hFILE *hcbopen(hFILE_ops ops, const char* mode) HTS_RESULT_USED;
 
 /// Associate a stream with an existing open file descriptor
 /** @return An hFILE pointer, or `NULL` (with _errno_ set) if an error occurred.

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -56,15 +56,10 @@ typedef struct hFILE {
 /// Defines the operations that used by an IO file
 typedef struct  hFILE_ops {
 	void* cb_data;
-
 	ssize_t (*read)(void* cb_data, void* buf, size_t sz);
-
 	ssize_t (*write)(void* cb_data, const void* buf, size_t sz);
-
 	off_t (*seek)(void* cb_data, off_t ofs, int whence);
-
 	int (*flush)(void* cb_data);
-
 	int (*close)(void* cb_data);
 } hFILE_ops;
 
@@ -79,7 +74,8 @@ The usual `fopen(3)` _mode_ letters are supported: one of
 hFILE *hopen(const char *filename, const char *mode, ...) HTS_RESULT_USED;
 
 /// Wrap a group of operation callbacks into a HFile stream
-/** @return An hFILE pointer */
+/** @return An hFILE pointer, or NULL if error occurred
+ */
 hFILE *hcbopen(hFILE_ops ops, const char* mode) HTS_RESULT_USED;
 
 /// Associate a stream with an existing open file descriptor

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -371,6 +371,15 @@ char *hts_format_description(const htsFormat *format);
 */
 htsFile *hts_open(const char *fn, const char *mode);
 
+/*!
+  @abstract      Open a SAM/BAM/CRAM/VCF/BCF/etc from stream callbacks
+  @param ops     The IO operation callback
+  @param mode    The mode string
+  @discussion    
+     See hts_open for description of mode string.
+	 This function is useful when data sources other than file/pipe
+	 should be consumed.
+*/
 htsFile *hts_open_cb(const struct hFILE_ops* ops, const char* mode);
 
 /*!

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -44,6 +44,7 @@ typedef struct BGZF BGZF;
 #endif
 struct cram_fd;
 struct hFILE;
+struct hFILE_ops;
 struct hts_tpool;
 
 #ifndef KSTRING_T
@@ -369,6 +370,8 @@ char *hts_format_description(const htsFormat *format);
       [rw]   .. uncompressed VCF
 */
 htsFile *hts_open(const char *fn, const char *mode);
+
+htsFile *hts_open_cb(const struct hFILE_ops* ops, const char* mode);
 
 /*!
   @abstract       Open a SAM/BAM/CRAM/VCF/BCF/etc file


### PR DESCRIPTION
The use case I am currently working on is use htslib with C++ istream. And this change makes htslib able to consume data from a set of consumized callback functions. 
For my sernario, I can just wrap the C++ stream object as an callback function, thus the htslib can work with the istream.
```C
struct stream_data_t {
	std::istream& stream;
	stream_data_t(std::istream& is) : stream(is){}
	
	static ssize_t read(void* data, void* resbuf, size_t sz)
	{
		stream_data_t *stream_data = static_cast<stream_data_t*>(data);
		stream_data->stream.read((char*)resbuf, sz);
		if(!stream_data->stream)
			sz = (ssize_t)stream_data->stream.gcount();
		return (ssize_t)sz;
	}
	
	static int close(void* data)
	{
		free(data);
		return 0;
	}
};
stream_data_t* cb_data = new stream_data_t(*is);
hFILE_ops ops;
memset(&ops, 0, sizeof(ops));
ops.read = stream_data_t::read;
ops.close = stream_data_t::close;
ops.cb_data = cb_data;
samFile* fp = hts_open_cb(&ops, "rb");
```

This is also allows program detect the data format in a pipe by reading a few bytes from the pipe and then detect if htslib should be used. Otherwise, since UNIX pipe cannot do either unget or seek, thus once the program detect the data should be handled by htslib, it's too late to handle off the FD.
