### PR TITLE
Fixes and improvements for the multi-region iterator code

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -2701,44 +2701,42 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_multi_t *iter, void *r)
             ++iter->i;
         }
 
-        if ((ret = iter->readrec(fp, fd, r, &tid, &beg, &end)) >= 0) {
-            iter->curr_off = iter->tell(fp);
-            if (tid != iter->curr_tid) {
-                hts_reglist_t key;
-                key.tid = tid;
+        ret = iter->readrec(fp, fd, r, &tid, &beg, &end);
+        if (ret < 0)
+            break;
 
-                found_reg = (hts_reglist_t *)bsearch(&key, iter->reg_list, iter->n_reg, sizeof(hts_reglist_t), compare_regions);
+        iter->curr_off = iter->tell(fp);
+        if (tid != iter->curr_tid) {
+            hts_reglist_t key;
+            key.tid = tid;
 
-                if (!found_reg)
-                    continue;
-
-                iter->curr_reg = (found_reg - iter->reg_list);
-                iter->curr_tid = tid;
-                iter->curr_intv = 0;
-            }
-
-            cr = iter->curr_reg;
-            ci = iter->curr_intv;
-
-
-            if (beg >  iter->off[iter->i].max) {
-                iter->curr_off = iter->off[iter->i].v;
-                continue;
-            }
-            if (beg >  iter->reg_list[cr].max_end)
+            found_reg = (hts_reglist_t *)bsearch(&key, iter->reg_list, iter->n_reg, sizeof(hts_reglist_t), compare_regions);
+            if (!found_reg)
                 continue;
 
-            for (i = ci; i < iter->reg_list[cr].count; i++) {
-                if (end > iter->reg_list[cr].intervals[i].beg && iter->reg_list[cr].intervals[i].end > beg) {
-                    iter->curr_beg = beg;
-                    iter->curr_end = end;
-                    iter->curr_intv = i;
+            iter->curr_reg = (found_reg - iter->reg_list);
+            iter->curr_tid = tid;
+            iter->curr_intv = 0;
+        }
 
-                    return ret;
-                }
+        cr = iter->curr_reg;
+        ci = iter->curr_intv;
+
+        if (beg >  iter->off[iter->i].max) {
+            iter->curr_off = iter->off[iter->i].v;
+            continue;
+        }
+        if (beg >  iter->reg_list[cr].max_end)
+            continue;
+
+        for (i = ci; i < iter->reg_list[cr].count; i++) {
+            if (end > iter->reg_list[cr].intervals[i].beg && iter->reg_list[cr].intervals[i].end > beg) {
+                iter->curr_beg = beg;
+                iter->curr_end = end;
+                iter->curr_intv = i;
+
+                return ret;
             }
-        } else {
-            break; // end of file or error
         }
     }
     iter->finished = 1;

--- a/sam.c
+++ b/sam.c
@@ -676,7 +676,11 @@ static int cram_pseek(void *fp, int64_t offset, int whence)
 
     if (fd->ctr) {
         cram_free_container(fd->ctr);
+        if (fd->ctr_mt && fd->ctr_mt != fd->ctr)
+            cram_free_container(fd->ctr_mt);
+            
         fd->ctr = NULL;
+        fd->ctr_mt = NULL;
         fd->ooc = 0;
     }
 
@@ -699,7 +703,7 @@ static int64_t cram_ptell(void *fp)
     if (fd && fd->fp) {
         ret = htell(fd->fp);
         if ((c = fd->ctr) != NULL) {
-            ret -= ((c->curr_slice != c->max_slice || c->curr_rec != c->max_rec) ? c->offset + 1 : 0);
+            ret -= ((c->curr_slice < c->max_slice || c->curr_rec < c->num_records) ? c->offset + 1 : 0);
         }
     }
 


### PR DESCRIPTION
Fixes `cram_pseek` function by clearing the `ctr_mt` pointer.
Fixes `cram_ptell` function by using the correct indicator of
maximum records in a container.
Minor code improvements.