### PR TITLE
Fix mingw printf format warnings

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ build_script:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
-  - "sh -lc \"aclocal && autoheader && autoconf && ./configure CFLAGS='-Wno-format -g -O2' && make -j2\""
+  - "sh -lc \"aclocal && autoheader && autoconf && ./configure && make -j2\""
 
 #build_script:
 #  - make

--- a/htslib/hts_log.h
+++ b/htslib/hts_log.h
@@ -69,7 +69,7 @@ extern int hts_verbose;
 * \param format        Format string with placeholders, like printf.
 */
 void hts_log(enum htsLogLevel severity, const char *context, const char *format, ...)
-HTS_FORMAT(printf, 3, 4);
+HTS_FORMAT(HTS_PRINTF_FMT, 3, 4);
 
 /*! Logs an event with severity HTS_LOG_ERROR and default context. Parameters: format, ... */
 #define hts_log_error(...) hts_log(HTS_LOG_ERROR, __func__, __VA_ARGS__)


### PR DESCRIPTION
Infrastructure to do this was added to hts_defs.h in 75d9f0d, but was not applied to the hts_log() declaration in hts_log.h

Remove -Wno-format CFLAGS from appveyor config (reverting 5fef1b) now a better solution has been found.