### PR TITLE
Add option to set compression level in bgzip

### DIFF
--- a/bgzip.c
+++ b/bgzip.c
@@ -73,24 +73,25 @@ static int bgzip_main_usage(void)
     fprintf(stderr, "Version: %s\n", hts_version());
     fprintf(stderr, "Usage:   bgzip [OPTIONS] [FILE] ...\n");
     fprintf(stderr, "Options:\n");
-    fprintf(stderr, "   -b, --offset INT        decompress at virtual file pointer (0-based uncompressed offset)\n");
-    fprintf(stderr, "   -c, --stdout            write on standard output, keep original files unchanged\n");
-    fprintf(stderr, "   -d, --decompress        decompress\n");
-    fprintf(stderr, "   -f, --force             overwrite files without asking\n");
-    fprintf(stderr, "   -h, --help              give this help\n");
-    fprintf(stderr, "   -i, --index             compress and create BGZF index\n");
-    fprintf(stderr, "   -I, --index-name FILE   name of BGZF index file [file.gz.gzi]\n");
-    fprintf(stderr, "   -r, --reindex           (re)index compressed file\n");
-    fprintf(stderr, "   -g, --rebgzip           use an index file to bgzip a file\n");
-    fprintf(stderr, "   -s, --size INT          decompress INT bytes (uncompressed size)\n");
-    fprintf(stderr, "   -@, --threads INT       number of compression threads to use [1]\n");
+    fprintf(stderr, "   -b, --offset INT           decompress at virtual file pointer (0-based uncompressed offset)\n");
+    fprintf(stderr, "   -c, --stdout               write on standard output, keep original files unchanged\n");
+    fprintf(stderr, "   -d, --decompress           decompress\n");
+    fprintf(stderr, "   -f, --force                overwrite files without asking\n");
+    fprintf(stderr, "   -h, --help                 give this help\n");
+    fprintf(stderr, "   -i, --index                compress and create BGZF index\n");
+    fprintf(stderr, "   -I, --index-name FILE      name of BGZF index file [file.gz.gzi]\n");
+    fprintf(stderr, "   -l, --compress-level INT   Compression level to use when compressing, from 0 to 9 [-1]\n");
+    fprintf(stderr, "   -r, --reindex              (re)index compressed file\n");
+    fprintf(stderr, "   -g, --rebgzip              use an index file to bgzip a file\n");
+    fprintf(stderr, "   -s, --size INT             decompress INT bytes (uncompressed size)\n");
+    fprintf(stderr, "   -@, --threads INT          number of compression threads to use [1]\n");
     fprintf(stderr, "\n");
     return 1;
 }
 
 int main(int argc, char **argv)
 {
-    int c, compress, pstdout, is_forced, index = 0, rebgzip = 0, reindex = 0;
+    int c, compress, compress_level = -1, pstdout, is_forced, index = 0, rebgzip = 0, reindex = 0;
     BGZF *fp;
     void *buffer;
     long start, end, size;
@@ -106,6 +107,7 @@ int main(int argc, char **argv)
         {"force", no_argument, NULL, 'f'},
         {"index", no_argument, NULL, 'i'},
         {"index-name", required_argument, NULL, 'I'},
+        {"compress-level", required_argument, NULL, 'l'},
         {"reindex", no_argument, NULL, 'r'},
         {"rebgzip",no_argument,NULL,'g'},
         {"size", required_argument, NULL, 's'},
@@ -115,7 +117,7 @@ int main(int argc, char **argv)
     };
 
     compress = 1; pstdout = 0; start = 0; size = -1; end = -1; is_forced = 0;
-    while((c  = getopt_long(argc, argv, "cdh?fb:@:s:iI:gr",loptions,NULL)) >= 0){
+    while((c  = getopt_long(argc, argv, "cdh?fb:@:s:iI:l:gr",loptions,NULL)) >= 0){
         switch(c){
         case 'd': compress = 0; break;
         case 'c': pstdout = 1; break;
@@ -124,6 +126,7 @@ int main(int argc, char **argv)
         case 'f': is_forced = 1; break;
         case 'i': index = 1; break;
         case 'I': index_fname = optarg; break;
+        case 'l': compress_level = atol(optarg); break;
         case 'g': rebgzip = 1; break;
         case 'r': reindex = 1; compress = 0; break;
         case '@': threads = atoi(optarg); break;
@@ -144,6 +147,11 @@ int main(int argc, char **argv)
     if (compress == 1) {
         struct stat sbuf;
         int f_src = fileno(stdin);
+
+        if (compress_level < -1 || compress_level > 9) {
+            fprintf(stderr, "[bgzip] Invalid compress-level: %d\n", compress_level);
+            return 1;
+        }
 
         if ( argc>optind )
         {
@@ -185,6 +193,8 @@ int main(int argc, char **argv)
         }
         else
             fp = bgzf_open("-", "w");
+
+        fp->compress_level = compress_level;
 
         if ( index && rebgzip )
         {


### PR DESCRIPTION
It would be nice if bgzip supported compression levels other than the default (like some of the samtools subcommands do). This pull request adds `-l INT` short and `--compress-level INT` long options to bgzip.