### PR TITLE
Fixes crashes caused when decoding some cramtools produced CRAM files.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1248,9 +1248,9 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 
 	if (ncigar+2 >= cigar_alloc) {
 	    cigar_alloc = cigar_alloc ? cigar_alloc*2 : 1024;
-	    s->cigar = cigar;
 	    if (!(cigar = realloc(cigar, cigar_alloc * sizeof(*cigar))))
 		return -1;
+	    s->cigar = cigar;
 	}
 
 	if (ds & CRAM_FC) {
@@ -1819,9 +1819,9 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 
 	if (ncigar+1 >= cigar_alloc) {
 	    cigar_alloc = cigar_alloc ? cigar_alloc*2 : 1024;
-	    s->cigar = cigar;
 	    if (!(cigar = realloc(cigar, cigar_alloc * sizeof(*cigar))))
 		return -1;
+	    s->cigar = cigar;
 	}
 #ifdef USE_X
 	if (cig_len && cig_op != BAM_CBASE_MATCH) {
@@ -1849,9 +1849,9 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
     if (cig_len) {
 	if (ncigar >= cigar_alloc) {
 	    cigar_alloc = cigar_alloc ? cigar_alloc*2 : 1024;
-	    s->cigar = cigar;
 	    if (!(cigar = realloc(cigar, cigar_alloc * sizeof(*cigar))))
 		return -1;
+	    s->cigar = cigar;
 	}
 
 	cigar[ncigar++] = (cig_len<<4) + cig_op;


### PR DESCRIPTION
In cramtools it appears that the "N" cigar op doesn't update the end position for reference extents, meaning a long N can cause the slice header to be invalid.  If we only load the part of the reference listed in the header, we can then read beyond the end of this buffer.

This works around the bug reported here https://github.com/enasequence/cramtools/issues/65.

Note this bug only happened when using the standard Makefile (ie not ./configure).  This disables use of mmap, which avoided the problem by having the entire reference in memory instead of the requested region.  Also use of multi-threading caused the code to fetch the entire reference, also working around the issue.

Trivial example SAM file to trigger the issue:

```
@HD	VN:1.5	SO:coordinate
@SQ	SN:18	LN:78077248	M5:b15d4b2d29dde9d3e4f93d1d0f2cbc9c
s1	0	18	50006	0	1M1N1M	*	0	0	CG	*
```

Build the cram file using:

```
java -jar ~/work/picard.jar SamFormatConverter R=$HREF I=bug.sam O=bug.picard.cram
samtools view -C bug.sam -o bug.samtools.cram
```

Looking at the CRAM slice headers using cram_dump (from staden io_lib: todo - add as a misc tool to samtools) shows the difference:

```
$ cram_dump bug.picard.cram |egrep -A7 '^Container'|head -8
Container pos 1081 size 1326
    Ref id:            0
    Ref pos:           50006 + 2
    Rec counter:       0
    No. recs:          1
    No. bases          2
    No. blocks:        31
    No. landmarks:     1
$ cram_dump bug.samtools.cram |egrep -A7 '^Container'|head -8
Container pos 222 size 383
    Ref id:            0
    Ref pos:           50006 + 3
    Rec counter:       0
    No. recs:          1
    No. bases          2
    No. blocks:        7
    No. landmarks:     1
```

Also try CT (match) instead of CG, and try 1M1N1D1M cigar too.  Best observed using valgrind to check for the read 1 past end of array.