### PR TITLE
Accomodate use of some internal APIs in plug-ins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,9 @@ cram_sam_header_h = cram/sam_header.h cram/string_alloc.h cram/pooled_alloc.h $(
 cram_samtools_h = cram/cram_samtools.h $(htslib_sam_h) $(cram_sam_header_h)
 cram_structs_h = cram/cram_structs.h $(htslib_thread_pool_h) cram/string_alloc.h $(htslib_khash_h)
 cram_open_trace_file_h = cram/open_trace_file.h cram/mFILE.h
-hfile_internal_h = hfile_internal.h $(htslib_hfile_h)
-hts_internal_h = hts_internal.h $(htslib_hts_h)
+hfile_internal_h = hfile_internal.h $(htslib_hfile_h) $(textutils_internal_h)
+hts_internal_h = hts_internal.h $(htslib_hts_h) $(textutils_internal_h)
+textutils_internal_h = textutils_internal.h $(htslib_kstring_h)
 thread_pool_internal_h = thread_pool_internal.h $(htslib_thread_pool_h)
 
 
@@ -294,7 +295,7 @@ hfile.o hfile.pico: hfile.c config.h $(htslib_hfile_h) $(hfile_internal_h) $(hts
 hfile_gcs.o hfile_gcs.pico: hfile_gcs.c config.h $(htslib_hts_h) $(htslib_kstring_h) $(hfile_internal_h)
 hfile_libcurl.o hfile_libcurl.pico: hfile_libcurl.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
 hfile_net.o hfile_net.pico: hfile_net.c config.h $(hfile_internal_h) $(htslib_knetfile_h)
-hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hts_internal_h) $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
+hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
 hts.o hts.pico: hts.c config.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(hfile_internal_h) $(htslib_hfile_h) version.h $(hts_internal_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h)
 hts_os.o hts_os.pico: hts_os.c config.h os/rand.c
 vcf.o vcf.pico: vcf.c config.h $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_hfile_h) $(hts_internal_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_hts_endian_h)

--- a/hfile_internal.h
+++ b/hfile_internal.h
@@ -29,6 +29,8 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "htslib/hfile.h"
 
+#include "textutils_internal.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -30,7 +30,6 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <time.h>
 
-#include "hts_internal.h"
 #include "hfile_internal.h"
 #ifdef ENABLE_PLUGINS
 #include "version.h"

--- a/hts_internal.h
+++ b/hts_internal.h
@@ -28,121 +28,21 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "htslib/hts.h"
 
+#include "textutils_internal.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct hFILE;
 
