### PR TITLE
Sam reading and writing speed improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ lib*.so.*
 /test/test-bcf-sr
 /test/test-bcf-translate
 /test/test_bgzf
+/test/test_kstring
 /test/test_realn
 /test/test-regidx
 /test/test-vcf-api

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ BUILT_TEST_PROGRAMS = \
 	test/hfile \
 	test/sam \
 	test/test_bgzf \
+	test/test_kstring \
 	test/test_realn \
 	test/test-regidx \
 	test/test_view \
@@ -357,6 +358,7 @@ tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htsl
 #    MSYS2_ARG_CONV_EXCL="*" make check
 check test: $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS)
 	test/hts_endian
+	test/test_kstring
 	test/fieldarith test/fieldarith.sam
 	test/hfile
 	test/test_bgzf test/bgziptest.txt
@@ -379,6 +381,9 @@ test/sam: test/sam.o libhts.a
 
 test/test_bgzf: test/test_bgzf.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_bgzf.o libhts.a -lz $(LIBS) -lpthread
+
+test/test_kstring: test/test_kstring.o libhts.a
+	$(CC) $(LDFLAGS) -o $@ test/test_kstring.o libhts.a -lz $(LIBS) -lpthread
 
 test/test_realn: test/test_realn.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_realn.o libhts.a $(LIBS) -lpthread
@@ -406,6 +411,7 @@ test/fieldarith.o: test/fieldarith.c config.h $(htslib_sam_h)
 test/hfile.o: test/hfile.c config.h $(htslib_hfile_h) $(htslib_hts_defs_h)
 test/sam.o: test/sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h)
 test/test_bgzf.o: test/test_bgzf.c config.h $(htslib_bgzf_h) $(htslib_hfile_h) $(hfile_internal_h)
+test/test_kstring.o: test/test_kstring.c $(htslib_kstring_h)
 test/test-realn.o: test/test_realn.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h)
 test/test-regidx.o: test/test-regidx.c config.h $(htslib_regidx_h) $(hts_internal_h)
 test/test_view.o: test/test_view.c config.h $(cram_h) $(htslib_sam_h)

