### PR TITLE
Additional installation hints for dependencies.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,6 +5,9 @@ Requirements
 ============
 
 Building HTSlib requires a few programs and libraries to be present.
+See the "System Specific Details" below for guidance on how to install
+these.
+
 At least the following are required:
 
     GNU make
@@ -17,7 +20,7 @@ In addition, building the configure script requires:
 
 Running the configure script uses awk, along with a number of
 standard UNIX tools (cat, cp, grep, mv, rm, sed, among others).  Almost
-all installations will have these already.  
+all installations will have these already.
 
 Running the test harness (make test) uses:
 
@@ -29,7 +32,7 @@ library itself, and include files needed to compile code that uses functions
 from the library.  Note that some Linux distributions put include files in
 a development ('-dev' or '-devel') package separate from the main library.
 
-    libz       (required)
+    zlib       (required)
     libbz2     (required, unless configured with --disable-bz2)
     liblzma    (required, unless configured with --disable-lzma)
     libcurl    (optional, but strongly recommended)
@@ -200,3 +203,42 @@ For example,
     make DESTDIR=/tmp/staging prefix=/opt
 
 would install into bin, lib, etc subdirectories under /tmp/staging/opt.
+
+
+System Specific Details
+=======================
+
+Installing the prerequisites is system dependent and there is more
+than one correct way of satisfying these, including downloading them
+from source, compiling and installing them yourself.
+
+For people with super-user access, we provide an example set of commands
+below for installing the dependencies on a variety of operating system
+distributions.  Note these are not specific recommendations on distribution,
+compiler or SSL implementation.  It is assumed you already have the core set
+of packages for the given distribution - the lists may be incomplete if
+this is not the case.
+
+Debian / Ubuntu
+---------------
+
+sudo apt-get update  # Ensure the package list is up to date
+sudo apt-get install autoconf automake make gcc perl zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev
+
+Note: libcurl4-openssl-dev can be used as an alternative to libcurl4-gnutls-dev.
+
+RedHat / CentOS
+---------------
+
+sudo yum install autoconf automake make gcc perl-Data-Dumper zlib-devel bzip2 bzip2-devel xz-devel curl-devel openssl-devel
+
+Alpine Linux
+------------
+
+sudo apk update  # Ensure the package list is up to date
+sudo apk add autoconf automake make gcc musl-dev perl bash zlib-dev bzip2-dev xz-dev curl-dev libressl-dev
+
+OpenSUSE
+--------
+
+sudo zypper install autoconf automake make gcc perl zlib-devel libbz2-devel xz-devel libcurl-devel libopenssl-devel


### PR DESCRIPTION
The configure.ac script has guidance on the missing packages when it
finds them, but it is useful to have this information listed upfront
rather than hitting each in turn.

If approved, I can make the same change to Samtools (it's only curses / ncurses though).