-/// Decode percent-encoded (URL-encoded) text
-/** On input, _dest_ should be a buffer at least the same size as _s_,
-    and may be equal to _s_ to decode in place.  On output, _dest_ will be
-    NUL-terminated and the number of characters written (not including the
-    NUL) is stored in _destlen_.
-*/
-int hts_decode_percent(char *dest, size_t *destlen, const char *s);
-
-/// Return decoded data length given length of base64-encoded text
-/** This gives an upper bound, as it overestimates by a byte or two when
-    the encoded text ends with (possibly omitted) `=` padding characters.
-*/
-size_t hts_base64_decoded_length(size_t len);
-
-/// Decode base64-encoded data
-/** On input, _dest_ should be a sufficient buffer (see `hts_base64_length()`),
-    and may be equal to _s_ to decode in place.  On output, the number of
-    bytes writen is stored in _destlen_.
-*/
-int hts_decode_base64(char *dest, size_t *destlen, const char *s);
-
-
-/// Token structure returned by JSON lexing functions
-/** Token types correspond to scalar JSON values and selected punctuation
-as follows:
-  - `s` string
-  - `n` number
-  - `b` boolean literal
-  - `.` null literal
-  - `{`, `}`, `[`, `]` object and array delimiters
-  - `?` lexing error
-  - `\0` terminator at end of input
-*/
-typedef struct hts_json_token {
+struct hts_json_token {
     char type;    ///< Token type
     char *str;    ///< Value as a C string (filled in for all token types)
     // TODO Add other fields to fill in for particular data types, e.g.
     // int inum;
     // float fnum;
-} hts_json_token;
-
-/// Read one JSON token from a file
-/** @param str    The input C string
-    @param state  The input string state
-    @param token  On return, filled in with the token read
-    @return  The type of the token read
-
-On return, `token->str` points into the supplied input string, which
-is modified by having token-terminating characters overwritten as NULs.
-The `state` argument records the current position within `str` after each
-`hts_json_snext()` call, and should be set to 0 before the first call.
-*/
-char hts_json_snext(char *str, size_t *state, hts_json_token *token);
-
-/// Read and discard a complete JSON value from a string
-/** @param str    The input C string
-    @param state  The input string state, as per `hts_json_snext()`
-    @param type   If the first token of the value to be discarded has already
-                  been read, provide its type; otherwise `'\0'`
-    @return  One of `v` (success), `\0` (end of string), and `?` (lexing error)
-
-Skips a complete JSON value, which may be a single token or an entire object
-or array.
-*/
-char hts_json_sskip_value(char *str, size_t *state, char type);
-
-/// Read one JSON token from a file
-/** @param fp     The file stream
-    @param token  On return, filled in with the token read
-    @param kstr   Buffer used to store the token string returned
-    @return  The type of the token read
-
-The `kstr` buffer is used to store the string value of the token read,
-so `token->str` is only valid until the next time `hts_json_fnext()` is
-called with the same `kstr` argument.
-*/
-char hts_json_fnext(struct hFILE *fp, hts_json_token *token, kstring_t *kstr);
-
-/// Read and discard a complete JSON value from a file
-/** @param fp    The file stream
-    @param type  If the first token of the value to be discarded has already
-                 been read, provide its type; otherwise `'\0'`
-    @return  One of `v` (success), `\0` (EOF), and `?` (lexing error)
-
-Skips a complete JSON value, which may be a single token or an entire object
-or array.
-*/
-char hts_json_fskip_value(struct hFILE *fp, char type);
-
-
-// The <ctype.h> functions operate on ints such as are returned by fgetc(),
-// i.e., characters represented as unsigned-char-valued ints, or EOF.
-// To operate on plain chars (and to avoid warnings on some platforms),
-// technically one must cast to unsigned char everywhere (see CERT STR37-C)
-// or less painfully use these *_c() functions that operate on plain chars
-// (but not EOF, which must be considered separately where it is applicable).
-// TODO We may eventually wish to implement these functions directly without
-// using their <ctype.h> equivalents, and thus make them immune to locales.
-static inline int isalnum_c(char c) { return isalnum((unsigned char) c); }
-static inline int isalpha_c(char c) { return isalpha((unsigned char) c); }
-static inline int isdigit_c(char c) { return isdigit((unsigned char) c); }
-static inline int isgraph_c(char c) { return isgraph((unsigned char) c); }
-static inline int islower_c(char c) { return islower((unsigned char) c); }
-static inline int isprint_c(char c) { return isprint((unsigned char) c); }
-static inline int isspace_c(char c) { return isspace((unsigned char) c); }
-static inline int isupper_c(char c) { return isupper((unsigned char) c); }
-static inline char tolower_c(char c) { return tolower((unsigned char) c); }
-static inline char toupper_c(char c) { return toupper((unsigned char) c); }
-
+};
 
 struct cram_fd;
 
@@ -160,7 +60,6 @@ typedef struct hts_cram_idx_t {
 
 // Entry point to hFILE_multipart backend.
 struct hFILE *hopen_htsget_redirect(struct hFILE *hfile, const char *mode);
-
 
 struct hts_path_itr {
     kstring_t path, entry;

--- a/textutils.c
+++ b/textutils.c
@@ -215,6 +215,18 @@ static char token_type(hts_json_token *token)
     }
 }
 
