### PR TITLE
Minor man page formatting fixes

### DIFF
--- a/bgzip.1
+++ b/bgzip.1
@@ -174,4 +174,5 @@ by Heng Li for remote file access and in-memory caching.
 
 .SH SEE ALSO
 .PP
-.BR gzip (1), tabix (1)
+.BR gzip (1),
+.BR tabix (1)

--- a/tabix.1
+++ b/tabix.1
@@ -48,11 +48,11 @@ gff|bed|sam|vcf]
 .PP
 Tabix indexes a TAB-delimited genome position file
 .I in.tab.bgz
-and creates an index file (
-.I in.tab.bgz.tbi
+and creates an index file
+.RI ( in.tab.bgz.tbi
 or 
-.I in.tab.bgz.csi
-) when
+.IR in.tab.bgz.csi )
+when
 .I region
 is absent from the command-line. The input data file must be position
 sorted and compressed by
@@ -121,17 +121,16 @@ Print only the header/meta lines.
 .B "-l, --list-chroms "
 List the sequence names stored in the index file.
 .TP
-.B "-r, --reheader " FILE
+.BI "-r, --reheader " FILE
 Replace the header with the content of FILE
 .TP
-.B "-R, --regions " FILE
+.BI "-R, --regions " FILE
 Restrict to regions listed in the FILE. The FILE can be BED file (requires .bed, .bed.gz, .bed.bgz 
 file name extension) or a TAB-delimited file with CHROM, POS, and,  optionally,
 POS_TO columns, where positions are 1-based and inclusive.  When this option is in use, the input
 file may not be sorted. 
-regions.
 .TP
-.B "-T, --targets" FILE
+.BI "-T, --targets " FILE
 Similar to 
 .B -R
 but the entire input will be read sequentially and regions not listed in FILE will be skipped.
@@ -168,4 +167,5 @@ access and in-memory caching.
 
 .SH SEE ALSO
 .PP
-.BR bgzip (1), samtools (1)
+.BR bgzip (1),
+.BR samtools (1)


### PR DESCRIPTION
Some tiny formatting fixes that have been sitting in my tree for way too long. Puts a space after the comma in


```
SEE ALSO
       gzip(1),tabix(1)
```

and similar.