### PR TITLE
Ignore colons in HLA contig names

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -2511,7 +2511,7 @@ const char *hts_parse_reg(const char *s, int *beg, int *end)
 {
     char *hyphen;
     const char *colon = strrchr(s, ':');
-    if (colon == NULL) {
+    if (colon == NULL || strncmp(s, "HLA", 3) == 0) {
         *beg = 0; *end = INT_MAX;
         return s + strlen(s);
     }


### PR DESCRIPTION
This is a fix for a situation where `hts_parse_reg()` is unable to recognize specified HLA regions, because the colons are interpreted as specifier for a range. This leads to errors and unexpected behavior:
```
[main_samview] region "HLA-A*01:01:01:01" specifies an unknown reference name. Continue anyway.
```
The fix I am proposing here disallows ':' for specifying a range, in the special case where the region name starts with 'HLA'. Of course that also means that specifying a range for contigs named HLA* is no longer possible at all. However, it is arguably more important that the HLA regions at least get recognized correctly.