### PR TITLE
Text file type detection updates

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -80,6 +80,12 @@ Noteworthy changes in release a.b
   may report "invalid QUAL character" instead of "SEQ and QUAL are of
   different length".
 
+* Empty (0-length) files are no longer considered to be valid SAM files.
+  Input files without any headers or records at all are usually seen in
+  pipelines such as `somecmd | samtools ...` with `somecmd` aborting and
+  outputting nothing, and it is beneficial for the second command to
+  propagate the error.  (#261)
+
 * New API functions hts_reglist_create() and sam_itr_regarray() are added
   to create hts_reglist_t region lists from `chr:<from>-<to>` type region
   specifiers.

--- a/NEWS
+++ b/NEWS
@@ -80,6 +80,11 @@ Noteworthy changes in release a.b
   may report "invalid QUAL character" instead of "SEQ and QUAL are of
   different length".
 
+* hts_detect_format() no longer identifies arbitrary text files as SAM.
+  Instead the first few lines are checked for @HD/etc headers or having
+  11 or more SAM-like columns.  It also identifies BED files and several
+  index formats.  (#200, PR #721)
+
 * Empty (0-length) files are no longer considered to be valid SAM files.
   Input files without any headers or records at all are usually seen in
   pipelines such as `somecmd | samtools ...` with `somecmd` aborting and

--- a/NEWS
+++ b/NEWS
@@ -82,8 +82,8 @@ Noteworthy changes in release a.b
 
 * hts_detect_format() no longer identifies arbitrary text files as SAM.
   Instead the first few lines are checked for @HD/etc headers or having
-  11 or more SAM-like columns.  It also identifies BED files and several
-  index formats.  (#200, PR #721)
+  11 or more SAM-like columns.  It also identifies BED/FASTA/FASTQ files
+  and several index formats.  (#200, #719, PR #721)
 
 * Empty (0-length) files are no longer considered to be valid SAM files.
   Input files without any headers or records at all are usually seen in

--- a/hts.c
+++ b/hts.c
@@ -52,6 +52,10 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/ksort.h"
 #include "htslib/tbx.h"
 
+#ifndef EFTYPE
+#define EFTYPE ENOEXEC
+#endif
+
 KHASH_INIT2(s2i,, kh_cstr_t, int64_t, 1, kh_str_hash_func, kh_str_hash_equal)
 
 int hts_verbose = HTS_LOG_WARNING;
@@ -921,7 +925,7 @@ htsFile *hts_hopen(hFILE *hfile, const char *fn, const char *mode)
         break;
 
     default:
-        errno = ENOEXEC;
+        errno = EFTYPE;
         goto error;
     }
 

--- a/hts.c
+++ b/hts.c
@@ -121,6 +121,7 @@ static enum htsFormatCategory format_category(enum htsExactFormat fmt)
     case unknown_format:
     case binary_format:
     case text_format:
+    case empty_format:
     case format_maximum:
         break;
     }
@@ -241,6 +242,11 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
     }
     if (len < 0) return -1;
 
+    if (len == 0) {
+        fmt->format = empty_format;
+        return 0;
+    }
+
     if (len >= 6 && memcmp(s,"CRAM",4) == 0 && s[4]>=1 && s[4]<=3 && s[5]<=1) {
         fmt->category = sequence_data;
         fmt->format = cram;
@@ -347,6 +353,7 @@ char *hts_format_description(const htsFormat *format)
     case csi:   kputs("CSI", &str); break;
     case tbi:   kputs("Tabix", &str); break;
     case htsget: kputs("htsget", &str); break;
+    case empty_format:  kputs("empty", &str); break;
     default:    kputs("unknown", &str); break;
     }
 
@@ -396,6 +403,9 @@ char *hts_format_description(const htsFormat *format)
         case bed:
         case htsget:
             kputs(" text", &str);
+            break;
+
+        case empty_format:
             break;
 
         default:
@@ -912,6 +922,7 @@ htsFile *hts_hopen(hFILE *hfile, const char *fn, const char *mode)
         fp->is_cram = 1;
         break;
 
+    case empty_format:
     case text_format:
     case sam:
     case vcf:
@@ -977,6 +988,7 @@ int hts_close(htsFile *fp)
         ret = cram_close(fp->fp.cram);
         break;
 
+    case empty_format:
     case text_format:
     case sam:
     case vcf:

--- a/hts.c
+++ b/hts.c
@@ -203,6 +203,13 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
     ssize_t len = hpeek(hfile, s, 18);
     if (len < 0) return -1;
 
+    fmt->category = unknown_category;
+    fmt->format = unknown_format;
+    fmt->version.major = fmt->version.minor = -1;
+    fmt->compression = no_compression;
+    fmt->compression_level = -1;
+    fmt->specific = NULL;
+
     if (len >= 2 && s[0] == 0x1f && s[1] == 0x8b) {
         // The stream is either gzip-compressed or BGZF-compressed.
         // Determine which, and decompress the first few bytes.
@@ -211,13 +218,9 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
         len = decompress_peek(hfile, s, sizeof s);
     }
     else {
-        fmt->compression = no_compression;
         len = hpeek(hfile, s, sizeof s);
     }
     if (len < 0) return -1;
-
-    fmt->compression_level = -1;
-    fmt->specific = NULL;
 
     if (len >= 6 && memcmp(s,"CRAM",4) == 0 && s[4]>=1 && s[4]<=3 && s[5]<=1) {
         fmt->category = sequence_data;
@@ -262,7 +265,6 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
         else if (memcmp(s, "TBI\1", 4) == 0) {
             fmt->category = index_file;
             fmt->format = tbi;
-            fmt->version.major = -1, fmt->version.minor = -1;
             return 0;
         }
     }
@@ -271,8 +273,6 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
         fmt->format = vcf;
         if (len >= 21 && s[16] == 'v')
             parse_version(fmt, &s[17], &s[len]);
-        else
-            fmt->version.major = fmt->version.minor = -1;
         return 0;
     }
     else if (len >= 4 && s[0] == '@' &&
@@ -291,7 +291,6 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
     else if (cmp_nonblank("{\"htsget\":", s, &s[len]) == 0) {
         fmt->category = unknown_category;
         fmt->format = htsget;
-        fmt->version.major = fmt->version.minor = -1;
         return 0;
     }
     else {
@@ -307,10 +306,7 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
         return 0;
     }
 
-    fmt->category = unknown_category;
-    fmt->format = unknown_format;
-    fmt->version.major = fmt->version.minor = -1;
-    fmt->compression = no_compression;
+    // Nothing recognised: leave unset fmt-> fields as unknown.
     return 0;
 }
 

