### PR TITLE
Fix warnings found when compiling with gcc 8.1.0

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -2886,6 +2886,7 @@ static int process_one_read(cram_fd *fd, cram_container *c,
                 kh_val(s->pair[sec], k) = rnum;
         } else {
             new = 1;
+            k = 0; // Prevents false-positive warning from gcc -Og
         }
 
         if (new == 0) {

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -31,6 +31,7 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <limits.h>
 
 #ifndef kroundup32
 #define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
@@ -141,9 +142,9 @@ static inline char *ks_release(kstring_t *s)
 	return ss;
 }
 
-static inline int kputsn(const char *p, int l, kstring_t *s)
+static inline int kputsn(const char *p, size_t l, kstring_t *s)
 {
-	if (ks_resize(s, s->l + l + 2) < 0)
+    if (l > SIZE_MAX - 2 - s->l || ks_resize(s, s->l + l + 2) < 0)
 		return EOF;
 	memcpy(s->s + s->l, p, l);
 	s->l += l;
@@ -173,9 +174,9 @@ static inline int kputc_(int c, kstring_t *s)
 	return 1;
 }
 
-static inline int kputsn_(const void *p, int l, kstring_t *s)
+static inline int kputsn_(const void *p, size_t l, kstring_t *s)
 {
-	if (ks_resize(s, s->l + l) < 0)
+	if (l > SIZE_MAX - s->l || ks_resize(s, s->l + l) < 0)
 		return EOF;
 	memcpy(s->s + s->l, p, l);
 	s->l += l;

--- a/sam.c
+++ b/sam.c
@@ -227,11 +227,9 @@ bam_hdr_t *bam_hdr_read(BGZF *fp)
 
 int bam_hdr_write(BGZF *fp, const bam_hdr_t *h)
 {
-    char buf[4];
     int32_t i, name_len, x;
     // write "BAM1"
-    strncpy(buf, "BAM\1", 4);
-    if (bgzf_write(fp, buf, 4) < 0) return -1;
+    if (bgzf_write(fp, "BAM\1", 4) < 0) return -1;
     // write plain text and the number of reference sequences
     if (fp->is_be) {
         x = ed_swap_4(h->l_text);

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -877,6 +877,7 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
 // returns -1 on error, 0 if the line is a comment line, 1 on success
 static int _regions_parse_line(char *line, int ichr,int ifrom,int ito, char **chr,char **chr_end,int *from,int *to)
 {
+    if (ifrom < 0 || ito < 0) return -1;
     *chr_end = NULL;
 
     if ( line[0]=='#' ) return 0;


### PR DESCRIPTION
Possible integer overflow in kputs.

Possible buffer overflow in cram_populate_ref().

Not caught by gcc, but seen at the same time: Possible overflow in expand_cache_path().

Possible use of uninitialised values in bcf_sr_regions_next().  @pd3 probably needs to check the fix for this one.