### PR TITLE
Fix possible thread pool lockup, and tidy up mutex locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ lib*.so.*
 /test/test-vcf-api
 /test/test-vcf-sweep
 /test/test_view
-/test/thrash_threads[1-6]
+/test/thrash_threads[1-7]
 /test/*.tmp
 /test/*.tmp.*
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ BUILT_THRASH_PROGRAMS = \
 	test/thrash_threads3 \
 	test/thrash_threads4 \
 	test/thrash_threads5 \
-	test/thrash_threads6
+	test/thrash_threads6 \
+	test/thrash_threads7
 
 all: lib-static lib-shared $(BUILT_PROGRAMS) plugins $(BUILT_TEST_PROGRAMS)
 
@@ -431,7 +432,8 @@ test/thrash_threads5: test/thrash_threads5.o libhts.a
 
 test/thrash_threads6: test/thrash_threads6.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads6.o libhts.a -lz $(LIBS) -lpthread
-
+test/thrash_threads7: test/thrash_threads7.o libhts.a
+	$(CC) $(LDFLAGS) -o $@ test/thrash_threads7.o libhts.a -lz $(LIBS) -lpthread
 test_thrash: $(BUILT_THRASH_PROGRAMS)
 
 

--- a/test/thrash_threads7.c
+++ b/test/thrash_threads7.c
@@ -1,0 +1,119 @@
+/* The MIT/Expat License
+
+Copyright (C) 2017 Genome Research Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+ */
+/*
+ * Test for thread lock-ups caused by a race condition on the queue list
+ * where the process tpool_worker is working on could get detached just
+ * after it finished running a job.  This would result on the pointer
+ * to the next process to be searched for work being set to NULL, which
+ * stopped all the workers from finding anything to do.
+ */
+
+
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <errno.h>
+#include "htslib/thread_pool.h"
+
+
+void *job(void *v) {
+    unsigned int *usecs = (unsigned int *) v;
+    usleep(*usecs);
+    return NULL;
+}
+
+int main(int argc, char *argv[]) {
+    int run_for_secs = 120;
+    int num_threads = 8;
+    int num_jobs = 8, count = 0, n_proc = 8, i;
+    struct timeval end, now;
+    hts_tpool *p = NULL;
+    hts_tpool_process *q[n_proc];
+
+    p = hts_tpool_init(num_threads);
+    if (!p) {
+        perror("hts_tpool_init");
+        exit(EXIT_FAILURE);
+    }
+
+    for (i = 0; i < n_proc; i++) {
+        q[i] = hts_tpool_process_init(p, 10, 1);
+        if (!q[i]) {
+            perror("hts_tpool_process_init");
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    if (gettimeofday(&end, NULL) != 0) {
+        perror("gettimeofday");
+        exit(EXIT_FAILURE);
+    }
+
+    end.tv_sec += run_for_secs;
+
+    do {
+        unsigned int *t;
+        int qnum = rand() % n_proc;
+        t = malloc(num_jobs * sizeof(*t));
+        if (!t) {
+            perror("malloc");
+            exit(EXIT_FAILURE);
+        }
+        if ((count++ & 15) == 0) {
+            fprintf(stderr, "\r%d ", count);
+            alarm(10);
+        }
+        for (i = 0; i < num_jobs; i++) {
+            t[i] = 1000;
+            if (hts_tpool_dispatch(p, q[qnum], job, &t[i]) < 0) {
+                perror("hts_tpool_dispatch");
+                exit(EXIT_FAILURE);
+            }
+        }
+        hts_tpool_process_flush(q[qnum]);
+        hts_tpool_process_destroy(q[qnum]);
+        free(t);
+        q[qnum] = hts_tpool_process_init(p, 10, 1);
+        if (!q[qnum]) {
+            perror("hts_tpool_process_init");
+            exit(EXIT_FAILURE);
+        }
+
+        if (gettimeofday(&now, NULL) != 0) {
+            perror("gettimeofday");
+            exit(EXIT_FAILURE);
+        }
+    } while (now.tv_sec < end.tv_sec
+             || (now.tv_sec == end.tv_sec && now.tv_usec < end.tv_usec));
+    for (i = 0; i < n_proc; i++) {
+        hts_tpool_process_flush(q[i]);
+        hts_tpool_process_destroy(q[i]);
+    }
+    hts_tpool_destroy(p);
+    fprintf(stderr, "\n");
+
+    return EXIT_SUCCESS;
+}

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -582,10 +582,12 @@ static void *tpool_worker(void *arg) {
         }
         if (--q->ref_count == 0) // we were the last user
             hts_tpool_process_destroy(q);
-        else
+        else {
             // Out of jobs on this queue, so restart search from next one.
             // This is equivalent to "work-stealing".
-            p->q_head = q->next;
+            if (p->q_head)
+                p->q_head = p->q_head->next;
+        }
 
         pthread_mutex_unlock(&p->pool_m);
     }

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -40,6 +40,9 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "thread_pool_internal.h"
 
+static void hts_tpool_process_detach_locked(hts_tpool *p,
+                                            hts_tpool_process *q);
+
 //#define DEBUG
 
 #ifdef DEBUG
@@ -298,14 +301,18 @@ int hts_tpool_process_sz(hts_tpool_process *q) {
  * This sets the shutdown flag and wakes any threads waiting on process
  * condition variables.
  */
-void hts_tpool_process_shutdown(hts_tpool_process *q) {
-    pthread_mutex_lock(&q->p->pool_m);
+static void hts_tpool_process_shutdown_locked(hts_tpool_process *q) {
     q->shutdown = 1;
     pthread_cond_broadcast(&q->output_avail_c);
     pthread_cond_broadcast(&q->input_not_full_c);
     pthread_cond_broadcast(&q->input_empty_c);
     pthread_cond_broadcast(&q->none_processing_c);
-    pthread_mutex_unlock(&q->p->pool_m);
+}
+
+void hts_tpool_process_shutdown(hts_tpool_process *q) {
+     pthread_mutex_lock(&q->p->pool_m);
+     hts_tpool_process_shutdown_locked(q);
+     pthread_mutex_unlock(&q->p->pool_m);
 }
 
 /*
@@ -384,8 +391,8 @@ void hts_tpool_process_destroy(hts_tpool_process *q) {
     // Ensure it's fully drained before destroying the queue
     hts_tpool_process_reset(q, 0);
     pthread_mutex_lock(&q->p->pool_m);
-    hts_tpool_process_detach(q->p, q);
-    hts_tpool_process_shutdown(q);
+    hts_tpool_process_detach_locked(q->p, q);
+    hts_tpool_process_shutdown_locked(q);
 
     // Maybe a worker is scanning this queue, so delay destruction
     if (--q->ref_count > 0) {
@@ -429,10 +436,10 @@ void hts_tpool_process_attach(hts_tpool *p, hts_tpool_process *q) {
     pthread_mutex_unlock(&p->pool_m);
 }
 
-void hts_tpool_process_detach(hts_tpool *p, hts_tpool_process *q) {
-    pthread_mutex_lock(&p->pool_m);
+static void hts_tpool_process_detach_locked(hts_tpool *p,
+                                            hts_tpool_process *q) {
     if (!p->q_head || !q->prev || !q->next)
-        goto done;
+        return;
 
     hts_tpool_process *curr = p->q_head, *first = curr;
     do {
@@ -450,11 +457,13 @@ void hts_tpool_process_detach(hts_tpool *p, hts_tpool_process *q) {
 
         curr = curr->next;
     } while (curr != first);
-
- done:
-    pthread_mutex_unlock(&p->pool_m);
 }
 
+void hts_tpool_process_detach(hts_tpool *p, hts_tpool_process *q) {
+    pthread_mutex_lock(&p->pool_m);
+    hts_tpool_process_detach_locked(p, q);
+    pthread_mutex_unlock(&p->pool_m);
+}
 
 /* ----------------------------------------------------------------------------
  * The thread pool.
@@ -477,18 +486,15 @@ static void *tpool_worker(void *arg) {
     hts_tpool *p = w->p;
     hts_tpool_job *j;
 
-    for (;;) {
+    pthread_mutex_lock(&p->pool_m);
+    while (!p->shutdown) {
         // Pop an item off the pool queue
-        pthread_mutex_lock(&p->pool_m);
 
         assert(p->q_head == 0 || (p->q_head->prev && p->q_head->next));
 
         int work_to_do = 0;
         hts_tpool_process *first = p->q_head, *q = first;
         do {
-            if (p->shutdown)
-                break;
-
             // Iterate over queues, finding one with jobs and also
             // room to put the result.
             //if (q && q->input_head && !hts_tpool_process_output_full(q)) {
@@ -500,15 +506,6 @@ static void *tpool_worker(void *arg) {
 
             if (q) q = q->next;
         } while (q && q != first);
-
-        if (p->shutdown) {
-        shutdown:
-#ifdef DEBUG
-            fprintf(stderr, "%d: Shutting down\n", worker_id(p));
-#endif
-            pthread_mutex_unlock(&p->pool_m);
-            return NULL;
-        }
 
         if (!work_to_do) {
             // We scanned all queues and cannot process any, so we wait.
@@ -536,8 +533,7 @@ static void *tpool_worker(void *arg) {
             }
 
             p->nwaiting--;
-            pthread_mutex_unlock(&p->pool_m);
-            continue; // To outer for(;;) loop.
+            continue; // To outer loop.
         }
 
         // Otherwise work_to_do, so process as many items in this queue as
@@ -588,9 +584,14 @@ static void *tpool_worker(void *arg) {
             if (p->q_head)
                 p->q_head = p->q_head->next;
         }
-
-        pthread_mutex_unlock(&p->pool_m);
     }
+
+ shutdown:
+    pthread_mutex_unlock(&p->pool_m);
+#ifdef DEBUG
+    fprintf(stderr, "%d: Shutting down\n", worker_id(p));
+#endif
+    return NULL;
 }
 
 static void wake_next_worker(hts_tpool_process *q, int locked) {


### PR DESCRIPTION
Fix thread pool lock-up that caused 1 in 20 `bambi i2b` processes to get stuck.

Also tidy up some mutex locking to remove double locks and simplify `tpool_worker()`.