--- a/hts.c
+++ b/hts.c
@@ -215,7 +215,22 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
         // Determine which, and decompress the first few bytes.
         fmt->compression = (len >= 18 && (s[3] & 4) &&
                             memcmp(&s[12], "BC\2\0", 4) == 0)? bgzf : gzip;
+        if (len >= 9 && s[2] == 8)
+            fmt->compression_level = (s[8] == 2)? 9 : (s[8] == 4)? 1 : -1;
+
         len = decompress_peek(hfile, s, sizeof s);
+    }
+    else if (len >= 10 && memcmp(s, "BZh", 3) == 0 &&
+             (memcmp(&s[4], "\x31\x41\x59\x26\x53\x59", 6) == 0 ||
+              memcmp(&s[4], "\x17\x72\x45\x38\x50\x90", 6) == 0)) {
+        fmt->compression = bzip2_compression;
+        fmt->compression_level = s[3] - '0';
+        // Decompressing via libbz2 produces no output until it has a whole
+        // block (of size 100Kb x level), which is too large for peeking.
+        // So unfortunately we can recognise bzip2 but not the contents,
+        // except that \x1772... magic indicates the stream is empty.
+        if (s[4] == '\x31') return 0;
+        else len = 0;
     }
     else {
         len = hpeek(hfile, s, sizeof s);
@@ -341,6 +356,7 @@ char *hts_format_description(const htsFormat *format)
     }
 
     switch (format->compression) {
+    case bzip2_compression:  kputs(" bzip2-compressed", &str); break;
     case custom: kputs(" compressed", &str); break;
     case gzip:   kputs(" gzip-compressed", &str); break;
     case bgzf:

--- a/hts.c
+++ b/hts.c
@@ -99,6 +99,7 @@ static enum htsFormatCategory format_category(enum htsExactFormat fmt)
     case bam:
     case sam:
     case cram:
+    case fastq_format:
         return sequence_data;
 
     case vcf:
@@ -108,6 +109,8 @@ static enum htsFormatCategory format_category(enum htsExactFormat fmt)
     case bai:
     case crai:
     case csi:
+    case fai_format:
+    case fqi_format:
     case gzi:
     case tbi:
         return index_file;
@@ -115,6 +118,7 @@ static enum htsFormatCategory format_category(enum htsExactFormat fmt)
     case bed:
         return region_list;
 
+    case fasta_format:
     case htsget:
         return unknown_category;
 
@@ -206,6 +210,22 @@ static int is_text_only(const unsigned char *u, const unsigned char *ulim)
             return 0;
 
     return 1;
+}
+
+static int
+secondline_is_bases(const unsigned char *u, const unsigned char *ulim)
+{
+    // Skip to second line, returning false if there isn't one
+    u = memchr(u, '\n', ulim - u);
+    if (u == NULL || ++u == ulim) return 0;
+
+    // Scan over all base-encoding letters (including 'N' but not SEQ's '=')
+    while (u < ulim && (seq_nt16_table[*u] != 15 || toupper(*u) == 'N')) {
+        if (*u == '=') return 0;
+        u++;
+    }
+
+    return (u == ulim || *u == '\r' || *u == '\n')? 1 : 0;
 }
 
 // Parse tab-delimited text, filling in a string of column types and returning