--- a/hts.c
+++ b/hts.c
@@ -1133,7 +1133,7 @@ int hts_getline(htsFile *fp, int delimiter, kstring_t *str)
     switch (fp->format.compression) {
     case no_compression:
         str->l = 0;
-        ret = kgetline(str, (kgets_func *) hgets, fp->fp.hfile);
+        ret = kgetline2(str, (kgets_func2 *) hgetln, fp->fp.hfile);
         if (ret >= 0) ret = str->l;
         else if (herrno(fp->fp.hfile)) ret = -2, errno = herrno(fp->fp.hfile);
         else ret = -1;

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -101,6 +101,8 @@ extern "C" {
 	 * EOF or on error (determined by querying fp, as per fgets()). */
 	typedef char *kgets_func(char *, int, void *);
 	int kgetline(kstring_t *s, kgets_func *fgets, void *fp);
+	typedef ssize_t kgets_func2(char *, int, void *);
+	int kgetline2(kstring_t *s, kgets_func2 *fgets, void *fp);
 
 #ifdef __cplusplus
 }

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -54,6 +54,11 @@
 #define KS_ATTR_PRINTF(fmt, arg)
 #endif
 
+#ifndef HAVE___BUILTIN_CLZ
+#if defined __GNUC__ && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4))
+#define HAVE___BUILTIN_CLZ 1
+#endif
+#endif
 
 /* kstring_t is a simple non-opaque type whose fields are likely to be
  * used directly by user code (but see also ks_str() and ks_len() below).
@@ -187,34 +192,23 @@ static inline int kputsn_(const void *p, size_t l, kstring_t *s)
 
 static inline int kputuw(unsigned x, kstring_t *s)
 {
-    if (x < 10) {
-        if (ks_resize(s, s->l + 2) < 0)
-            return EOF;
-        s->s[s->l++] = '0'+x;
-        s->s[s->l] = 0;
-        return 0;
-    }
-
-#if defined(HAVE___BUILTIN_CLZ) || (defined __GNUC__ && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)))
-    static const unsigned int r[32] =
-        {0,0,1e9,0,0,1e8,0,0,1e7,0,0,0,1e6,0,0,1e5,0,0,1e4,0,0,0,1e3,0,0,100,0,0,10,0,0,0};
-    static const int d[32] =
-        {10,10,10,9,9,9,8,8,8,7,7,7,7,6,6,6,5,5,5,4,4,4,4,3,3,3,2,2,2,1,1,1};
-    int l = __builtin_clz(x);
-    l = d[l] - (x<r[l]);
+#if HAVE___BUILTIN_CLZ && UINT_MAX == 4294967295U
+    const static unsigned int kputuw_num_digits[32] = {
+        10, 10, 10,  9,  9,  9,  8,  8,
+        8,   7,  7,  7,  7,  6,  6,  6,
+        5,   5,  5,  4,  4,  4,  4,  3,
+        3,   3,  2,  2,  2,  1,  1,  1
+    };
+    const static unsigned int kputuw_thresholds[32] = {
+        0,        0, 1000000000U, 0,       0, 100000000U,   0,      0,
+        10000000, 0,          0,  0, 1000000,         0,    0, 100000,
+        0,        0,      10000,  0,       0,         0, 1000,      0,
+        0,      100,          0,  0,      10,         0,    0,      0
+    };
 #else
-    int l = 0;
-    uint64_t m = 1;
-    do {
-        l++;
-        m *= 10;
-    } while (x >= m);
+    uint64_t m;
 #endif
-
-    if (ks_resize(s, s->l + l + 2) < 0)
-        return EOF;
-
-    static const char *dig2r =
+    const static char kputuw_dig2r[200] =
         "00010203040506070809"
         "10111213141516171819"
         "20212223242526272829"
@@ -225,18 +219,56 @@ static inline int kputuw(unsigned x, kstring_t *s)
         "70717273747576777879"
         "80818283848586878889"
         "90919293949596979899";
+    unsigned int l, j;
+    char *cp;
 
-    unsigned int j = l;
+    // Trivial case - also prevents __builtin_clz(0), which is undefined
+    if (x < 10) {
+        if (ks_resize(s, s->l + 2) < 0)
+            return EOF;
+        s->s[s->l++] = '0'+x;
+        s->s[s->l] = 0;
+        return 0;
+    }
 
-    char *cp = s->s + s->l;
+    // Find out how many digits are to be printed.
+#if HAVE___BUILTIN_CLZ && UINT_MAX == 4294967295U
+    /*
+     * Table method - should be quick if clz can be done in hardware.
+     * Find the most significant bit of the value to print and look
+     * up in a table to find out how many decimal digits are needed.
+     * This number needs to be adjusted by 1 for cases where the decimal
+     * length could vary for a given number of bits (for example,
+     * a four bit number could be between 8 and 15).
+     */
+
+    l = __builtin_clz(x);
+    l = kputuw_num_digits[l] - (x < kputuw_thresholds[l]);
+#else
+    // Fallback for when clz is not available
+    m = 1;
+    l = 0;
+    do {
+        l++;
+        m *= 10;
+    } while (x >= m);
+#endif
+
+    if (ks_resize(s, s->l + l + 2) < 0)
+        return EOF;
+
+    // Add digits two at a time
+    j = l;
+    cp = s->s + s->l;
     while (x >= 10) {
-        const char *d = dig2r + 2*(x%100);
+        const char *d = &kputuw_dig2r[2*(x%100)];
         x /= 100;
         memcpy(&cp[j-=2], d, 2);
     }
 
+    // Last one (if necessary).  We know that x < 10 by now.
     if (j == 1)
-        cp[0] = x%10 + '0';
+        cp[0] = x + '0';
 
     s->l += l;
     s->s[s->l] = 0;

--- a/kstring.c
+++ b/kstring.c
@@ -271,6 +271,30 @@ int kgetline(kstring_t *s, kgets_func *fgets_fn, void *fp)
 	return 0;
 }
 
+int kgetline2(kstring_t *s, kgets_func2 *fgets_fn, void *fp)
+{
+	size_t l0 = s->l;
+
+	while (s->l == l0 || s->s[s->l-1] != '\n') {
+		if (s->m - s->l < 200) {
+			if (ks_resize(s, s->m + 200) < 0)
+				return EOF;
+		}
+		ssize_t len = fgets_fn(s->s + s->l, s->m - s->l, fp);
+		if (len <= 0) break;
+		s->l += len;
+	}
+
+	if (s->l == l0) return EOF;
+
+	if (s->l > l0 && s->s[s->l-1] == '\n') {
+		s->l--;
+		if (s->l > l0 && s->s[s->l-1] == '\r') s->l--;
+	}
+	s->s[s->l] = '\0';
+	return 0;
+}
+
 /**********************
  * Boyer-Moore search *
  **********************/

