### PR TITLE
Repeated calling of bcf_empty() must not segfault

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -1002,6 +1002,9 @@ void bcf_empty(bcf1_t *v)
     free(v->d.allele); free(v->d.flt); free(v->d.info); free(v->d.fmt);
     if (v->d.var ) free(v->d.var);
     free(v->shared.s); free(v->indiv.s);
+    memset(&v->d,0,sizeof(v->d));
+    memset(&v->shared,0,sizeof(v->shared));
+    memset(&v->indiv,0,sizeof(v->indiv));
 }
 
 void bcf_destroy(bcf1_t *v)


### PR DESCRIPTION
Set `free()`-ed pointers to NULL, calling `bcf_empty()` repeatedly should not result in segfault.