@@ -393,6 +413,15 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
         fmt->format = htsget;
         return 0;
     }
+    else if (len >= 1 && s[0] == '>' && secondline_is_bases(s, &s[len])) {
+        fmt->format = fasta_format;
+        return 0;
+    }
+    else if (len >= 1 && s[0] == '@' && secondline_is_bases(s, &s[len])) {
+        fmt->category = sequence_data;
+        fmt->format = fastq_format;
+        return 0;
+    }
     else if (parse_tabbed_text(columns, sizeof columns, s, &s[len]) > 0) {
         if (colmatch(columns, "ZiZiiCZiiZZOOOOOOOOOOOOOOOOOOOO+") >= 11) {
             fmt->category = sequence_data;
@@ -403,6 +432,16 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
         else if (fmt->compression == gzip && colmatch(columns, "iiiiii") == 6) {
             fmt->category = index_file;
             fmt->format = crai;
+            return 0;
+        }
+        else if (colmatch(columns, "Ziiiii") == 6) {
+            fmt->category = index_file;
+            fmt->format = fqi_format;
+            return 0;
+        }
+        else if (colmatch(columns, "Ziiii") == 5) {
+            fmt->category = index_file;
+            fmt->format = fai_format;
             return 0;
         }
         else if (colmatch(columns, "Zii+") >= 3) {
@@ -427,6 +466,8 @@ char *hts_format_description(const htsFormat *format)
     case sam:   kputs("SAM", &str); break;
     case bam:   kputs("BAM", &str); break;
     case cram:  kputs("CRAM", &str); break;
+    case fasta_format:  kputs("FASTA", &str); break;
+    case fastq_format:  kputs("FASTQ", &str); break;
     case vcf:   kputs("VCF", &str); break;
     case bcf:
         if (format->version.major == 1) kputs("Legacy BCF", &str);
@@ -435,6 +476,8 @@ char *hts_format_description(const htsFormat *format)
     case bai:   kputs("BAI", &str); break;
     case crai:  kputs("CRAI", &str); break;
     case csi:   kputs("CSI", &str); break;
+    case fai_format:    kputs("FASTA-IDX", &str); break;
+    case fqi_format:    kputs("FASTQ-IDX", &str); break;
     case gzi:   kputs("GZI", &str); break;
     case tbi:   kputs("Tabix", &str); break;
     case bed:   kputs("BED", &str); break;
@@ -488,6 +531,10 @@ char *hts_format_description(const htsFormat *format)
         case crai:
         case vcf:
         case bed:
+        case fai_format:
+        case fqi_format:
+        case fasta_format:
+        case fastq_format:
         case htsget:
             kputs(" text", &str);
             break;
@@ -564,7 +611,8 @@ htsFile *hts_open_format(const char *fn, const char *mode, const htsFormat *fmt)
     if (fp->is_write && fmt &&
         (fmt->format == bam || fmt->format == sam ||
          fmt->format == vcf || fmt->format == bcf ||
-         fmt->format == bed))
+         fmt->format == bed || fmt->format == fasta_format ||
+         fmt->format == fastq_format))
         fp->format.format = fmt->format;
 
     if (fmt && fmt->specific)
@@ -1012,6 +1060,8 @@ htsFile *hts_hopen(hFILE *hfile, const char *fn, const char *mode)
     case empty_format:
     case text_format:
     case bed:
+    case fasta_format:
+    case fastq_format:
     case sam:
     case vcf:
         if (fp->format.compression != no_compression) {
@@ -1079,6 +1129,8 @@ int hts_close(htsFile *fp)
     case empty_format:
     case text_format:
     case bed:
+    case fasta_format:
+    case fastq_format:
     case sam:
     case vcf:
         if (fp->format.compression != no_compression)
@@ -1121,9 +1173,13 @@ const char *hts_format_file_extension(const htsFormat *format) {
     case vcf:  return "vcf";
     case bcf:  return "bcf";
     case csi:  return "csi";
+    case fai_format:   return "fai";
+    case fqi_format:   return "fqi";
     case gzi:  return "gzi";
     case tbi:  return "tbi";
     case bed:  return "bed";
+    case fasta_format: return "fa";
+    case fastq_format: return "fq";
     default:   return "?";
     }
 }

--- a/hts.c
+++ b/hts.c
@@ -129,14 +129,11 @@ static enum htsFormatCategory format_category(enum htsExactFormat fmt)
     return unknown_category;
 }
 
