### PR TITLE
Make htslib a little bit more efficient

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -368,8 +368,10 @@ int hputc2(int c, hFILE *fp)
     return c;
 }
 
-/* Called only from hwrite() and hputs2(); when called, our buffer is full and
-   ncopied bytes from the source have already been copied to our buffer.  */
+/* Called only from hwrite() and hputs2(); when called, our buffer is either
+   full and ncopied bytes from the source have already been copied to our
+   buffer; or completely empty, ncopied is zero and totalbytes is greater than
+   the buffer size.  */
 ssize_t hwrite2(hFILE *fp, const void *srcv, size_t totalbytes, size_t ncopied)
 {
     const char *src = (const char *) srcv;

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -249,6 +249,12 @@ hwrite(hFILE *fp, const void *buffer, size_t nbytes)
     }
 
     size_t n = fp->limit - fp->begin;
+    if (nbytes >= n && fp->begin == fp->buffer) {
+        // Go straight to hwrite2 if the buffer is empty and the request
+        // won't fit.
+        return hwrite2(fp, buffer, nbytes, 0);
+    }
+
     if (n > nbytes) n = nbytes;
     memcpy(fp->begin, buffer, n);
     fp->begin += n;

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -159,7 +159,8 @@ static hts_tpool_result *hts_tpool_next_result_locked(hts_tpool_process *q) {
             // Not technically input full, but can guarantee there is
             // room for the input to go somewhere so we still signal.
             // The waiting code will then check the condition again.
-            pthread_cond_signal(&q->input_not_full_c);
+            if (q->n_input < q->qsize)
+                pthread_cond_signal(&q->input_not_full_c);
             if (!q->shutdown)
                 wake_next_worker(q, 1);
         }


### PR DESCRIPTION
The first two commits here reduce the number of times threads get woken up only to discover there's nothing to do.  Fewer wake-ups means less lock contention.

The third avoids a `memcpy()` and extra call to `fp->backend->write()` when `hwrite()` is called with more data than fits in the buffer and the buffer was empty to begin with.  This seems to happen quite a bit when writing bam files.

The fourth copies the code for handling level 0 (uncompressed blocks) from the libdeflate version of bgzf_compress() into the zlib version as well.  The main benefit is that it avoids some unnecessary memory allocations in `deflateInit2()` and frees in `deflateEnd()` for buffers that are never used.

The fifth is also for uncompressed bgzf, this time when using threads.  It removes the `memcpy()` between the uncompressed and compressed buffers by writing the data into the correct location in the compressed buffer and then calling the thread job to calculate the CRC and surround the data with the normal header and trailer.