### PR TITLE
Prevent make from working after configure errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,11 @@ AH_TOP([/* If you use configure, this file provides @%:@defines reflecting your
 dnl Variant of AC_MSG_ERROR that ensures subsequent make(1) invocations fail
 dnl until the configuration error is resolved and configure is run again.
 AC_DEFUN([MSG_ERROR],
-  [echo '$(error Resolve configure error first)' >config.mk
+  [cat > config.mk <<'EOF'
+ifneq ($(MAKECMDGOALS),distclean)
+$(error Resolve configure error first)
+endif
+EOF
    AC_MSG_ERROR([$1], [$2])])
 
 AC_PROG_CC

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Configure script for htslib, a C library for high-throughput sequencing data.
 #
-#    Copyright (C) 2015-2017 Genome Research Ltd.
+#    Copyright (C) 2015-2018 Genome Research Ltd.
 #
 #    Author: John Marshall <jm18@sanger.ac.uk>
 #
@@ -32,7 +32,7 @@ AC_CONFIG_HEADERS(config.h)
 m4_include([m4/hts_prog_cc_warnings.m4])
 
 dnl Copyright notice to be copied into the generated configure script
-AC_COPYRIGHT([Portions copyright (C) 2016 Genome Research Ltd.
+AC_COPYRIGHT([Portions copyright (C) 2018 Genome Research Ltd.
 
 This configure script is free software: you are free to change and
 redistribute it.  There is NO WARRANTY, to the extent permitted by law.])
@@ -47,6 +47,12 @@ AH_TOP([/* If you use configure, this file provides @%:@defines reflecting your
    are immaterial, as we assume standard ISO C headers and facilities;
    the PACKAGE_* defines are unused and are overridden by the more
    accurate PACKAGE_VERSION as computed by the Makefile.  */])
+
+dnl Variant of AC_MSG_ERROR that ensures subsequent make(1) invocations fail
+dnl until the configuration error is resolved and configure is run again.
+AC_DEFUN([MSG_ERROR],
+  [echo '$(error Resolve configure error first)' >config.mk
+   AC_MSG_ERROR([$1], [$2])])
 
 AC_PROG_CC
 AC_PROG_RANLIB
@@ -106,7 +112,7 @@ AC_ARG_WITH([plugin-dir],
   [AS_HELP_STRING([--with-plugin-dir=DIR],
                   [plugin installation location [LIBEXECDIR/htslib]])],
   [case $withval in
-     yes|no) AC_MSG_ERROR([no directory specified for --with-plugin-dir]) ;;
+     yes|no) MSG_ERROR([no directory specified for --with-plugin-dir]) ;;
    esac],
    [with_plugin_dir='$(libexecdir)/htslib'])
 AC_SUBST([plugindir], $with_plugin_dir)
@@ -115,7 +121,7 @@ AC_ARG_WITH([plugin-path],
   [AS_HELP_STRING([--with-plugin-path=PATH],
                   [default HTS_PATH plugin search path [PLUGINDIR]])],
   [case $withval in
-     yes) AC_MSG_ERROR([no path specified for --with-plugin-path]) ;;
+     yes) MSG_ERROR([no path specified for --with-plugin-path]) ;;
      no)  with_plugin_path= ;;
    esac],
   [with_plugin_path=$with_plugin_dir])
