### PR TITLE
Fixes a race condition in building fai indices.

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -493,7 +493,12 @@ static int fai_build3_core(const char *fn, const char *fnfai, const char *fngzi)
         goto fail;
     }
 
-    fp = hopen(fnfai, "wb");
+    if (hisremote(fnfai)) {
+        fp = hopen(fnfai, "wb");
+    } else {
+        unlink(fnfai);
+        fp = hopen(fnfai, "wbx");
+    }
 
     if ( !fp ) {
         hts_log_error("Failed to open %s index %s : %s", file_type, fnfai, strerror(errno));


### PR DESCRIPTION
The API for the fai_build* functions is to take a filename.  This
inherently leaves a race.  Code currently does things like
    if (!access(...)) fai_build()
or
    if (!open(...)) fai_build().

Both of these suffer the same problem - an attacker could symlink the
file between the access/open check and the decision to rebuild it.

This solution makes the build function itself unlink the file and does
an exclusive open so it'll fail if someone wins the race between
unlink and hopen.

There is one small fly in the ointment - we can currently do "samtools
faidx s3:foo.fa" and this will hopen s3:foo.fa.fai.  The unlink will
fail, so we've now changed behaviour because previously we could
overwrite an existing s3 fai file with a new one whereas now we
require the user to manually delete their existing one first.  Without
having an hunlink() function we're scuppered on this.  The only
possible workaround is to validate the filename first, so if the fasta
file is fd_backend we use exclusive open, and don't otherwise.  (This
is what is implemented here.)

Fixes #736