-// Decompress up to ten or so bytes by peeking at the file, which must be
+// Decompress several hundred bytes by peeking at the file, which must be
 // positioned at the start of a GZIP block.
 static size_t decompress_peek(hFILE *fp, unsigned char *dest, size_t destsize)
 {
-    // Typically at most a couple of hundred bytes of input are required
-    // to get a few bytes of output from inflate(), so hopefully this buffer
-    // size suffices in general.
-    unsigned char buffer[512];
+    unsigned char buffer[2048];
     z_stream zs;
     ssize_t npeek = hpeek(fp, buffer, sizeof buffer);
 
@@ -202,9 +199,86 @@ cmp_nonblank(const char *key, const unsigned char *u, const unsigned char *ulim)
     return 0;
 }
 
+static int is_text_only(const unsigned char *u, const unsigned char *ulim)
+{
+    for (; u < ulim; u++)
+        if (! (*u >= ' ' || *u == '\t' || *u == '\r' || *u == '\n'))
+            return 0;
+
+    return 1;
+}
+
+// Parse tab-delimited text, filling in a string of column types and returning
+// the number of columns spotted (within [u,ulim), and up to column_len) or -1
+// if non-printable characters were seen.  Column types:
+//     i: integer, s: strand sign, C: CIGAR, O: SAM optional field, Z: anything
+static int
+parse_tabbed_text(char *columns, int column_len,
+                  const unsigned char *u, const unsigned char *ulim)
+{
+    const char *str  = (const char *) u;
+    const char *slim = (const char *) ulim;
+    const char *s;
+    int ncolumns = 0;
+
+    enum { digit = 1, leading_sign = 2, cigar_operator = 4, other = 8 };
+    unsigned seen = 0;
+
+    for (s = str; s < slim; s++)
+        if (*s >= ' ') {
+            if (isdigit_c(*s))
+                seen |= digit;
+            else if ((*s == '+' || *s == '-') && s == str)
+                seen |= leading_sign;
+            else if (strchr(BAM_CIGAR_STR, *s) && s > str && isdigit_c(s[-1]))
+                seen |= cigar_operator;
+            else
+                seen |= other;
+        }
+        else if (*s == '\t' || *s == '\r' || *s == '\n') {
+            size_t len = s - str;
+            char type;
+
+            if (seen == digit || seen == (leading_sign|digit)) type = 'i';
+            else if (seen == (digit|cigar_operator)) type = 'C';
+            else if (len == 1)
+                switch (str[0]) {
+                case '*': type = 'C'; break;
+                case '+': case '-': case '.': type = 's'; break;
+                default: type = 'Z'; break;
+                }
+            else if (len >= 5 && str[2] == ':' && str[4] == ':') type = 'O';
+            else type = 'Z';
+
+            columns[ncolumns++] = type;
+            if (*s != '\t' || ncolumns >= column_len - 1) break;
+
+            str = s + 1;
+            seen = 0;
+        }
+        else return -1;
+
+    columns[ncolumns] = '\0';
+    return ncolumns;
+}
+
+// Match COLUMNS as a prefix against PATTERN (so COLUMNS may run out first).
+// Returns len(COLUMNS) (modulo '+'), or 0 if there is a mismatched entry.
+static int colmatch(const char *columns, const char *pattern)
+{
+    int i;
+    for (i = 0; columns[i] != '\0'; i++) {
+        if (pattern[i] == '+') return i;
+        if (! (columns[i] == pattern[i] || pattern[i] == 'Z')) return 0;
+    }
+
+    return i;
+}
+
 int hts_detect_format(hFILE *hfile, htsFormat *fmt)
 {
-    unsigned char s[32];
+    char columns[24];
+    unsigned char s[1024];
     ssize_t len = hpeek(hfile, s, 18);
     if (len < 0) return -1;
 
@@ -217,7 +291,7 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
 
     if (len >= 2 && s[0] == 0x1f && s[1] == 0x8b) {
         // The stream is either gzip-compressed or BGZF-compressed.
-        // Determine which, and decompress the first few bytes.
+        // Determine which, and decompress the first few records or lines.
         fmt->compression = (len >= 18 && (s[3] & 4) &&
                             memcmp(&s[12], "BC\2\0", 4) == 0)? bgzf : gzip;
         if (len >= 9 && s[2] == 8)
@@ -302,7 +376,8 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
     }
     else if (len >= 4 && s[0] == '@' &&
              (memcmp(s, "@HD\t", 4) == 0 || memcmp(s, "@SQ\t", 4) == 0 ||
-              memcmp(s, "@RG\t", 4) == 0 || memcmp(s, "@PG\t", 4) == 0)) {
+              memcmp(s, "@RG\t", 4) == 0 || memcmp(s, "@PG\t", 4) == 0 ||
+              memcmp(s, "@CO\t", 4) == 0)) {
         fmt->category = sequence_data;
         fmt->format = sam;
         // @HD-VN is not guaranteed to be the first tag, but then @HD is
@@ -318,18 +393,27 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
         fmt->format = htsget;
         return 0;
     }
