### PR TITLE
Corrected rans normalisation bug introduced in 4ef6c76f.

### DIFF
--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -89,7 +89,7 @@ unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
     tr = ((uint64_t)TOTFREQ<<31)/in_size + (1<<30)/in_size;
  normalise_harder:
     // Normalise so T[i] == TOTFREQ
-    for (m = M = j = 0; j < 256; j++) {
+    for (fsum = m = M = j = 0; j < 256; j++) {
         if (!F[j])
             continue;
 


### PR DESCRIPTION
A noddy failure to reinitialise fsum.  Odd that it worked when tested
before on the original bug - presumably due to luck somehow (wrap
around not being detrimental).

Fixes samtools/samtools#895.