@@ -166,7 +172,7 @@ AC_CHECK_DECL([fdatasync(int)], [AC_CHECK_FUNCS(fdatasync)])
 
 if test $enable_plugins != no; then
   AC_SEARCH_LIBS([dlopen], [dl], [],
-    [AC_MSG_ERROR([dlopen() not found
+    [MSG_ERROR([dlopen() not found
 
 Plugin support requires dynamic linking facilities from the operating system.
 Either configure with --disable-plugins or resolve this error to build HTSlib.])])
@@ -183,7 +189,7 @@ Either configure with --disable-plugins or resolve this error to build HTSlib.])
 fi
 
 AC_SEARCH_LIBS([log], [m], [],
-  [AC_MSG_ERROR([log() not found
+  [MSG_ERROR([log() not found
 
 HTSLIB requires a working floating-point math library.
 FAILED.  This error must be resolved in order to build HTSlib successfully.])])
@@ -194,7 +200,7 @@ AC_CHECK_HEADER([zlib.h], [], [zlib_devel=missing], [;])
 AC_CHECK_LIB(z, inflate,  [], [zlib_devel=missing])
 
 if test $zlib_devel != ok; then
-  AC_MSG_ERROR([zlib development files not found
+  MSG_ERROR([zlib development files not found
 
 HTSlib uses compression routines from the zlib library <http://zlib.net>.
 Building HTSlib requires zlib development files to be installed on the build
@@ -210,14 +216,14 @@ AC_SEARCH_LIBS([recv], [socket ws2_32], [
 if test "$ac_cv_search_recv" != "none required"
 then
   static_LIBS="$static_LIBS $ac_cv_search_recv"
-fi], [AC_MSG_ERROR([unable to find the recv() function])])
+fi], [MSG_ERROR([unable to find the recv() function])])
 
 if test "$enable_bz2" != no; then
   bz2_devel=ok
   AC_CHECK_HEADER([bzlib.h], [], [bz2_devel=missing], [;])
   AC_CHECK_LIB([bz2], [BZ2_bzBuffToBuffCompress], [], [bz2_devel=missing])
   if test $bz2_devel != ok; then
-    AC_MSG_ERROR([libbzip2 development files not found
+    MSG_ERROR([libbzip2 development files not found
 
 The CRAM format may use bzip2 compression, which is implemented in HTSlib
 by using compression routines from libbzip2 <http://www.bzip.org/>.
@@ -245,7 +251,7 @@ if test "$enable_lzma" != no; then
   AC_CHECK_HEADERS([lzma.h], [], [lzma_devel=header-missing], [;])
   AC_CHECK_LIB([lzma], [lzma_easy_buffer_encode], [], [lzma_devel=missing])
   if test $lzma_devel = missing; then
-    AC_MSG_ERROR([liblzma development files not found
+    MSG_ERROR([liblzma development files not found
 
 The CRAM format may use LZMA2 compression, which is implemented in HTSlib
 by using compression routines from liblzma <http://tukaani.org/xz/>.
@@ -271,7 +277,7 @@ AS_IF([test "x$with_libdeflate" != "xno"],
      private_LIBS="$private_LIBS -ldeflate"
      static_LIBS="$static_LIBS -ldeflate"],
     [AS_IF([test "x$with_libdeflate" != "xcheck"],
-       [AC_MSG_ERROR([libdeflate development files not found: $libdeflate
+       [MSG_ERROR([libdeflate development files not found: $libdeflate
 
 You requested libdeflate, but do not have the required header / library
 files.  The source for libdeflate is available from
@@ -292,7 +298,7 @@ if test "$enable_libcurl" != no; then
        [message="library not found"])
      case "$enable_libcurl" in
        check) AC_MSG_WARN([libcurl not enabled: $message]) ;;
-       *) AC_MSG_ERROR([libcurl $message
+       *) MSG_ERROR([libcurl $message
 
 Support for HTTPS and other SSL-based URLs requires routines from the libcurl
 library <http://curl.haxx.se/libcurl/>.  Building HTSlib with libcurl enabled
@@ -321,7 +327,7 @@ if test "$enable_gcs" != no; then
   else
     case "$enable_gcs" in
       check) AC_MSG_WARN([GCS support not enabled: requires libcurl support]) ;;
-      *) AC_MSG_ERROR([GCS support not enabled
+      *) MSG_ERROR([GCS support not enabled
 
 Support for Google Cloud Storage URLs requires libcurl support to be enabled
 in HTSlib.  Configure with --enable-libcurl in order to use GCS URLs.])
@@ -339,7 +345,7 @@ if test "$enable_s3" != no; then
   else
     case "$enable_s3" in
       check) AC_MSG_WARN([S3 support not enabled: requires libcurl support]) ;;
-      *) AC_MSG_ERROR([S3 support not enabled
+      *) MSG_ERROR([S3 support not enabled
 
 Support for Amazon AWS S3 URLs requires libcurl support to be enabled
 in HTSlib.  Configure with --enable-libcurl in order to use S3 URLs.])
@@ -362,7 +368,7 @@ if test $need_crypto != no; then
      [case "$need_crypto" in
      check) AC_MSG_WARN([S3 support not enabled: requires SSL development files])
          s3=disabled ;;
-     *) AC_MSG_ERROR([SSL development files not found
+     *) MSG_ERROR([SSL development files not found
 
 Support for AWS S3 URLs requires routines from an SSL library.  Building
 HTSlib with libcurl enabled requires SSL development files to be installed


### PR DESCRIPTION
In samtools/samtools#862 a fairly experienced user managed to not notice the voluminous error message at the end of the voluminous configure output, and continued by running `make` despite configure having ended in error.

With no _config.mk_ etc, `make` carried on and built a default configuration of HTSlib, which did not have desired functionality that would have been --enabled during configure.

This PR makes configuration errors write a _config.mk_ fragment that causes:

```
… … …
checking for curl_easy_pausebork in -lcurl... no
checking for curl_easy_init in -lcurl... yes
configure: error: libcurl library is too old (7.18+ required)

Support for HTTPS and other SSL-based URLs requires routines from the libcurl
library <http://curl.haxx.se/libcurl/>.  Building HTSlib with libcurl enabled
requires libcurl development files to be installed on the build machine; you
may need to ensure a package such as libcurl4-{gnutls,nss,openssl}-dev (on
Debian or Ubuntu Linux) or libcurl-devel (on RPM-based Linux distributions
or Cygwin) is installed.

Either configure with --disable-libcurl or resolve this error to build HTSlib.

$ make
config.mk:1: *** Resolve configure error first.  Stop.
```

You may wish to apply something similar to samtools's _configure.ac_.