### PR TITLE
Fix for multi-region iterator

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -2251,7 +2251,7 @@ hts_itr_multi_t *hts_itr_multi_bam(const hts_idx_t *idx, hts_itr_multi_t *iter)
                         if (bin == 0) { max_off = (uint64_t)-1; break; }
                         k = kh_get(bin, bidx, bin);
                         if (k != kh_end(bidx) && kh_val(bidx, k).n > 0) {
-                            max_off = kh_val(bidx, k).loff;
+                            max_off = kh_val(bidx, k).list[0].u;
                             break;
                         }
                         bin++;


### PR DESCRIPTION
Fixes a bug in the creation of the multi-region iterator, that
caused some reads to be wrongly skipped when reading a BAM file.