### PR TITLE
Fix end-of-range check & setting fd->eof in cram_next_slice()

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2941,7 +2941,8 @@ static cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
 	if (fd->range.refid != -2) {
 	    while (c->ref_seq_id != -2 &&
 		   (c->ref_seq_id < fd->range.refid ||
-		    c->ref_seq_start + c->ref_seq_span-1 < fd->range.start)) {
+                    (fd->range.refid >= 0 && c->ref_seq_id  == fd->range.refid
+                     && c->ref_seq_start + c->ref_seq_span-1 < fd->range.start))) {
 		if (0 != cram_seek(fd, c->length, SEEK_CUR))
 		    return NULL;
 		cram_free_container(fd->ctr);
@@ -2951,8 +2952,10 @@ static cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
 		} while (c->length == 0);
 	    }
 
-	    if (c->ref_seq_id != -2 && c->ref_seq_id != fd->range.refid)
+	    if (c->ref_seq_id != -2 && c->ref_seq_id != fd->range.refid) {
+                fd->eof = 1;
 		return NULL;
+            }
 	}
 
 	if (!(c->comp_hdr_block = cram_read_block(fd)))


### PR DESCRIPTION
In the loop that skips over containers in range queries, check that the range and container references are the same before comparing the start and end positions. Also check that range.refid is not -1 (unmapped), as in that case the start and end positions may not be valid.

Ensure that fd->eof is set when making range requests and the container found does not have the desired reference id.

Fixes #651

Also avoid accessing the bam record if cram_get_bam_seq() fails.  It's not likely to contain valid data. Spotted when looking into the problem above.  Instances fixed in cram_readrec(), sam_bam_cram_readrec() and sam_read1().

