### PR TITLE
Warn if the return status of VCF I/O functions is not checked

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -284,11 +284,11 @@ typedef struct {
     typedef htsFile vcfFile;
     #define bcf_open(fn, mode) hts_open((fn), (mode))
     #define vcf_open(fn, mode) hts_open((fn), (mode))
-    #define bcf_close(fp) hts_close(fp)
-    #define vcf_close(fp) hts_close(fp)
+    #define bcf_close(fp) hts_close(fp) HTS_RESULT_USED
+    #define vcf_close(fp) hts_close(fp) HTS_RESULT_USED
 
     /** Reads VCF or BCF header */
-    bcf_hdr_t *bcf_hdr_read(htsFile *fp);
+    bcf_hdr_t *bcf_hdr_read(htsFile *fp) HTS_RESULT_USED;
 
     /**
      *  bcf_hdr_set_samples() - for more efficient VCF parsing when only one/few samples are needed
@@ -317,7 +317,7 @@ typedef struct {
 
 
     /** Writes VCF or BCF header */
-    int bcf_hdr_write(htsFile *fp, bcf_hdr_t *h);
+    int bcf_hdr_write(htsFile *fp, bcf_hdr_t *h) HTS_RESULT_USED;
 
     /**
      * Parse VCF line contained in kstring and populate the bcf1_t struct
@@ -336,7 +336,7 @@ typedef struct {
      *  set to one of BCF_ERR* code and must be checked before calling
      *  vcf_write().
      */
-    int bcf_read(htsFile *fp, const bcf_hdr_t *h, bcf1_t *v);
+    int bcf_read(htsFile *fp, const bcf_hdr_t *h, bcf1_t *v) HTS_RESULT_USED;
 
     /**
      *  bcf_unpack() - unpack/decode a BCF record (fills the bcf1_t::d field)
@@ -367,17 +367,17 @@ typedef struct {
     /**
      *  bcf_write() - write one VCF or BCF record. The type is determined at the open() call.
      */
-    int bcf_write(htsFile *fp, bcf_hdr_t *h, bcf1_t *v);
+    int bcf_write(htsFile *fp, bcf_hdr_t *h, bcf1_t *v) HTS_RESULT_USED;
 
     /**
      *  The following functions work only with VCFs and should rarely be called
      *  directly. Usually one wants to use their bcf_* alternatives, which work
      *  transparently with both VCFs and BCFs.
      */
-    bcf_hdr_t *vcf_hdr_read(htsFile *fp);
-    int vcf_hdr_write(htsFile *fp, const bcf_hdr_t *h);
-    int vcf_read(htsFile *fp, const bcf_hdr_t *h, bcf1_t *v);
-    int vcf_write(htsFile *fp, const bcf_hdr_t *h, bcf1_t *v);
+    bcf_hdr_t *vcf_hdr_read(htsFile *fp) HTS_RESULT_USED;
+    int vcf_hdr_write(htsFile *fp, const bcf_hdr_t *h) HTS_RESULT_USED;
+    int vcf_read(htsFile *fp, const bcf_hdr_t *h, bcf1_t *v) HTS_RESULT_USED;
+    int vcf_write(htsFile *fp, const bcf_hdr_t *h, bcf1_t *v) HTS_RESULT_USED;
 
     /** Helper function for the bcf_itr_next() macro; internal use, ignore it */
     int bcf_readrec(BGZF *fp, void *null, void *v, int *tid, int *beg, int *end);

--- a/tabix.c
+++ b/tabix.c
@@ -162,7 +162,7 @@ static int query_regions(args_t *args, char *fname, char **regs, int nregs)
         bcf_hdr_t *hdr = bcf_hdr_read(fp);
         if ( !hdr ) error("Could not read the header: %s\n", fname);
         if ( args->print_header )
-            bcf_hdr_write(out,hdr);
+            if ( bcf_hdr_write(out,hdr)!=0 ) error("Failed to write to %s\n", fname);
         if ( !args->header_only )
         {
             bcf1_t *rec = bcf_init();
@@ -172,7 +172,7 @@ static int query_regions(args_t *args, char *fname, char **regs, int nregs)
                 while ( bcf_itr_next(fp, itr, rec) >=0 )
                 {
                     if ( reg_idx && !regidx_overlap(reg_idx, bcf_seqname(hdr,rec),rec->pos,rec->pos+rec->rlen-1, NULL) ) continue;
-                    bcf_write(out,hdr,rec);
+                    if ( bcf_write(out,hdr,rec)!=0 ) error("Failed to write to %s\n", fname);
                 }
                 tbx_itr_destroy(itr);
             }

--- a/test/test-bcf-translate.c
+++ b/test/test-bcf-translate.c
@@ -27,6 +27,15 @@
 #include <stdio.h>
 #include <htslib/vcf.h>
 
+void error(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vfprintf(stderr, format, ap);
+    va_end(ap);
+    exit(-1);
+}
+
 int main(int argc, char **argv)
 {
     char *fname = argc>1 ? argv[1] : "/dev/null";
@@ -68,7 +77,7 @@ int main(int argc, char **argv)
 
     hdr2 = bcf_hdr_merge(hdr2,hdr1);
     bcf_hdr_sync(hdr2);
-    bcf_hdr_write(fp, hdr2);
+    if ( bcf_hdr_write(fp, hdr2)!=0 ) error("Failed to write to %s\n", fname);
 
     bcf1_t *rec = bcf_init1();
     rec->rid = bcf_hdr_name2id(hdr1, "1");
@@ -91,7 +100,7 @@ int main(int argc, char **argv)
     bcf_update_format_int32(hdr1, rec, "FMT2", NULL, 0);
 
     bcf_translate(hdr2, hdr1, rec);
-    bcf_write(fp, hdr2, rec);
+    if ( bcf_write(fp, hdr2, rec)!=0 ) error("Faild to write to %s\n", fname);
 
     // Clean
     bcf_destroy1(rec);


### PR DESCRIPTION
As discussed in #740

Possibly more functions could be added, but at the very least these checks
should be always performed.