### PR TITLE
Add NULL checks to sam_hdr_read(), sam_hdr_write(); add checks to test/sam.c copy_check_alignment()

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -1007,6 +1007,11 @@ static bam_hdr_t *sam_hdr_sanitise(bam_hdr_t *h) {
 
 bam_hdr_t *sam_hdr_read(htsFile *fp)
 {
+    if (!fp) {
+        errno = EINVAL;
+        return NULL;
+    }
+
     switch (fp->format.format) {
     case bam:
         return sam_hdr_sanitise(bam_hdr_read(fp->fp.bgzf));
@@ -1061,7 +1066,7 @@ bam_hdr_t *sam_hdr_read(htsFile *fp)
 
 int sam_hdr_write(htsFile *fp, const bam_hdr_t *h)
 {
-    if (!h) {
+    if (!fp || !h) {
         errno = EINVAL;
         return -1;
     }


### PR DESCRIPTION
Check for NULL `fp` in `sam_hdr_read()`, `sam_hdr_write()`

Add more tests for failure in copy_check_alignment()
    
Catch problems like sam_open() and sam_read1() failing.  Prevents a seg fault if sam_open() fails on either the input or output file.  #728 triggered this by running `./sam` in the `test` directory instead of `./test/sam` in the base directory.

Fixes #728


