### PR TITLE
Fix warnings on various platforms

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ build_script:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
-  - "sh -lc \"aclocal && autoheader && autoconf && ./configure && make -j2\""
+  - "sh -lc \"aclocal && autoheader && autoconf && ./configure CFLAGS='-Wno-format -g -O2' && make -j2\""
 
 #build_script:
 #  - make

--- a/bgzf.c
+++ b/bgzf.c
@@ -1317,7 +1317,6 @@ restart:
             pthread_exit(NULL);
         }
     }
-    return NULL;
 }
 
 int bgzf_thread_pool(BGZF *fp, hts_tpool *pool, int qsize) {

--- a/bgzf.c
+++ b/bgzf.c
@@ -1250,7 +1250,7 @@ restart:
             pthread_cond_signal(&mt->command_c);
             pthread_mutex_unlock(&mt->command_m);
             hts_tpool_process_destroy(mt->out_queue);
-            pthread_exit(NULL);
+            return NULL;
 
         default:
             break;
@@ -1272,7 +1272,7 @@ restart:
         // We tear down the multi-threaded decoder and revert to the old code.
         hts_tpool_dispatch(mt->pool, mt->out_queue, bgzf_nul_func, j);
         hts_tpool_process_ref_decr(mt->out_queue);
-        pthread_exit(&j->errcode);
+        return &j->errcode;
     }
 
     // Dispatch an empty block so EOF is spotted.
@@ -1283,7 +1283,7 @@ restart:
     hts_tpool_dispatch(mt->pool, mt->out_queue, bgzf_nul_func, j);
     if (j->errcode != 0) {
         hts_tpool_process_destroy(mt->out_queue);
-        pthread_exit(&j->errcode);
+        return &j->errcode;
     }
 
     // We hit EOF so can stop reading, but we may get a subsequent
@@ -1314,7 +1314,7 @@ restart:
             pthread_cond_signal(&mt->command_c);
             pthread_mutex_unlock(&mt->command_m);
             hts_tpool_process_destroy(mt->out_queue);
-            pthread_exit(NULL);
+            return NULL;
         }
     }
 }

--- a/cram/cram_codecs.h
+++ b/cram/cram_codecs.h
@@ -108,6 +108,9 @@ typedef struct {
 /*
  * A generic codec structure.
  */
+#ifdef __SUNPRO_C
+#  pragma error_messages(off, E_ANONYMOUS_UNION_DECL)
+#endif
 typedef struct cram_codec {
     enum cram_encoding codec;
     cram_block *out;
@@ -135,6 +138,9 @@ typedef struct cram_codec {
 	cram_beta_decoder            e_beta;
     };
 } cram_codec;
+#ifdef __SUNPRO_C
+#  pragma error_messages(default, E_ANONYMOUS_UNION_DECL)
+#endif
 
 const char *cram_encoding2str(enum cram_encoding t);
 

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1152,11 +1152,11 @@ static int lossy_read_names(cram_fd *fd, cram_container *c, cram_slice *s,
 	    uint64_t i64;
 	    struct {
 		int32_t e,c; // expected & observed counts.
-	    };
+	    } counts;
 	} u;
 
 	e = expected_template_count(b);
-	u.e = e; u.c = 1;
+	u.counts.e = e; u.counts.c = 1;
 
 	k = kh_put(m_s2u64, names, bam_name(b), &n);
 	if (n == -1)
