### PR TITLE
Fix a couple of minor rANS issues with handling invalid data

### DIFF
--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -208,7 +208,8 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
     /* Load in the static tables */
     unsigned char *cp = in + 9;
     unsigned char *cp_end = in + in_size;
-    int i, j, x, out_sz, in_sz, rle;
+    int i, j, x, rle;
+    unsigned int out_sz, in_sz;
     char *out_buf;
     ari_decoder D;
     RansDecSymbol syms[256];
@@ -569,7 +570,8 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
     /* Load in the static tables */
     unsigned char *cp = in + 9;
     unsigned char *ptr_end = in + in_size;
-    int i, j = -999, x, out_sz, in_sz, rle_i, rle_j;
+    int i, j = -999, x, rle_i, rle_j;
+    unsigned int out_sz, in_sz;
     char *out_buf = NULL;
     ari_decoder *D = NULL;              /* D[256] */
     RansDecSymbol (*syms)[256] = NULL;  /* syms[256][256] */
@@ -590,7 +592,12 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
     D = calloc(256, sizeof(*D));
     if (!D) goto cleanup;
     syms = malloc(256 * sizeof(*syms));
+    if (!syms) goto cleanup;
+    /* These memsets prevent illegal memory access in syms due to
+       broken compressed data.  As D is calloc'd, all illegal transitions
+       will end up in either row or column 0 of syms. */
     memset(&syms[0], 0, sizeof(syms[0]));
+    for (i = 1; i < 256; i++) memset(&syms[i][0], 0, sizeof(syms[0][0]));
 
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 


### PR DESCRIPTION
In rans_uncompress_O0() and rans_uncompress_O1(), change in_sz and
out_sz to unsigned integers.  Prevents attempts to allocate
negative-size memory if out_sz bit 31 gets set.

In rans_uncompress_O1(), zero column 0 of `syms` as well as row 0
to prevent uninitialized memory reads on invalid input.  This
should be sufficient protection.  The decode array is calloc'd
so any invalid rANS state will decode to 0 and the next `syms`
look-up will go to column 0 as a result.  Any look-up in the
decode array that does not return 0 will have a corresponding
entry in `syms` due to the way they are set up together.  So as
long as the unused entries in row and column 0 of `syms` have been
zeroed the rANS codec should not try to access any other
uninitialized locations.