### PR TITLE
Bump SAM_FORMAT_VERSION to 1.6

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 
 /// Highest SAM format version supported by this library
-#define SAM_FORMAT_VERSION "1.5"
+#define SAM_FORMAT_VERSION "1.6"
 
 /**********************
  *** SAM/BAM header ***


### PR DESCRIPTION
We support SAM 1.6 features, notably the BAM CG tag for long CIGAR strings.