### PR TITLE
New interfaces to add or update bam integer, float and array aux tags

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -528,11 +528,27 @@ int bam_aux_update_str(bam1_t *b, const char tag[2], int len, const char *data);
    ENOMEM: The bam data needs to be expanded and either the attempt to
    reallocate the data buffer failed or the resulting buffer would be
    longer than the maximum size allowed in a bam record (2Gbytes).
-
-   This function will not change the ordering of tags in the bam record.
-   New tags will be appended to any existing aux records.
 */
 int bam_aux_update_int(bam1_t *b, const char tag[2], int64_t val);
+
+/// Update or add a floating-point tag
+/* @param b    The bam record to update
+   @param tag  Tag identifier
+   @param val  The new value
+   @return 0 on success, -1 on failure
+   This function will not change the ordering of tags in the bam record.
+   New tags will be appended to any existing aux records.
+
+   On failure, errno may be set to one of the following values:
+
+   EINVAL: The bam record's aux data is corrupt or an existing tag with the
+   given ID is not of a float type.
+
+   ENOMEM: The bam data needs to be expanded and either the attempt to
+   reallocate the data buffer failed or the resulting buffer would be
+   longer than the maximum size allowed in a bam record (2Gbytes).
+*/
+int bam_aux_update_float(bam1_t *b, const char tag[2], float val);
 
 /**************************
  *** Pileup and Mpileup ***

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -550,6 +550,45 @@ int bam_aux_update_int(bam1_t *b, const char tag[2], int64_t val);
 */
 int bam_aux_update_float(bam1_t *b, const char tag[2], float val);
 
+/// Update or add an array tag
+/* @param b     The bam record to update
+   @param tag   Tag identifier
+   @param type  Data type (one of c, C, s, S, i, I or f)
+   @param items Number of items
+   @param data  Pointer to data
+   @return 0 on success, -1 on failure
+   The type parameter indicates the how the data is interpreted:
+
+   Letter code | Data type | Item Size (bytes)
+   ----------- | --------- | -----------------
+   c           | int8_t    | 1
+   C           | uint8_t   | 1
+   s           | int16_t   | 2
+   S           | uint16_t  | 2
+   i           | int32_t   | 4
+   I           | uint32_t  | 4
+   f           | float     | 4
+
+   This function will not change the ordering of tags in the bam record.
+   New tags will be appended to any existing aux records.  The bam record
+   will grow or shrink in order to accomodate the new data.
+
+   The data parameter must not point to any data in the bam record itself or
+   undefined behaviour may result.
+
+   On failure, errno may be set to one of the following values:
+
+   EINVAL: The bam record's aux data is corrupt, an existing tag with the
+   given ID is not of an array type or the type parameter is not one of
+   the values listed above.
+
+   ENOMEM: The bam data needs to be expanded and either the attempt to
+   reallocate the data buffer failed or the resulting buffer would be
+   longer than the maximum size allowed in a bam record (2Gbytes).
+*/
+int bam_aux_update_array(bam1_t *b, const char tag[2],
+                         uint8_t type, uint32_t items, void *data);
+
 /**************************
  *** Pileup and Mpileup ***
  **************************/

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -488,14 +488,51 @@ int bam_aux_append(bam1_t *b, const char tag[2], char type, int len, const uint8
 */
 int bam_aux_del(bam1_t *b, uint8_t *s);
 
-/// Update a string-type tag
+/// Update or add a string-type tag
 /* @param b    The bam record to update
    @param tag  Tag identifier
    @param len  The length of the new string
    @param data The new string
    @return 0 on success, -1 on failure
+   This function will not change the ordering of tags in the bam record.
+   New tags will be appended to any existing aux records.
+
+   On failure, errno may be set to one of the following values:
+
+   EINVAL: The bam record's aux data is corrupt or an existing tag with the
+   given ID is not of type 'Z'.
+
+   ENOMEM: The bam data needs to be expanded and either the attempt to
+   reallocate the data buffer failed or the resulting buffer would be
+   longer than the maximum size allowed in a bam record (2Gbytes).
 */
 int bam_aux_update_str(bam1_t *b, const char tag[2], int len, const char *data);
+
+/// Update or add an integer tag
+/* @param b    The bam record to update
+   @param tag  Tag identifier
+   @param val  The new value
+   @return 0 on success, -1 on failure
+   This function will not change the ordering of tags in the bam record.
+   New tags will be appended to any existing aux records.
+
+   On failure, errno may be set to one of the following values:
+
+   EINVAL: The bam record's aux data is corrupt or an existing tag with the
+   given ID is not of an integer type (c, C, s, S, i or I).
+
+   EOVERFLOW (or ERANGE on systems that do not have EOVERFLOW): val is
+   outside the range that can be stored in an integer bam tag (-2147483647
+   to 4294967295).
+
+   ENOMEM: The bam data needs to be expanded and either the attempt to
+   reallocate the data buffer failed or the resulting buffer would be
+   longer than the maximum size allowed in a bam record (2Gbytes).
+
+   This function will not change the ordering of tags in the bam record.
+   New tags will be appended to any existing aux records.
+*/
+int bam_aux_update_int(bam1_t *b, const char tag[2], int64_t val);
 
 /**************************
  *** Pileup and Mpileup ***


### PR DESCRIPTION
Fixes #686 by adding interfaces in the style of `bam_aux_update_str()` that do the same job on integer, floating point and array type tags.  They should provide an easier interface than having to use `bam_aux_del()` and `bam_aux_append()` to achieve the same result.  `bam_aux_update_int()` is also easier to use as it will choose an appropriate size for the inserted data.

The new functions don't change the order of existing tags.  `bam_aux_update_int()` and `bam_aux_update_float()` will try to avoid moving the following data on updates if the new value fits inside the old space.

Some code for reallocating bam data is put into its own function as the number of copies was starting to get rather high.

Includes tests and doxygen.  Tests have been run on sparc to ensure the big-endian parts work.