--- a/test/test_kstring.c
+++ b/test/test_kstring.c
@@ -1,0 +1,187 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <limits.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <getopt.h>
+
+#include <htslib/kstring.h>
+
+static inline void clamp(int64_t *val, int64_t min, int64_t max) {
+    if (*val < min) *val = min;
+    if (*val > max) *val = max;
+}
+
+static int test_kputuw_from_to(kstring_t *str, unsigned int s, unsigned int e) {
+    unsigned int i = s;
+
+    for (;;) {
+        str->l = 0;
+        memset(str->s, 0xff, str->m);
+        if (kputuw(i, str) < 0 || !str->s) {
+            perror("kputuw");
+            return -1;
+        }
+        if (str->l >= str->m || str->s[str->l] != '\0') {
+            fprintf(stderr, "No NUL termination on string from kputuw\n");
+            return -1;
+        }
+        if (i != strtoul(str->s, NULL, 10)) {
+            fprintf(stderr,
+                    "kputuw wrote the wrong value, expected %u, got %s\n",
+                    i, str->s);
+            return -1;
+        }
+        if (i >= e) break;
+        i++;
+    }
+    return 0;
+}
+
+static int test_kputuw(int64_t start, int64_t end) {
+    kstring_t str = { 0, 0, NULL };
+    int64_t val;
+
+    str.s = malloc(2);
+    if (!str.s) {
+        perror("malloc");
+        return -1;
+    }
+    str.m = 2;
+
+    for (val = 0; val < UINT_MAX; val = val == 0 ? 1 : val * 10) {
+        unsigned int s = val == 0 ? 0 : val - 5;
+        unsigned int e = val + 5;
+
+        if (test_kputuw_from_to(&str, s, e) < 0) {
+            free(ks_release(&str));
+            return -1;
+        }
+    }
+
+    if (test_kputuw_from_to(&str, UINT_MAX - 5, UINT_MAX) < 0) {
+        free(ks_release(&str));
+        return -1;
+    }
+
+    str.m = 1; // Force a resize
+    clamp(&start, 0, UINT_MAX);
+    clamp(&end,   0, UINT_MAX);
+
+    if (test_kputuw_from_to(&str, start, end) < 0) {
+        free(ks_release(&str));
+        return -1;
+    }
+
+    free(ks_release(&str));
+
+    return 0;
+}
+
+static int test_kputw_from_to(kstring_t *str, int s, int e) {
+    int i = s;
+
+    for (;;) {
+        str->l = 0;
+        memset(str->s, 0xff, str->m);
+        if (kputw(i, str) < 0 || !str->s) {
+            perror("kputw");
+            return -1;
+        }
+        if (str->l >= str->m || str->s[str->l] != '\0') {
+            fprintf(stderr, "No NUL termination on string from kputw\n");
+            return -1;
+        }
+        if (i != strtol(str->s, NULL, 10)) {
+            fprintf(stderr,
+                    "kputw wrote the wrong value, expected %u, got %s\n",
+                    i, str->s);
+            return -1;
+        }
+        if (i >= e) break;
+        i++;
+    }
+    return 0;
+}
+
+static int test_kputw(int64_t start, int64_t end) {
+    kstring_t str = { 0, 0, NULL };
+    int64_t val;
+
+    str.s = malloc(2);
+    if (!str.s) {
+        perror("malloc");
+        return -1;
+    }
+    str.m = 2;
+
+    for (val = 1; val < INT_MAX; val *= 10) {
+        if (test_kputw_from_to(&str, val > 5 ? val - 5 : 0, val + 5) < 0) {
+            free(ks_release(&str));
+            return -1;
+        }
+    }
+
+    for (val = -1; val > INT_MIN; val *= 10) {
+        if (test_kputw_from_to(&str, val - 5, val < -5 ? val + 5 : 0) < 0) {
+            free(ks_release(&str));
+            return -1;
+        }
+    }
+
+    if (test_kputw_from_to(&str, INT_MAX - 5, INT_MAX) < 0) {
+        free(ks_release(&str));
+        return -1;
+    }
+
+    if (test_kputw_from_to(&str, INT_MIN, INT_MIN + 5) < 0) {
+        free(ks_release(&str));
+        return -1;
+    }
+
+    str.m = 1; // Force a resize
+    clamp(&start, INT_MIN, INT_MAX);
+    clamp(&end,   INT_MIN, INT_MAX);
+
+    if (test_kputw_from_to(&str, start, end) < 0) {
+        free(ks_release(&str));
+        return -1;
+    }
+
+    free(ks_release(&str));
+
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    int opt, res = EXIT_SUCCESS;
+    int64_t start = 0;
+    int64_t end   = 0;
+    char *test    = NULL;
+
+    while ((opt = getopt(argc, argv, "e:s:t:")) != -1) {
+        switch (opt) {
+        case 's':
+            start = strtoll(optarg, NULL, 0);
+            break;
+        case 'e':
+            end = strtoll(optarg, NULL, 0);
+            break;
+        case 't':
+            test = optarg;
+            break;
+        default:
+            fprintf(stderr, "Usage : %s [-s <num>] [-e <num>] [-t <test>]\n",
+                    argv[0]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (!test || strcmp(test, "kputuw") == 0)
+        if (test_kputuw(start, end) != 0) res = EXIT_FAILURE;
+
+    if (!test || strcmp(test, "kputw") == 0)
+        if (test_kputw(start, end) != 0) res = EXIT_FAILURE;
+
+    return res;
+}


### PR DESCRIPTION
Warning - a scary level of changes to fundamental parts of the code.

It does however speed up reading by about a factor of 2.1 and writing by 1.8 (gcc8 tests).  See the commits for a more detailed speed analysis.

The main relevant changes are:

- New kputw/kputuw which is >2x faster than the old one, depending on compiler.

- A new kgetline2 function which accepts `hgetln` instead of `hgets` prototype.  This means we return the length rather than the original pointer, avoiding a pointless second pass over the string.

- Replacements for strtol and strtoul which are base 10 specific and better optimised.

- (Now the scarier stuff!).  Unaligned 64-bit specific code (with appropriate guards) taken from io_lib for tab/newline tokenisation during SAM decode.

- Various tweaks to use `kputc_` instead of `kputc` to avoid excessive early nul-termination.