-    else {
-        // Various possibilities for tab-delimited text:
-        // .crai   (gzipped tab-delimited six columns: seqid 5*number)
-        // .bed    ([3..12] tab-delimited columns)
-        // .bedpe  (>= 10 tab-delimited columns)
-        // .sam    (tab-delimited >= 11 columns: seqid number seqid...)
-        // FIXME For now, assume it's SAM
-        fmt->category = sequence_data;
-        fmt->format = sam;
-        fmt->version.major = 1, fmt->version.minor = -1;
-        return 0;
+    else if (parse_tabbed_text(columns, sizeof columns, s, &s[len]) > 0) {
+        if (colmatch(columns, "ZiZiiCZiiZZOOOOOOOOOOOOOOOOOOOO+") >= 11) {
+            fmt->category = sequence_data;
+            fmt->format = sam;
+            fmt->version.major = 1, fmt->version.minor = -1;
+            return 0;
+        }
+        else if (fmt->compression == gzip && colmatch(columns, "iiiiii") == 6) {
+            fmt->category = index_file;
+            fmt->format = crai;
+            return 0;
+        }
+        else if (colmatch(columns, "Zii+") >= 3) {
+            fmt->category = region_list;
+            fmt->format = bed;
+            return 0;
+        }
     }
+
+    // Arbitrary text files can be read using hts_getline().
+    if (is_text_only(s, &s[len])) fmt->format = text_format;
 
     // Nothing recognised: leave unset fmt-> fields as unknown.
     return 0;
@@ -351,7 +435,9 @@ char *hts_format_description(const htsFormat *format)
     case bai:   kputs("BAI", &str); break;
     case crai:  kputs("CRAI", &str); break;
     case csi:   kputs("CSI", &str); break;
+    case gzi:   kputs("GZI", &str); break;
     case tbi:   kputs("Tabix", &str); break;
+    case bed:   kputs("BED", &str); break;
     case htsget: kputs("htsget", &str); break;
     case empty_format:  kputs("empty", &str); break;
     default:    kputs("unknown", &str); break;
@@ -397,6 +483,7 @@ char *hts_format_description(const htsFormat *format)
 
     if (format->compression == no_compression)
         switch (format->format) {
+        case text_format:
         case sam:
         case crai:
         case vcf:
@@ -924,6 +1011,7 @@ htsFile *hts_hopen(hFILE *hfile, const char *fn, const char *mode)
 
     case empty_format:
     case text_format:
+    case bed:
     case sam:
     case vcf:
         if (fp->format.compression != no_compression) {
@@ -990,6 +1078,7 @@ int hts_close(htsFile *fp)
 
     case empty_format:
     case text_format:
+    case bed:
     case sam:
     case vcf:
         if (fp->format.compression != no_compression)

--- a/htsfile.c
+++ b/htsfile.c
@@ -38,6 +38,10 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/sam.h"
 #include "htslib/vcf.h"
 
+#ifndef EFTYPE
+#define EFTYPE ENOEXEC
+#endif
+
 enum { identify, view_headers, view_all, copy } mode = identify;
 int show_headers = 1;
 int verbose = 0;
@@ -312,7 +316,7 @@ int main(int argc, char **argv)
                 if (hts_close(hts) < 0) error("closing \"%s\" failed", argv[i]);
                 fp = NULL;
             }
-            else if (errno == ENOEXEC && verbose)
+            else if ((errno == EFTYPE || errno == ENOEXEC) && verbose)
                 view_raw(fp, argv[i]);
             else
                 error("can't view \"%s\"", argv[i]);

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -191,7 +191,7 @@ enum htsExactFormat {
 };
 
 enum htsCompression {
-    no_compression, gzip, bgzf, custom,
+    no_compression, gzip, bgzf, custom, bzip2_compression,
     compression_maximum = 32767
 };
 

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -187,6 +187,7 @@ enum htsExactFormat {
     sam, bam, bai, cram, crai, vcf, bcf, csi, gzi, tbi, bed,
     htsget,
     json HTS_DEPRECATED_ENUM("Use htsExactFormat 'htsget' instead") = htsget,
+    empty_format,  // File is empty (or empty after decompression)
     format_maximum = 32767
 };
 

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -404,7 +404,8 @@ int hts_detect_format(struct hFILE *fp, htsFormat *fmt);
 char *hts_format_description(const htsFormat *format);
 
 /*!
-  @abstract       Open a SAM/BAM/CRAM/VCF/BCF/etc file
+  @abstract       Open a sequence data (SAM/BAM/CRAM) or variant data (VCF/BCF)
+                  or possibly-compressed textual line-orientated file
   @param fn       The file name or "-" for stdin/stdout. For indexed files
                   with a non-standard naming, the file name can include the
                   name of the index file delimited with HTS_IDX_DELIM

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -188,6 +188,7 @@ enum htsExactFormat {
     htsget,
     json HTS_DEPRECATED_ENUM("Use htsExactFormat 'htsget' instead") = htsget,
     empty_format,  // File is empty (or empty after decompression)
+    fasta_format, fastq_format, fai_format, fqi_format,
     format_maximum = 32767
 };
 

--- a/sam.c
+++ b/sam.c
@@ -1372,6 +1372,10 @@ sam_hdr_t *sam_hdr_read(htsFile *fp)
     case sam:
         return sam_hdr_create(fp);
 
+    case empty_format:
+        errno = EPIPE;
+        return NULL;
+
     default:
         errno = EFTYPE;
         return NULL;
@@ -1969,6 +1973,10 @@ err_recover:
         }
         return ret;
     }
+
+    case empty_format:
+        errno = EPIPE;
+        return -3;
 
     default:
         errno = EFTYPE;

--- a/sam.c
+++ b/sam.c
@@ -49,6 +49,9 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/khash.h"
 KHASH_DECLARE(s2i, kh_cstr_t, int64_t)
 
+#ifndef EFTYPE
+#define EFTYPE ENOEXEC
+#endif
 #ifndef EOVERFLOW
 #define EOVERFLOW ERANGE
 #endif
@@ -1370,7 +1373,8 @@ sam_hdr_t *sam_hdr_read(htsFile *fp)
         return sam_hdr_create(fp);
 
     default:
-        abort();
+        errno = EFTYPE;
+        return NULL;
     }
 }
 
@@ -1468,7 +1472,8 @@ int sam_hdr_write(htsFile *fp, const sam_hdr_t *h)
         break;
 
     default:
-        abort();
+        errno = EBADF;
+        return -1;
     }
     return 0;
 }
@@ -1931,8 +1936,10 @@ int sam_read1(htsFile *fp, sam_hdr_t *h, bam1_t *b)
         int r = bam_read1(fp->fp.bgzf, b);
         if (h && r >= 0) {
             if (b->core.tid  >= h->n_targets || b->core.tid  < -1 ||
-                b->core.mtid >= h->n_targets || b->core.mtid < -1)
+                b->core.mtid >= h->n_targets || b->core.mtid < -1) {
+                errno = ERANGE;
                 return -3;
+            }
         }
         return r;
         }
@@ -1964,7 +1971,8 @@ err_recover:
     }
 
     default:
-        abort();
+        errno = EFTYPE;
+        return -3;
     }
 }
 
@@ -2199,7 +2207,8 @@ int sam_write1(htsFile *fp, const sam_hdr_t *h, const bam1_t *b)
         return fp->line.l;
 
     default:
-        abort();
+        errno = EBADF;
+        return -1;
     }
 }
 

--- a/tabix.c
+++ b/tabix.c
@@ -191,7 +191,7 @@ static int query_regions(args_t *args, char *fname, char **regs, int nregs, int 
         bcf_hdr_destroy(hdr);
         hts_idx_destroy(idx);
     }
-    else if ( format==vcf || format==sam || format==unknown_format )
+    else if ( format==vcf || format==sam || format==bed || format==text_format || format==unknown_format )
     {
         tbx_t *tbx = tbx_index_load3(fname, NULL, download ? HTS_IDX_SAVE_REMOTE : 0);
         if ( !tbx ) error("Could not load .tbi/.csi index of %s\n", fname);

--- a/tabix.c
+++ b/tabix.c
@@ -88,7 +88,7 @@ int file_type(const char *fname)
             error("Couldn't open \"%s\" : %s\n", fname, strerror(errno));
         }
     }
-    enum htsExactFormat format = fp->format.format;
+    enum htsExactFormat format = hts_get_format(fp)->format;
     hts_close(fp);
     if ( format == bcf ) return IS_BCF;
     if ( format == bam ) return IS_BAM;

--- a/test/hfile.c
+++ b/test/hfile.c
@@ -252,10 +252,10 @@ int main(void)
     if (strcmp(buffer, "hello, world!\x0A") != 0) fail("hread result");
     if (hclose(fin) != 0) fail("hclose(\"data:...\")");
 
-    fin = hopen("test/xx#blank.sam", "r");
-    if (fin == NULL) fail("hopen(\"test/xx#blank.sam\") for reading");
-    if (hread(fin, buffer, 100) != 0) fail("test/xx#blank.sam is non-empty");
-    if (hclose(fin) != 0) fail("hclose(\"test/xx#blank.sam\") for reading");
+    fin = hopen("test/emptyfile", "r");
+    if (fin == NULL) fail("hopen(\"test/emptyfile\") for reading");
+    if (hread(fin, buffer, 100) != 0) fail("test/emptyfile is non-empty");
+    if (hclose(fin) != 0) fail("hclose(\"test/emptyfile\") for reading");
 
     fin = hopen("data:,", "r");
     if (fin == NULL) fail("hopen(\"data:\") for reading");

--- a/test/sam.c
+++ b/test/sam.c
@@ -1047,6 +1047,7 @@ static void test_empty_sam_file(const char *filename)
 {
     samFile *in = sam_open(filename, "r");
     if (in) {
+        enum htsExactFormat format = hts_get_format(in)->format;
         bam1_t *aln = bam_init1();
 
         sam_hdr_t *header = sam_hdr_read(in);
@@ -1054,6 +1055,9 @@ static void test_empty_sam_file(const char *filename)
             fail("sam_hdr_read() from %s should fail\n", filename);
         if (sam_read1(in, header, aln) >= 0)
             fail("sam_read1() from %s should fail\n", filename);
+
+        if (format != empty_format)
+            fail("detected %s as %d (expected empty_format)", filename, format);
 
         bam_destroy1(aln);
         sam_hdr_destroy(header);

--- a/test/sam.c
+++ b/test/sam.c
@@ -1062,7 +1062,7 @@ static void test_empty_sam_file(const char *filename)
     else fail("can't open %s to read as SAM", filename);
 }
 
-static void test_empty_text_file(const char *filename)
+static void test_text_file(const char *filename, int nexp)
 {
     htsFile *in = hts_open(filename, "r");
     if (in) {
@@ -1070,7 +1070,7 @@ static void test_empty_text_file(const char *filename)
         int ret, n = 0;
         while ((ret = hts_getline(in, '\n', &str)) >= 0) n++;
         if (ret != -1) fail("hts_getline got an error from %s\n", filename);
-        if (n != 0) fail("hts_getline read %d lines from %s\n", n, filename);
+        if (n != nexp) fail("hts_getline read %d lines from %s (expected %d)\n", n, filename, nexp);
 
         hts_close(in);
         free(str.s);
@@ -1114,7 +1114,10 @@ int main(int argc, char **argv)
     test_header_pg_lines();
     test_header_updates();
     test_empty_sam_file("test/emptyfile");
-    test_empty_text_file("test/emptyfile");
+    test_text_file("test/emptyfile", 0);
+    test_text_file("test/xx#pair.sam", 7);
+    test_text_file("test/xx.fa", 7);
+    test_text_file("test/fastqs.fq", 500);
     check_enum1();
     check_cigar_tab();
     for (i = 1; i < argc; i++) faidx1(argv[i]);

--- a/test/sam.c
+++ b/test/sam.c
@@ -62,9 +62,9 @@ uint8_t *check_bam_aux_get(const bam1_t *aln, const char *tag, char type)
     uint8_t *p = bam_aux_get(aln, tag);
     if (p) {
         if (*p == type) return p;
-        else fail("%s field of type '%c', expected '%c'\n", tag, *p, type);
+        else fail("%s field of type '%c', expected '%c'", tag, *p, type);
     }
-    else fail("can't find %s field\n", tag);
+    else fail("can't find %s field", tag);
 
     return NULL;
 }
@@ -76,18 +76,18 @@ static void check_int_B_array(bam1_t *aln, char *tag,
         uint32_t i;
 
         if (bam_auxB_len(p) != nvals)
-            fail("Wrong length reported for %s field, got %u, expected %u\n",
+            fail("Wrong length reported for %s field, got %u, expected %u",
                  tag, bam_auxB_len(p), nvals);
 
         for (i = 0; i < nvals; i++) {
             if (bam_auxB2i(p, i) != vals[i]) {
                 fail("Wrong value from bam_auxB2i for %s field index %u, "
-                     "got %"PRId64" expected %"PRId64"\n",
+                     "got %"PRId64" expected %"PRId64,
                      tag, i, bam_auxB2i(p, i), vals[i]);
             }
             if (bam_auxB2f(p, i) != (double) vals[i]) {
                 fail("Wrong value from bam_auxB2f for %s field index %u, "
-                     "got %f expected %f\n",
+                     "got %f expected %f",
                      tag, i, bam_auxB2f(p, i), (double) vals[i]);
             }
         }
@@ -304,13 +304,13 @@ static int aux_fields1(void)
         nvals = NELE(bfvals);
         if ((p = check_bam_aux_get(aln, "Bf", 'B')) != NULL) {
             if (bam_auxB_len(p) != nvals)
-                fail("Wrong length reported for Bf field, got %d, expected %zd\n",
+                fail("Wrong length reported for Bf field, got %d, expected %zd",
                      bam_auxB_len(p), nvals);
 
             for (i = 0; i < nvals; i++) {
                 if (bam_auxB2f(p, i) != bfvals[i]) {
                     fail("Wrong value from bam_auxB2f for Bf field index %zd, "
-                         "got %f expected %f\n",
+                         "got %f expected %f",
                          i, bam_auxB2f(p, i), bfvals[i]);
                 }
             }
@@ -1011,10 +1011,10 @@ static void faidx1(const char *filename)
     faidx_t *fai;
 
     fin = fopen(filename, "rb");
-    if (fin == NULL) fail("can't open %s\n", filename);
+    if (fin == NULL) fail("can't open %s", filename);
     sprintf(tmpfilename, "%s.tmp", filename);
     fout = fopen(tmpfilename, "wb");
-    if (fout == NULL) fail("can't create temporary %s\n", tmpfilename);
+    if (fout == NULL) fail("can't create temporary %s", tmpfilename);
     while (fgets(line, sizeof line, fin)) {
         if (line[0] == '>') n_exp++;
         if (line[0] == '+' && line[1] == '\n') n_fq_exp++;
@@ -1049,15 +1049,15 @@ static void test_empty_sam_file(const char *filename)
     if (in) {
         enum htsExactFormat format = hts_get_format(in)->format;
         bam1_t *aln = bam_init1();
-
         sam_hdr_t *header = sam_hdr_read(in);
-        if (header)
-            fail("sam_hdr_read() from %s should fail\n", filename);
-        if (sam_read1(in, header, aln) >= 0)
-            fail("sam_read1() from %s should fail\n", filename);
+        int ret = sam_read1(in, header, aln);
 
         if (format != empty_format)
             fail("detected %s as %d (expected empty_format)", filename, format);
+        if (header)
+            fail("sam_hdr_read() from %s should fail", filename);
+        if (ret >= -1)
+            fail("sam_read1() from %s returned %d but should fail", filename, ret);
 
         bam_destroy1(aln);
         sam_hdr_destroy(header);
@@ -1073,8 +1073,8 @@ static void test_text_file(const char *filename, int nexp)
         kstring_t str = KS_INITIALIZE;
         int ret, n = 0;
         while ((ret = hts_getline(in, '\n', &str)) >= 0) n++;
-        if (ret != -1) fail("hts_getline got an error from %s\n", filename);
-        if (n != nexp) fail("hts_getline read %d lines from %s (expected %d)\n", n, filename, nexp);
+        if (ret != -1) fail("hts_getline got an error from %s", filename);
+        if (n != nexp) fail("hts_getline read %d lines from %s (expected %d)", n, filename, nexp);
 
         hts_close(in);
         free(str.s);

--- a/test/xx#blank.sam
+++ b/test/xx#blank.sam
@@ -1,0 +1,1 @@
+@CO	No useful headers or records (0-length file is not considered SAM)


### PR DESCRIPTION
Dusting off some old branches, notably to fix #200, making identification of SAM files more accurate. At present, any text file is recognised as SAM, which is less than ideal.

This adds four new entries to `htsExactFormat`, so it may be a good time to review #587 with a view to adding these entries with a suitable prefix from the start.

Unfortunately some code, notably bcftools, has taken advantage of the bug that any text file is recognised as SAM to open arbitrary text files with `hts_open()` in contravention of its documentation:

```
/*! @abstract       Open a SAM/BAM/CRAM/VCF/BCF/etc file
…
*/
htsFile *hts_open(const char *fn, const char *mode);
```

Ideally such code would be rewritten to use `bgzf_open`/`bgzf_getline`/etc instead of misusing `hts_open`/`hts_getline`/etc.

Alternatively the use of `hts_open` to read text files could be blessed. The patch contains workarounds to enable such use (as currently _tabix.c_ is guilty of the same thing), but bcftools may need similar alterations to that in _tabix.c_ to work with this fixed file type detection PR.