### PR TITLE
Memory leak iterating multiple queries over cram

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2747,10 +2747,17 @@ void cram_free_container(cram_container *c) {
 	cram_free_block(c->comp_hdr_block);
 
     if (c->slices) {
-	for (i = 0; i < c->max_slice; i++)
-	    if (c->slices[i])
-		cram_free_slice(c->slices[i]);
-	free(c->slices);
+        for (i = 0; i < c->max_slice; i++) {
+            if (c->slices[i])
+                cram_free_slice(c->slices[i]);
+            if (c->slices[i] == c->slice)
+                c->slice = NULL;
+        }
+        free(c->slices);
+    }
+
+    if (c->slice) {
+        cram_free_slice(c->slice);
     }
 
     for (id = DS_RN; id < DS_TN; id++)
@@ -2885,6 +2892,7 @@ cram_container *cram_read_container(cram_fd *fd) {
 
     c->offset = rd;
     c->slices = NULL;
+    c->slice = NULL;
     c->curr_slice = 0;
     c->max_slice = c->num_landmarks;
     c->slice_rec = 0;
@@ -3129,14 +3137,20 @@ static int cram_flush_result(cram_fd *fd) {
 		return -1;
 
 	/* Free the container */
-	for (i = 0; i < c->max_slice; i++) {
-	    if (c->slices && c->slices[i]) {
-		cram_free_slice(c->slices[i]);
-		c->slices[i] = NULL;
-	    }
-	}
+    if (c->slices) {
+        for (i = 0; i < c->max_slice; i++) {
+            if (c->slices[i])
+                cram_free_slice(c->slices[i]);
+            if (c->slices[i] == c->slice)
+                c->slice = NULL;
+            c->slices[i] = NULL;
+        }
+    }
 
-	c->slice = NULL;
+    if (c->slice) {
+        cram_free_slice(c->slice);
+        c->slice = NULL;
+    }
 	c->curr_slice = 0;
 
 	// Our jobs will be in order, so we free the last


### PR DESCRIPTION
The following code consumes memory indefinitely. Memory leak is gone once the change is applied.
Steps:
1. build htslib
2. compile test.c with:
gcc -O0  -ggdb -I htslib/install/include test.c -L htslib/install/lib/ -l:libhts.a -lz -lpthread -llzma -lbz2
3. run ./a.out some.cram chr1
4. watch virtual memory going up in top
5. apply patch, rebuild test.c, notice virtual memory does not change

test.c:
```c++
#include <stdlib.h>
#include <string.h>
#include <stdio.h>
#include <unistd.h>
#include <math.h>
#include <inttypes.h>
#include <stdbool.h>
#include <assert.h>
#include "htslib/sam.h"
#include "htslib/faidx.h"
#include "htslib/kstring.h"
#include "htslib/khash.h"

int main(int argc,char** argv)
{
        hts_itr_t *iter=NULL;
        hts_idx_t *idx=NULL;
        samFile *in = NULL;
        bam1_t *b= NULL;
        bam_hdr_t *header = NULL;
        if(argc!=3) return -1;
        in = sam_open(argv[1], "r");

        if(in==NULL) return -1;
        if ((header = sam_hdr_read(in)) == 0) return -1;

        idx = sam_index_load(in,  argv[1]);
        if(idx==NULL) return -1;

        b = bam_init1();
        fputs("reading\n",stdout);
        do
        {
                if (iter) hts_itr_destroy(iter);
                iter = sam_itr_querys(idx, header, argv[2]);
                if(!iter) return -1;
//              fputs("DO STUFF\n",stdout);
        }
        while (sam_itr_next(in, iter, b) >= 0);

        fputs("done reading\n",stdout);

        hts_itr_destroy(iter);
        bam_destroy1(b);
        hts_idx_destroy(idx);
        bam_hdr_destroy(header);
        sam_close(in);
        return 0;
}
```