### PR TITLE
Add aclocal.m4 to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /version.h
 
 autom4te.cache
+aclocal.m4
 config.cache
 config.h
 config.h.in


### PR DESCRIPTION
This is a generated file from automake, so should be included in the `.gitignore` file.