### PR TITLE
Improved round-trip support for NM and MD tags in CRAM.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,13 @@ Noteworthy changes in release a.b
   decompression.  Results vary by CPU but compression should be twice as fast
   and decompression faster.
   
+* CRAM encoding now stored MD and NM tags verbatim where the reference
+  contains 'N' characters, to work around ambiguities in the SAM
+  specification (samtools #717/762).
+  Also added "store_md" and "store_nm" cram-options for forcing these
+  tags to be stored at all locations.  This is best when combined with
+  a subsequent decode_md=0 option while reading CRAM.
+
 * Multiple CRAM bug fixes, including a fix to free and the subsequent reuse of
   references with `-T ref.fa`. (#654; reported by Chris Saunders)
 

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -2072,7 +2072,8 @@ static char *cram_encode_aux_1_0(cram_fd *fd, bam_seq_t *b, cram_container *c,
  *         NULL on failure or no rg present (FIXME)
  */
 static char *cram_encode_aux(cram_fd *fd, bam_seq_t *b, cram_container *c,
-			     cram_slice *s, cram_record *cr) {
+			     cram_slice *s, cram_record *cr,
+			     int verbatim_NM, int verbatim_MD) {
     char *aux, *orig, *rg = NULL;
     int aux_size = bam_get_l_aux(b);
     cram_block *td_b = c->comp_hdr->TD_blk;
@@ -2095,7 +2096,7 @@ static char *cram_encode_aux(cram_fd *fd, bam_seq_t *b, cram_container *c,
 
 	// MD:Z
 	if (aux[0] == 'M' && aux[1] == 'D' && aux[2] == 'Z') {
-	    if (cr->len && !fd->no_ref && !(cr->flags & BAM_FUNMAP)) {
+	    if (cr->len && !fd->no_ref && !(cr->flags & BAM_FUNMAP) && !verbatim_MD) {
 		while (*aux++);
 		continue;
 	    }
@@ -2103,7 +2104,7 @@ static char *cram_encode_aux(cram_fd *fd, bam_seq_t *b, cram_container *c,
 
 	// NM:i
 	if (aux[0] == 'N' && aux[1] == 'M') {
-	    if (cr->len && !fd->no_ref && !(cr->flags & BAM_FUNMAP)) {
+	    if (cr->len && !fd->no_ref && !(cr->flags & BAM_FUNMAP) && !verbatim_NM) {
 		switch(aux[2]) {
 		case 'A': case 'C': case 'c': aux+=4; break;
 		case 'S': case 's':           aux+=5; break;
@@ -2516,6 +2517,14 @@ static int process_one_read(cram_fd *fd, cram_container *c,
     char *cp, *rg;
     char *ref, *seq, *qual;
 
+    // Any places with N in seq and/or reference can lead to ambiguous
+    // interpretation of the SAM NM:i tag.  So we store these verbatim
+    // to ensure valid data round-trips the same regardless of who
+    // defines it as valid.
+    // Similarly when alignments go beyond end of the reference.
+    int verbatim_NM = fd->store_nm;
+    int verbatim_MD = fd->store_md;
+
     // FIXME: multi-ref containers
 
     ref = c->ref;
@@ -2524,33 +2533,6 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 
     //fprintf(stderr, "%s => %d\n", rg ? rg : "\"\"", cr->rg);
 
-    // Fields to resolve later
-    //cr->mate_line;    // index to another cram_record
-    //cr->mate_flags;   // MF
-    //cr->ntags;        // TC
-    cr->ntags      = 0; //cram_stats_add(c->stats[DS_TC], cr->ntags);
-    if (CRAM_MAJOR_VERS(fd->version) == 1)
-	rg = cram_encode_aux_1_0(fd, b, c, s, cr);
-    else
-	rg = cram_encode_aux(fd, b, c, s, cr);
-
-    //cr->aux_size = b->blk_size - ((char *)bam_aux(b) - (char *)&bam_ref(b));
-    //cr->aux = DSTRING_LEN(s->aux_ds);
-    //dstring_nappend(s->aux_ds, bam_aux(b), cr->aux_size);
-
-    /* Read group, identified earlier */
-    if (rg) {
-	SAM_RG *brg = sam_hdr_find_rg(fd->header, rg);
-	cr->rg = brg ? brg->id : -1;
-    } else if (CRAM_MAJOR_VERS(fd->version) == 1) {
-	SAM_RG *brg = sam_hdr_find_rg(fd->header, "UNKNOWN");
-	assert(brg);
-    } else {
-	cr->rg = -1;
-    }
-    cram_stats_add(c->stats[DS_RG], cr->rg);
-
-    
     cr->ref_id      = bam_ref(b);  cram_stats_add(c->stats[DS_RI], cr->ref_id);
     cram_stats_add(c->stats[DS_BF], fd->cram_flag_swap[cr->flags & 0xfff]);
 
@@ -2691,6 +2673,8 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 			return -1;
 		    }
 		    for (l = 0; l < end; l++) {
+			if (rp[l] == 'N' && sp[l] == 'N')
+			    verbatim_NM = verbatim_MD = 1;
 			if (rp[l] != sp[l]) {
 			    if (!sp[l])
 				break;
@@ -2739,6 +2723,7 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 			}
 		    } else {
 			/* off end of sequence or non-ref based output */
+			verbatim_NM = verbatim_MD = 1;
 			for (; l < cig_len && seq[spos]; l++, spos++) {
 			    if (cram_add_base(fd, c, s, cr, spos,
 					      seq[spos], qual[spos]))
@@ -2748,6 +2733,7 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 		    apos += cig_len;
 		} else if (!cr->len) {
 		    /* Seq "*" */
+		    verbatim_NM = verbatim_MD = 1;
 		    apos += cig_len;
 		    spos += cig_len;
 		}
@@ -2833,6 +2819,24 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 	    cram_stats_add(c->stats[DS_BA], seq[i]);
 	fake_qual = 0;
     }
+
+    cr->ntags      = 0; //cram_stats_add(c->stats[DS_TC], cr->ntags);
+    if (CRAM_MAJOR_VERS(fd->version) == 1)
+	rg = cram_encode_aux_1_0(fd, b, c, s, cr);
+    else
+	rg = cram_encode_aux(fd, b, c, s, cr, verbatim_NM, verbatim_MD);
+
+    /* Read group, identified earlier */
+    if (rg) {
+	SAM_RG *brg = sam_hdr_find_rg(fd->header, rg);
+	cr->rg = brg ? brg->id : -1;
+    } else if (CRAM_MAJOR_VERS(fd->version) == 1) {
+	SAM_RG *brg = sam_hdr_find_rg(fd->header, "UNKNOWN");
+	assert(brg);
+    } else {
+	cr->rg = -1;
+    }
+    cram_stats_add(c->stats[DS_RG], cr->rg);
 
     /*
      * Append to the qual block now. We do this here as

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -4120,6 +4120,8 @@ cram_fd *cram_dopen(hFILE *fp, const char *filename, const char *mode) {
     fd->multi_seq = -1;
     fd->unsorted   = 0;
     fd->shared_ref = 0;
+    fd->store_md = 0;
+    fd->store_nm = 0;
 
     fd->index       = NULL;
     fd->own_pool    = 0;
@@ -4522,6 +4524,14 @@ int cram_set_voption(cram_fd *fd, enum hts_fmt_option opt, va_list args) {
 	fd->required_fields = va_arg(args, int);
 	if (fd->range.refid != -2)
 	    fd->required_fields |= SAM_POS;
+	break;
+
+    case CRAM_OPT_STORE_MD:
+	fd->store_md = va_arg(args, int);
+	break;
+
+    case CRAM_OPT_STORE_NM:
+	fd->store_nm = va_arg(args, int);
 	break;
 
     case HTS_OPT_COMPRESSION_LEVEL:

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -724,6 +724,8 @@ typedef struct cram_fd {
     int use_lzma;
     int shared_ref;
     unsigned int required_fields;
+    int store_md;
+    int store_nm;
     cram_range range;
 
     // lookup tables, stored here so we can be trivially multi-threaded

--- a/hts.c
+++ b/hts.c
@@ -589,6 +589,14 @@ int hts_opt_add(hts_opt **opts, const char *c_arg) {
              strcmp(o->arg, "NAME_PREFIX") == 0)
         o->opt = CRAM_OPT_PREFIX, o->val.s = val;
 
+    else if (strcmp(o->arg, "store_md") == 0 ||
+             strcmp(o->arg, "store_md") == 0)
+        o->opt = CRAM_OPT_STORE_MD, o->val.i = atoi(val);
+
+    else if (strcmp(o->arg, "store_nm") == 0 ||
+             strcmp(o->arg, "store_nm") == 0)
+        o->opt = CRAM_OPT_STORE_NM, o->val.i = atoi(val);
+
     else if (strcmp(o->arg, "block_size") == 0 ||
              strcmp(o->arg, "BLOCK_SIZE") == 0)
         o->opt = HTS_OPT_BLOCK_SIZE, o->val.i = strtol(val, NULL, 0);

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -230,6 +230,8 @@ enum hts_fmt_option {
     CRAM_OPT_REQUIRED_FIELDS,
     CRAM_OPT_LOSSY_NAMES,
     CRAM_OPT_BASES_PER_SLICE,
+    CRAM_OPT_STORE_MD,
+    CRAM_OPT_STORE_NM,
 
     // General purpose
     HTS_OPT_COMPRESSION_LEVEL = 100,


### PR DESCRIPTION
See samtools/samtools#717 for discussion.

The NM tag is ambiguous and infact differs in implementation between
htsjdk and htslib.  Specifically N in both ref and seq is considered
to be a mismatch for samtools and a match in picard.

If we detect this case we now also store NM and MD verbatim, along
with the suspect case of falling off the end of the reference (who
knows what people write to these fields in that ill-defined case).

This makes it more likely that a round-trip from SAM -> CRAM -> SAM
will work even when the input SAM was produced via htsjdk.

To be ultra careful, we also add store_md and store_nm options to
always store this data verbatim.  When combined with decode_md (note
this implicitly also implies decode_nm) this means it is possible to
round-trip while keeping these fields perfect even when they are set
to complete hogwash that neither picard nor samtools accepts, and also
to distinguish between the case of some reads having these fields
while others do not.

For example:

    samtools view -O cram,store_md=1,store_nm=1 in.sam -o out.cram
    samtools view -I decode_md=0 out.cram -o out.cram.sam

I thought about having a join store_md field that covers NM too, but
there are reasons why we'd want to store NM verbatim and not MD such
as NM being tiny in comparison to MD and MD being more tightly defined
in the spec.