+hts_json_token * hts_json_alloc_token() {
+    return calloc(1, sizeof(hts_json_token));
+}
+
+char hts_json_token_type(hts_json_token *token) {
+    return token->type;
+}
+
+char *hts_json_token_str(hts_json_token *token) {
+    return token->str;
+}
+
 char hts_json_snext(char *str, size_t *state, hts_json_token *token)
 {
     char *s = &str[*state >> 2];

--- a/textutils.c
+++ b/textutils.c
@@ -223,6 +223,10 @@ char hts_json_token_type(hts_json_token *token) {
     return token->type;
 }
 
+void hts_json_free_token(hts_json_token *token) {
+    free(token);
+}
+
 char *hts_json_token_str(hts_json_token *token) {
     return token->str;
 }

--- a/textutils_internal.h
+++ b/textutils_internal.h
@@ -68,9 +68,7 @@ typedef struct hts_json_token hts_json_token;
 hts_json_token * hts_json_alloc_token();
 
 /// Free a JSON token
-static inline void hts_json_free_token(hts_json_token *token) {
-    free(token);
-}
+void hts_json_free_token(hts_json_token *token);
 
 /// Accessor funtion to get JSON token type
 /** @param  token Pointer to JSON token

--- a/textutils_internal.h
+++ b/textutils_internal.h
@@ -1,0 +1,177 @@
+/* textutils_internal.h -- non-bioinformatics utility routines for text etc.
+
+   Copyright (C) 2016,2018 Genome Research Ltd.
+
+   Author: John Marshall <jm18@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#ifndef HTSLIB_TEXTUTILS_INTERNAL_H
+#define HTSLIB_TEXTUTILS_INTERNAL_H
+
+/* N.B. These interfaces may be used by plug-ins */
+
+#include <ctype.h>
+#include <stdlib.h>
+#include "htslib/kstring.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Decode percent-encoded (URL-encoded) text
+/** On input, _dest_ should be a buffer at least the same size as _s_,
+    and may be equal to _s_ to decode in place.  On output, _dest_ will be
+    NUL-terminated and the number of characters written (not including the
+    NUL) is stored in _destlen_.
+*/
+int hts_decode_percent(char *dest, size_t *destlen, const char *s);
+
+/// Return decoded data length given length of base64-encoded text
+/** This gives an upper bound, as it overestimates by a byte or two when
+    the encoded text ends with (possibly omitted) `=` padding characters.
+*/
+size_t hts_base64_decoded_length(size_t len);
+
+/// Decode base64-encoded data
+/** On input, _dest_ should be a sufficient buffer (see `hts_base64_length()`),
+    and may be equal to _s_ to decode in place.  On output, the number of
+    bytes writen is stored in _destlen_.
+*/
+int hts_decode_base64(char *dest, size_t *destlen, const char *s);
+
+/// Token structure returned by JSON lexing functions
+/** Structure is defined in hts_internal.h
+ */
+
+typedef struct hts_json_token hts_json_token;
+
+/// Allocate an empty JSON token structure, for use with hts_json_* functions
+/** @return An empty token on success; NULL on failure
+ */
+hts_json_token * hts_json_alloc_token();
+
+/// Free a JSON token
+static inline void hts_json_free_token(hts_json_token *token) {
+    free(token);
+}
+
+/// Accessor funtion to get JSON token type
+/** @param  token Pointer to JSON token
+    @return Character indicating the token type
+
+Token types correspond to scalar JSON values and selected punctuation
+as follows:
+  - `s` string
+  - `n` number
+  - `b` boolean literal
+  - `.` null literal
+  - `{`, `}`, `[`, `]` object and array delimiters
+  - `?` lexing error
+  - `!` other errors (e.g. out of memory)
+  - `\0` terminator at end of input
+*/
+char hts_json_token_type(hts_json_token *token);
+
+/// Accessor funtion to get JSON token in string form
+/** @param  token Pointer to JSON token
+    @return String representation of the JSON token; NULL if unset
+
+If the token was parsed from a string using hts_json_snext(), the return value
+will point into the string passed as the first parameter to hts_json_snext().
+If the token was parsed from a file using hts_json_fnext(), the return value
+will point at the kstring_t buffer passed as the third parameter to
+hts_json_fnext().  In that case, the value will only be valid until the
+next call to hts_json_fnext().
+ */
+char *hts_json_token_str(hts_json_token *token);
+
+/// Read one JSON token from a string
+/** @param str    The input C string
+    @param state  The input string state
+    @param token  On return, filled in with the token read
+    @return  The type of the token read
+
+On return, `token->str` points into the supplied input string, which
+is modified by having token-terminating characters overwritten as NULs.
+The `state` argument records the current position within `str` after each
+`hts_json_snext()` call, and should be set to 0 before the first call.
+*/
+char hts_json_snext(char *str, size_t *state, hts_json_token *token);
+
+/// Read and discard a complete JSON value from a string
+/** @param str    The input C string
+    @param state  The input string state, as per `hts_json_snext()`
+    @param type   If the first token of the value to be discarded has already
+                  been read, provide its type; otherwise `'\0'`
+    @return  One of `v` (success), `\0` (end of string), and `?` (lexing error)
+
+Skips a complete JSON value, which may be a single token or an entire object
+or array.
+*/
+char hts_json_sskip_value(char *str, size_t *state, char type);
+
+/// Read one JSON token from a file
+/** @param fp     The file stream
+    @param token  On return, filled in with the token read
+    @param kstr   Buffer used to store the token string returned
+    @return  The type of the token read
+
+The `kstr` buffer is used to store the string value of the token read,
+so `token->str` is only valid until the next time `hts_json_fnext()` is
+called with the same `kstr` argument.
+*/
+char hts_json_fnext(struct hFILE *fp, hts_json_token *token, kstring_t *kstr);
+
+/// Read and discard a complete JSON value from a file
+/** @param fp    The file stream
+    @param type  If the first token of the value to be discarded has already
+                 been read, provide its type; otherwise `'\0'`
+    @return  One of `v` (success), `\0` (EOF), and `?` (lexing error)
+
+Skips a complete JSON value, which may be a single token or an entire object
+or array.
+*/
+char hts_json_fskip_value(struct hFILE *fp, char type);
+
+
+// The <ctype.h> functions operate on ints such as are returned by fgetc(),
+// i.e., characters represented as unsigned-char-valued ints, or EOF.
+// To operate on plain chars (and to avoid warnings on some platforms),
+// technically one must cast to unsigned char everywhere (see CERT STR37-C)
+// or less painfully use these *_c() functions that operate on plain chars
+// (but not EOF, which must be considered separately where it is applicable).
+// TODO We may eventually wish to implement these functions directly without
+// using their <ctype.h> equivalents, and thus make them immune to locales.
+static inline int isalnum_c(char c) { return isalnum((unsigned char) c); }
+static inline int isalpha_c(char c) { return isalpha((unsigned char) c); }
+static inline int isdigit_c(char c) { return isdigit((unsigned char) c); }
+static inline int isgraph_c(char c) { return isgraph((unsigned char) c); }
+static inline int islower_c(char c) { return islower((unsigned char) c); }
+static inline int isprint_c(char c) { return isprint((unsigned char) c); }
+static inline int isspace_c(char c) { return isspace((unsigned char) c); }
+static inline int isupper_c(char c) { return isupper((unsigned char) c); }
+static inline char tolower_c(char c) { return tolower((unsigned char) c); }
+static inline char toupper_c(char c) { return toupper((unsigned char) c); }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Use of functions declared in hts_internal.h has crept into two
plug-ins: hfile_s3 uses isalnum_c(), etc. and hfile_libcurl uses
the JSON parsing API.  This makes these APIs more fixed than is
suggested by their being defined in the internal header files
and not the public ones.

Move the function declarations to a new file (textutils_internal.h)
which includes a note that the functions may be used in plug-ins.
This file is included from both hts_internal.h and hfile_internal.h.
Alter hfile_s3.c and hfile_libcurl.c to no longer include
hts_internal.h.

The definition of struct hts_json_token is left in hts_internal.h.
New functions to allocate this struct and access the contents are
added with declarations in textutils_internal.h.  This is to
enable changes to the structure in the future without breaking
existing plug-ins that use it.

Fixes #623.