### PR TITLE
do not override build variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,20 +22,18 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-CC     = gcc
+CC     ?= gcc
 AR     = ar
 RANLIB = ranlib
 
 # Default libraries to link if configure is not used
 htslib_default_libs = -lz -lm -lbz2 -llzma
 
-CPPFLAGS =
 # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
 # For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
 #CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D__FUNCTION__=__func__
 CFLAGS   = -g -Wall -O2
 EXTRA_CFLAGS_PIC = -fpic
-LDFLAGS  =
 LIBS     = $(htslib_default_libs)
 
 prefix      = /usr/local


### PR DESCRIPTION
When you set CC, CPPFLAGS and LDFLAGS with `=` the users choices will be overridden. The user can then only override this with `make -e` or hack the Makefile. CPPFLAGS and LDFLAGS are empty, so there is no need at all to set these. If CC is set by the user, e.g. to another compiler, `?=` should be used instead of `=` to provide the default.