### PR TITLE
Add kstring support to khash.

### DIFF
--- a/htslib/khash.h
+++ b/htslib/khash.h
@@ -128,6 +128,7 @@ int main() {
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#include <htslib/kstring.h>
 
 /* compiler specific configuration */
 
@@ -400,7 +401,7 @@ static kh_inline khint_t __ac_X31_hash_string(const char *s)
 }
 /*! @function
   @abstract     Another interface to const char* hash function
-  @param  key   Pointer to a null terminated string [const char*]
+  @param  key   Pointer to a nul terminated string [const char*]
   @return       The hash value [khint_t]
  */
 #define kh_str_hash_func(key) __ac_X31_hash_string(key)
@@ -408,6 +409,30 @@ static kh_inline khint_t __ac_X31_hash_string(const char *s)
   @abstract     Const char* comparison function
  */
 #define kh_str_hash_equal(a, b) (strcmp(a, b) == 0)
+
+/*! @function
+  @abstract     Kstring hash function
+  @param  s     Pointer to a kstring
+  @return       The hash value
+ */
+static kh_inline khint_t __ac_X31_hash_kstring(const kstring_t ks)
+{
+	khint_t h = 0;
+	size_t i;
+	for (i = 0; i < ks.l; i++)
+		h = (h << 5) - h + (khint_t)ks.s[i];
+	return h;
+}
+/*! @function
+  @abstract     Interface to kstring hash function.
+  @param  key   Pointer to a khash; permits hashing on non-nul terminated strings.
+  @return       The hash value [khint_t]
+ */
+#define kh_kstr_hash_func(key) __ac_X31_hash_kstring(key)
+/*! @function
+  @abstract     kstring comparison function
+ */
+#define kh_kstr_hash_equal(a, b) ((a).l == (b).l && strncmp((a).s, (b).s, (a).l) == 0)
 
 static kh_inline khint_t __ac_Wang_hash(khint_t key)
 {
@@ -623,5 +648,20 @@ typedef const char *kh_cstr_t;
  */
 #define KHASH_MAP_INIT_STR(name, khval_t)								\
 	KHASH_INIT(name, kh_cstr_t, khval_t, 1, kh_str_hash_func, kh_str_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash set containing kstring_t keys
+  @param  name  Name of the hash table [symbol]
+ */
+#define KHASH_SET_INIT_KSTR(name)										\
+	KHASH_INIT(name, kstring_t, char, 0, kh_kstr_hash_func, kh_kstr_hash_equal)
+
+/*! @function
+  @abstract     Instantiate a hash map containing kstring_t keys
+  @param  name  Name of the hash table [symbol]
+  @param  khval_t  Type of values [type]
+ */
+#define KHASH_MAP_INIT_KSTR(name, khval_t)								\
+	KHASH_INIT(name, kstring_t, khval_t, 1, kh_kstr_hash_func, kh_kstr_hash_equal)
 
 #endif /* __AC_KHASH_H */


### PR DESCRIPTION
It can be a pain to need to create nul-terminated strings when hashing, if we're just dealing with substrings of known length in a longer string (eg keys in an `@SQ` field).

Instead of passing in a const char * pointer, we instead hash using a kstring_t struct (not pointer, as we wish to store the length in the hash keys array without using external memory).

Technically this wastes a bit of memory as kstring_t has m (malloced size) as well as l (length) and s (string), however kstring is ubiquitous in htslib so it's the logical data type to operate on.

Example usage:

```
#include <stdio.h>
#include <assert.h>
#include <htslib/khash.h>

KHASH_MAP_INIT_KSTR(ks, int)

int main(int argc, char **argv) {
    khash_t(ks) *h = kh_init(ks);
    int i, idx;

    for (i = idx = 1; i < argc; i++) {
	char *cp = argv[i], *np;
        do {
            np = strchr(cp, ' ');
            kstring_t ks = {np ? np - cp : strlen(cp), 0, cp};
            khiter_t k;
            int ret;

            k = kh_put(ks, h, ks, &ret);
            if (ret == 0) {
                printf("%d\told\t%.*s\t%d\n", ret, (int)ks.l, ks.s, kh_val(h, k));
            } else {
                kh_val(h,k) = idx++;
                printf("%d\t+\t%.*s\t%d\n", ret, (int)ks.l, ks.s, kh_val(h, k));
            }

            while (np && *np == ' ')
                np++;

            cp = np;
        } while (cp);
    }

    kh_destroy(ks, h);

    return 0;
}
```
