### PR TITLE
Added -Werror  to travis & appveyor builds.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ build_script:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
-  - "sh -lc \"aclocal && autoheader && autoconf && ./configure && make -j2\""
+  - "sh -lc \"aclocal && autoheader && autoconf && ./configure --enable-werror CFLAGS='-g -O3' && make -j2\""
 
 #build_script:
 #  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ before_script:
 
 script:
   - if test "x$USE_LIBDEFLATE" = "xyes" ; then CONFIG_OPTS='CPPFLAGS="-I$HOME/libdeflate" LDFLAGS="-L$HOME/libdeflate" --with-libdeflate' ; else CONFIG_OPTS='--without-libdeflate' ; fi
-  - if test "$USE_CONFIG" = "yes" ; then autoreconf && eval ./configure $CONFIG_OPTS || { cat config.log ; false ; } ; fi && make -j 2 -e && make test
+  - if test "$USE_CONFIG" = "yes" ; then autoreconf && eval ./configure --enable-werror $CONFIG_OPTS CFLAGS=\"-g -O3\" || { cat config.log ; false ; } ; fi && make -j 2 -e && make test

--- a/tbx.c
+++ b/tbx.c
@@ -164,6 +164,12 @@ static inline int get_intv(tbx_t *tbx, kstring_t *str, tbx_intv_t *intv, int is_
     }
 }
 
+/*
+ * Called by tabix iterator to read the next record.
+ * Returns    >=  0 on success
+ *               -1 on EOF
+ *            <= -2 on error
+ */
 int tbx_readrec(BGZF *fp, void *tbxv, void *sv, int *tid, int *beg, int *end)
 {
     tbx_t *tbx = (tbx_t *) tbxv;
@@ -171,7 +177,8 @@ int tbx_readrec(BGZF *fp, void *tbxv, void *sv, int *tid, int *beg, int *end)
     int ret;
     if ((ret = bgzf_getline(fp, '\n', s)) >= 0) {
         tbx_intv_t intv;
-        get_intv(tbx, s, &intv, 0);
+        if (get_intv(tbx, s, &intv, 0) < 0)
+            return -2;
         *tid = intv.tid; *beg = intv.beg; *end = intv.end;
     }
     return ret;


### PR DESCRIPTION
Also enabled -O3 as some of the bugs aren't spotted at -O2.

Fixes a Tabix error handling bug, detected by gcc7 which (with -Werror) caused  AppVeyor to fail.