@@ -1165,13 +1165,13 @@ static int lossy_read_names(cram_fd *fd, cram_container *c, cram_slice *s,
 	if (n == 0) {
 	    // not a new name
 	    u.i64 = kh_val(names, k);
-	    if (u.e != e) {
+	    if (u.counts.e != e) {
 		// different expectation or already hit the max
 		//fprintf(stderr, "Err computing no. %s recs\n", bam_name(b));
 		kh_val(names, k) = 0;
 	    } else {
-		u.c++;
-		if (u.e == u.c) {
+		u.counts.c++;
+		if (u.counts.e == u.counts.c) {
 		    // Reached expected count.
 		    kh_val(names, k) = -1;
 		} else {

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -142,10 +142,10 @@ static int cram_block_compression_hdr_set_DS(cram_block_compression_hdr *ch,
 	return 0;
 
     default:
-	return -1;
+	break;
     }
 
-    return 0;
+    return -1;
 }
 
 int cram_block_compression_hdr_set_rg(cram_block_compression_hdr *ch, int new_rg) {

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3695,7 +3695,7 @@ static void full_path(char *out, char *in) {
     size_t in_l = strlen(in);
     if (*in == '/' ||
 	// Windows paths
-	(in_l > 3 && toupper(*in) >= 'A'  && toupper(*in) <= 'Z' &&
+	(in_l > 3 && toupper_c(*in) >= 'A'  && toupper_c(*in) <= 'Z' &&
 	 in[1] == ':' && (in[2] == '/' || in[2] == '\\'))) {
 	strncpy(out, in, PATH_MAX);
 	out[PATH_MAX-1] = 0;

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -469,68 +469,66 @@ typedef struct cram_record {
  * A feature is a base difference, used for the sequence reference encoding.
  * (We generate these internally when writing CRAM.)
  */
-typedef struct cram_feature {
-    union {
-	struct {
-	    int pos;
-	    int code;
-	    int base;    // substitution code
-	} X;
-	struct {
-	    int pos;
-	    int code;
-	    int base;    // actual base & qual
-	    int qual;
-	} B;
-	struct {
-	    int pos;
-	    int code;
-	    int seq_idx; // index to s->seqs_blk
-	    int len;
-	} b;
-	struct {
-	    int pos;
-	    int code;
-	    int qual;
-	} Q;
-	struct {
-	    int pos;
-	    int code;
-	    int len;
-	    int seq_idx; // soft-clip multiple bases
-	} S;
-	struct {
-	    int pos;
-	    int code;
-	    int len;
-	    int seq_idx; // insertion multiple bases
-	} I;
-	struct {
-	    int pos;
-	    int code;
-	    int base; // insertion single base
-	} i;
-	struct {
-	    int pos;
-	    int code;
-	    int len;
-	} D;
-	struct {
-	    int pos;
-	    int code;
-	    int len;
-	} N;
-	struct {
-	    int pos;
-	    int code;
-	    int len;
-	} P;
-	struct {
-	    int pos;
-	    int code;
-	    int len;
-	} H;
-    };
+typedef union cram_feature {
+    struct {
+        int pos;
+        int code;
+        int base;    // substitution code
+    } X;
+    struct {
+        int pos;
+        int code;
+        int base;    // actual base & qual
+        int qual;
+    } B;
+    struct {
+        int pos;
+        int code;
+        int seq_idx; // index to s->seqs_blk
+        int len;
+    } b;
+    struct {
+        int pos;
+        int code;
+        int qual;
+    } Q;
+    struct {
+        int pos;
+        int code;
+        int len;
+        int seq_idx; // soft-clip multiple bases
+    } S;
+    struct {
+        int pos;
+        int code;
+        int len;
+        int seq_idx; // insertion multiple bases
+    } I;
+    struct {
+        int pos;
+        int code;
+        int base; // insertion single base
+    } i;
+    struct {
+        int pos;
+        int code;
+        int len;
+    } D;
+    struct {
+        int pos;
+        int code;
+        int len;
+    } N;
+    struct {
+        int pos;
+        int code;
+        int len;
+    } P;
+    struct {
+        int pos;
+        int code;
+        int len;
+    } H;
 } cram_feature;
 
 /*
@@ -844,7 +842,7 @@ enum cram_fields {
 
 /* Internal only */
 #define CRAM_FLAG_STATS_ADDED          (1<<30)
-#define CRAM_FLAG_DISCARD_NAME         (1<<31)
+#define CRAM_FLAG_DISCARD_NAME         (1U<<31)
 
 #ifdef __cplusplus
 }

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -459,8 +459,8 @@ static int read_auth_plain(auth_token *tok, hFILE *auth_fp) {
     if (kgetline(&line, (char * (*)(char *, int, void *)) hgets, auth_fp) < 0) goto error;
     if (kputc('\0', &line) < 0) goto error;
 
-    for (start = line.s; *start && isspace(*start); start++) {}
-    for (end = start; *end && !isspace(*end); end++) {}
+    for (start = line.s; *start && isspace_c(*start); start++) {}
+    for (end = start; *end && !isspace_c(*end); end++) {}
 
     if (end > start) {
         if (kputs("Authorization: Bearer ", &token) < 0) goto error;

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -63,7 +63,7 @@ typedef struct {
 } auth_token;
 
 // For the authorization header cache
-KHASH_MAP_INIT_STR(auth_map, auth_token *);
+KHASH_MAP_INIT_STR(auth_map, auth_token *)
 
 // Curl-compatible header linked list
 typedef struct {

--- a/htslib/kseq.h
+++ b/htslib/kseq.h
@@ -32,6 +32,14 @@
 #include <string.h>
 #include <stdlib.h>
 
+#ifndef klib_unused
+#if (defined __clang__ && __clang_major__ >= 3) || (defined __GNUC__ && __GNUC__ >= 3)
+#define klib_unused __attribute__ ((__unused__))
+#else
+#define klib_unused
+#endif
+#endif /* klib_unused */
+
 #define KS_SEP_SPACE 0 // isspace(): \t, \n, \v, \f, \r
 #define KS_SEP_TAB   1 // isspace() && !' '
 #define KS_SEP_LINE  2 // line separator: "\n" (Unix) or "\r\n" (Windows)
@@ -65,7 +73,7 @@
 	}
 
 #define __KS_INLINED(__read) \
-	static inline int ks_getc(kstream_t *ks) \
+	static inline klib_unused int ks_getc(kstream_t *ks) \
 	{ \
 		if (ks->is_eof && ks->begin >= ks->end) return -1; \
 		if (ks->begin >= ks->end) { \
@@ -76,7 +84,7 @@
         ks->seek_pos++; \
 		return (int)ks->buf[ks->begin++]; \
 	} \
-	static inline int ks_getuntil(kstream_t *ks, int delimiter, kstring_t *str, int *dret) \
+	static inline klib_unused int ks_getuntil(kstream_t *ks, int delimiter, kstring_t *str, int *dret) \
 	{ return ks_getuntil2(ks, delimiter, str, dret, 0); }
 
 #ifndef KSTRING_T

--- a/htslib/ksort.h
+++ b/htslib/ksort.h
@@ -82,8 +82,9 @@ typedef struct {
 
 #define KSORT_SWAP(type_t, a, b) { register type_t t=(a); (a)=(b); (b)=t; }
 
-#define KSORT_INIT(name, type_t, __sort_lt)								\
-	void ks_mergesort_##name(size_t n, type_t array[], type_t temp[])	\
+#define KSORT_INIT(name, type_t, __sort_lt)	KSORT_INIT_(_ ## name, type_t, __sort_lt)
+#define KSORT_INIT_(name, type_t, __sort_lt)								\
+	void ks_mergesort##name(size_t n, type_t array[], type_t temp[])	\
 	{																	\
 		type_t *a2[2], *a, *b;											\
 		int curr, shift;												\
@@ -131,7 +132,7 @@ typedef struct {
 		}																\
 		if (temp == 0) free(a2[1]);										\
 	}																	\
-	void ks_heapadjust_##name(size_t i, size_t n, type_t l[])			\
+	void ks_heapadjust##name(size_t i, size_t n, type_t l[])			\
 	{																	\
 		size_t k = i;													\
 		type_t tmp = l[i];												\
@@ -142,21 +143,21 @@ typedef struct {
 		}																\
 		l[i] = tmp;														\
 	}																	\
-	void ks_heapmake_##name(size_t lsize, type_t l[])					\
+	void ks_heapmake##name(size_t lsize, type_t l[])					\
 	{																	\
 		size_t i;														\
 		for (i = (lsize >> 1) - 1; i != (size_t)(-1); --i)				\
-			ks_heapadjust_##name(i, lsize, l);							\
+			ks_heapadjust##name(i, lsize, l);							\
 	}																	\
-	void ks_heapsort_##name(size_t lsize, type_t l[])					\
+	void ks_heapsort##name(size_t lsize, type_t l[])					\
 	{																	\
 		size_t i;														\
 		for (i = lsize - 1; i > 0; --i) {								\
 			type_t tmp;													\
-			tmp = *l; *l = l[i]; l[i] = tmp; ks_heapadjust_##name(0, i, l); \
+			tmp = *l; *l = l[i]; l[i] = tmp; ks_heapadjust##name(0, i, l); \
 		}																\
 	}																	\
-	static inline void __ks_insertsort_##name(type_t *s, type_t *t)		\
+	static inline void __ks_insertsort##name(type_t *s, type_t *t)		\
 	{																	\
 		type_t *i, *j, swap_tmp;										\
 		for (i = s + 1; i < t; ++i)										\
@@ -164,7 +165,7 @@ typedef struct {
 				swap_tmp = *j; *j = *(j-1); *(j-1) = swap_tmp;			\
 			}															\
 	}																	\
-	void ks_combsort_##name(size_t n, type_t a[])						\
+	void ks_combsort##name(size_t n, type_t a[])						\
 	{																	\
 		const double shrink_factor = 1.2473309501039786540366528676643; \
 		int do_swap;													\
@@ -184,9 +185,9 @@ typedef struct {
 				}														\
 			}															\
 		} while (do_swap || gap > 2);									\
-		if (gap != 1) __ks_insertsort_##name(a, a + n);					\
+		if (gap != 1) __ks_insertsort##name(a, a + n);					\
 	}																	\
-	void ks_introsort_##name(size_t n, type_t a[])						\
+	void ks_introsort##name(size_t n, type_t a[])						\
 	{																	\
 		int d;															\
 		ks_isort_stack_t *top, *stack;									\
@@ -204,7 +205,7 @@ typedef struct {
 		while (1) {														\
 			if (s < t) {												\
 				if (--d == 0) {											\
-					ks_combsort_##name(t - s + 1, s);					\
+					ks_combsort##name(t - s + 1, s);					\
 					t = s;												\
 					continue;											\
 				}														\
@@ -231,7 +232,7 @@ typedef struct {
 			} else {													\
 				if (top == stack) {										\
 					free(stack);										\
-					__ks_insertsort_##name(a, a+n);						\
+					__ks_insertsort##name(a, a+n);						\
 					return;												\
 				} else { --top; s = (type_t*)top->left; t = (type_t*)top->right; d = top->depth; } \
 			}															\
@@ -239,7 +240,7 @@ typedef struct {
 	}																	\
 	/* This function is adapted from: http://ndevilla.free.fr/median/ */ \
 	/* 0 <= kk < n */													\
-	type_t ks_ksmall_##name(size_t n, type_t arr[], size_t kk)			\
+	type_t ks_ksmall##name(size_t n, type_t arr[], size_t kk)			\
 	{																	\
 		type_t *low, *high, *k, *ll, *hh, *mid;							\
 		low = arr; high = arr + n - 1; k = arr + kk;					\
@@ -266,7 +267,7 @@ typedef struct {
 			if (hh >= k) high = hh - 1;									\
 		}																\
 	}																	\
-	void ks_shuffle_##name(size_t n, type_t a[])						\
+	void ks_shuffle##name(size_t n, type_t a[])						\
 	{																	\
 		int i, j;														\
 		for (i = n; i > 1; --i) {										\
@@ -290,7 +291,7 @@ typedef struct {
 
 typedef const char *ksstr_t;
 
-#define KSORT_INIT_GENERIC(type_t) KSORT_INIT(type_t, type_t, ks_lt_generic)
+#define KSORT_INIT_GENERIC(type_t) KSORT_INIT_(_ ## type_t, type_t, ks_lt_generic)
 #define KSORT_INIT_STR KSORT_INIT(str, ksstr_t, ks_lt_str)
 
 #ifdef __cplusplus

--- a/knetfile.c
+++ b/knetfile.c
@@ -229,7 +229,7 @@ static int kftp_get_response(knetFile *ftp)
 		}
 		ftp->response[n++] = c;
 		if (c == '\n') {
-			if (n >= 4 && isdigit(ftp->response[0]) && isdigit(ftp->response[1]) && isdigit(ftp->response[2])
+			if (n >= 4 && isdigit((int)((unsigned char) ftp->response[0])) && isdigit((int)((unsigned char) ftp->response[1])) && isdigit((int)((unsigned char) ftp->response[2]))
 				&& ftp->response[3] != '-') break;
 			n = 0;
 			continue;

--- a/knetfile.c
+++ b/knetfile.c
@@ -87,6 +87,9 @@ static int socket_wait(int fd, int is_read)
 /* This function does not work with Windows due to the lack of
  * getaddrinfo() in winsock. It is addapted from an example in "Beej's
  * Guide to Network Programming" (http://beej.us/guide/bgnet/). */
+#  ifdef __SUNPRO_C
+#    pragma error_messages(off, E_END_OF_LOOP_CODE_NOT_REACHED)
+#  endif
 static int socket_connect(const char *host, const char *port)
 {
 #define __err_connect(func) do { perror(func); freeaddrinfo(res); return -1; } while (0)
@@ -110,6 +113,9 @@ static int socket_connect(const char *host, const char *port)
 	freeaddrinfo(res);
 	return fd;
 }
+#  ifdef __SUNPRO_C
+#    pragma error_messages(off, E_END_OF_LOOP_CODE_NOT_REACHED)
+#  endif
 #else
 /* MinGW's printf has problem with "%lld" */
 char *int64tostr(char *buf, int64_t x)

--- a/kstring.c
+++ b/kstring.c
@@ -228,10 +228,12 @@ int ksplit_core(char *s, int delimiter, int *_max, int **_offsets)
 
 	for (i = 0, last_char = last_start = 0; i <= l; ++i) {
 		if (delimiter == 0) {
-			if (isspace(s[i]) || s[i] == 0) {
-				if (isgraph(last_char)) __ksplit_aux; // the end of a field
+			if (isspace((int)((unsigned char) s[i])) || s[i] == 0) {
+				if (isgraph(last_char))
+                    __ksplit_aux; // the end of a field
 			} else {
-				if (isspace(last_char) || last_char == 0) last_start = i;
+				if (isspace(last_char) || last_char == 0)
+                    last_start = i;
 			}
 		} else {
 			if (s[i] == delimiter || s[i] == 0) {
@@ -240,7 +242,7 @@ int ksplit_core(char *s, int delimiter, int *_max, int **_offsets)
 				if (last_char == delimiter || last_char == 0) last_start = i;
 			}
 		}
-		last_char = s[i];
+		last_char = (int)((unsigned char)s[i]);
 	}
 	*_max = max; *_offsets = offsets;
 	return n;

--- a/sam.c
+++ b/sam.c
@@ -1935,9 +1935,12 @@ char *sam_open_mode_opts(const char *fn,
             free(mode_opts);
             return NULL;
         }
-        return sam_open_mode(cp, fn, ext+1)
-            ? (free(mode_opts), NULL)
-            : mode_opts;
+        if (sam_open_mode(cp, fn, ext+1) == 0) {
+            return mode_opts;
+        } else {
+            free(mode_opts);
+            return NULL;
+        }
     }
 
     if ((opts = strchr(format, ','))) {

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -69,25 +69,25 @@ char *bcf_sr_strerror(int errnum)
     switch (errnum)
     {
         case open_failed:
-            return strerror(errno); break;
+            return strerror(errno);
         case not_bgzf:
-            return "not compressed with bgzip"; break;
+            return "not compressed with bgzip";
         case idx_load_failed:
-            return "could not load index"; break;
+            return "could not load index";
         case file_type_error:
-            return "unknown file type"; break;
+            return "unknown file type";
         case api_usage_error:
-            return "API usage error"; break;
+            return "API usage error";
         case header_error:
-            return "could not parse header"; break;
+            return "could not parse header";
         case no_eof:
-            return "no BGZF EOF marker; file may be truncated"; break;
+            return "no BGZF EOF marker; file may be truncated";
         case no_memory:
-            return "Out of memory"; break;
+            return "Out of memory";
         case vcf_parse_error:
-            return "VCF parse error"; break;
+            return "VCF parse error";
         case bcf_read_error:
-            return "BCF read error"; break;
+            return "BCF read error";
         default: return "";
     }
 }

--- a/tabix.c
+++ b/tabix.c
@@ -542,5 +542,4 @@ int main(int argc, char *argv[])
         if ( tbx_index_build(fname, min_shift, &conf) ) error("tbx_index_build failed: %s\n", fname);
         return 0;
     }
-    return 0;
 }

--- a/test/test.pl
+++ b/test/test.pl
@@ -165,7 +165,7 @@ sub test_cmd
         open(my $fh,'>',"$$opts{path}/$args{out}") or error("$$opts{path}/$args{out}: $!");
         print $fh $out;
         close($fh);
-        my ($ret,$out) = _cmd("diff -q $$opts{path}/$args{out} $$opts{path}/$args{out}.old");
+        my ($ret,$out) = _cmd("cmp $$opts{path}/$args{out} $$opts{path}/$args{out}.old");
         if ( !$ret && $out eq '' ) { unlink("$$opts{path}/$args{out}.old"); }
         else
         {
@@ -408,7 +408,7 @@ sub test_rebgzip
     write_multiblock_bgzf($mb, \@frags);
 
     # See if it really does match
-    my ($ret, $out) = _cmd("diff -q $mb $$opts{path}/bgziptest.txt.gz");
+    my ($ret, $out) = _cmd("cmp $mb $$opts{path}/bgziptest.txt.gz");
 
     if (!$ret && $out eq '') { # If it does, use the original
 	test_cmd($opts, %args, out => "bgziptest.txt.gz",

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -584,8 +584,6 @@ static void *tpool_worker(void *arg) {
 
         pthread_mutex_unlock(&p->pool_m);
     }
-
-    return NULL;
 }
 
 static void wake_next_worker(hts_tpool_process *q, int locked) {

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -502,7 +502,7 @@ static void *tpool_worker(void *arg) {
             fprintf(stderr, "%d: Shutting down\n", worker_id(p));
 #endif
             pthread_mutex_unlock(&p->pool_m);
-            pthread_exit(NULL);
+            return NULL;
         }
 
         if (!work_to_do) {

--- a/vcf.c
+++ b/vcf.c
@@ -453,7 +453,7 @@ int bcf_hdr_register_hrec(bcf_hdr_t *hdr, bcf_hrec_t *hrec)
 
     // INFO/FILTER/FORMAT
     char *id = NULL;
-    uint32_t type = -1, var = -1;
+    uint32_t type = UINT32_MAX, var = UINT32_MAX;
     int num = -1, idx = -1;
     for (i=0; i<hrec->nkeys; i++)
     {
@@ -3697,7 +3697,7 @@ bcf_info_t *bcf_get_info_id(bcf1_t *line, const int id)
 
 int bcf_get_info_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, void **dst, int *ndst, int type)
 {
-    int i,j, tag_id = bcf_hdr_id2int(hdr, BCF_DT_ID, tag);
+    int i, ret = -4, tag_id = bcf_hdr_id2int(hdr, BCF_DT_ID, tag);
     if ( !bcf_hdr_idinfo_exists(hdr,BCF_HL_INFO,tag_id) ) return -1;    // no such INFO field in the header
     if ( bcf_hdr_id2type(hdr,BCF_HL_INFO,tag_id)!=type ) return -2;     // expected different type
 
@@ -3730,18 +3730,19 @@ int bcf_get_info_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, voi
         *dst  = realloc(*dst, *ndst * size1);
     }
 
-    #define BRANCH(type_t, convert, is_missing, is_vector_end, set_missing, set_regular, out_type_t) { \
+    #define BRANCH(type_t, convert, is_missing, is_vector_end, set_missing, set_regular, out_type_t) do { \
         out_type_t *tmp = (out_type_t *) *dst; \
+        int j; \
         for (j=0; j<info->len; j++) \
         { \
             type_t p = convert(info->vptr + j * sizeof(type_t)); \
-            if ( is_vector_end ) return j; \
+            if ( is_vector_end ) break; \
             if ( is_missing ) set_missing; \
             else set_regular; \
             tmp++; \
         } \
-        return j; \
-    }
+        ret = j; \
+    } while (0)
     switch (info->type) {
         case BCF_BT_INT8:  BRANCH(int8_t,  le_to_i8,  p==bcf_int8_missing,  p==bcf_int8_vector_end,  *tmp=bcf_int32_missing, *tmp=p, int32_t); break;
         case BCF_BT_INT16: BRANCH(int16_t, le_to_i16, p==bcf_int16_missing, p==bcf_int16_vector_end, *tmp=bcf_int32_missing, *tmp=p, int32_t); break;
@@ -3750,7 +3751,7 @@ int bcf_get_info_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, voi
         default: hts_log_error("Unexpected type %d", info->type); exit(1);
     }
     #undef BRANCH
-    return -4;  // this can never happen
+    return ret;  // set by BRANCH
 }
 
 int bcf_get_format_string(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, char ***dst, int *ndst)

--- a/vcf.c
+++ b/vcf.c
@@ -366,7 +366,7 @@ bcf_hrec_t *bcf_hdr_parse_line(const bcf_hdr_t *h, const char *line, int *len)
     // Skip to end of line
     int nonspace = 0;
     p = q;
-    while ( *q && *q!='\n' ) { nonspace |= !isspace(*q); q++; }
+    while ( *q && *q!='\n' ) { nonspace |= !isspace_c(*q); q++; }
     if (nonspace) {
         hts_log_warning("Dropped trailing junk from header line '%.*s'", (int) (q - line), line);
     }

--- a/vcfutils.c
+++ b/vcfutils.c
@@ -202,7 +202,7 @@ int bcf_trim_alleles(const bcf_hdr_t *header, bcf1_t *line)
         case BCF_BT_INT32: BRANCH(int32_t, bcf_int32_vector_end); break;
         default: hts_log_error("Unexpected GT %d at %s:%d",
             gt->type, header->id[BCF_DT_CTG][line->rid].key, line->pos + 1);
-            goto clean; break;
+            goto clean;
     }
     #undef BRANCH
 
@@ -391,7 +391,7 @@ int bcf_remove_allele_set(const bcf_hdr_t *header, bcf1_t *line, const struct kb
                 case BCF_BT_INT16: BRANCH(int16_t, p[0]==bcf_int16_missing); break;
                 case BCF_BT_INT32: BRANCH(int32_t, p[0]==bcf_int32_missing); break;
                 case BCF_BT_FLOAT: BRANCH(float,   bcf_float_is_missing(p[0])); break;
-                default: hts_log_error("Unexpected type %d", info->type); goto err; break;
+                default: hts_log_error("Unexpected type %d", info->type); goto err;
             }
             #undef BRANCH
             if (missing) continue; // could remove this INFO tag?
@@ -692,7 +692,7 @@ int bcf_remove_allele_set(const bcf_hdr_t *header, bcf1_t *line, const struct kb
                 case BCF_BT_INT16: BRANCH(int16_t, p[0]==bcf_int16_missing); break;
                 case BCF_BT_INT32: BRANCH(int32_t, p[0]==bcf_int32_missing); break;
                 case BCF_BT_FLOAT: BRANCH(float,   bcf_float_is_missing(p[0])); break;
-                default: hts_log_error("Unexpected type %d", fmt->type); goto err; break;
+                default: hts_log_error("Unexpected type %d", fmt->type); goto err;
             }
             #undef BRANCH
             if (all_missing) continue; // could remove this FORMAT tag?


### PR DESCRIPTION
SunStudio compiler warnings:
- Unreachable code
- Anonymous unions
- Integer conversions
- Suppressed 'end of loop not reached' error in a macro.  SunStudio annoyingly does not like `do { return; } while (0)`.

MinGW-w64:
- No return statement in function returning non-void.  Possibly due to mingw-w64's gcc not knowing that pthread_exit() can't return.
- Suppressed -Wformat warnings in appveyor config.  These are just broken on mingw-w64.

NetBSD:
- Warnings about char passed to isspace() ...etc.
- Fix unintended macro expansion in KSORT_INIT_GENERIC().  This is likely a bug as it caused the wrong symbols to be generated, and it's not entirely clear how the result got linked.

clang:
- Unused function warnings in kseq.