### PR TITLE
Make bgzip --help and tabix --help write to standard output

### DIFF
--- a/bgzip.c
+++ b/bgzip.c
@@ -68,27 +68,27 @@ static int confirm_overwrite(const char *fn)
     return ret;
 }
 
-static int bgzip_main_usage(void)
+static int bgzip_main_usage(FILE *fp, int status)
 {
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Version: %s\n", hts_version());
-    fprintf(stderr, "Usage:   bgzip [OPTIONS] [FILE] ...\n");
-    fprintf(stderr, "Options:\n");
-    fprintf(stderr, "   -b, --offset INT           decompress at virtual file pointer (0-based uncompressed offset)\n");
-    fprintf(stderr, "   -c, --stdout               write on standard output, keep original files unchanged\n");
-    fprintf(stderr, "   -d, --decompress           decompress\n");
-    fprintf(stderr, "   -f, --force                overwrite files without asking\n");
-    fprintf(stderr, "   -h, --help                 give this help\n");
-    fprintf(stderr, "   -i, --index                compress and create BGZF index\n");
-    fprintf(stderr, "   -I, --index-name FILE      name of BGZF index file [file.gz.gzi]\n");
-    fprintf(stderr, "   -l, --compress-level INT   Compression level to use when compressing; 0 to 9, or -1 for default [-1]\n");
-    fprintf(stderr, "   -r, --reindex              (re)index compressed file\n");
-    fprintf(stderr, "   -g, --rebgzip              use an index file to bgzip a file\n");
-    fprintf(stderr, "   -s, --size INT             decompress INT bytes (uncompressed size)\n");
-    fprintf(stderr, "   -@, --threads INT          number of compression threads to use [1]\n");
-    fprintf(stderr, "   -t, --test                 test integrity of compressed file");
-    fprintf(stderr, "\n");
-    return 1;
+    fprintf(fp, "\n");
+    fprintf(fp, "Version: %s\n", hts_version());
+    fprintf(fp, "Usage:   bgzip [OPTIONS] [FILE] ...\n");
+    fprintf(fp, "Options:\n");
+    fprintf(fp, "   -b, --offset INT           decompress at virtual file pointer (0-based uncompressed offset)\n");
+    fprintf(fp, "   -c, --stdout               write on standard output, keep original files unchanged\n");
+    fprintf(fp, "   -d, --decompress           decompress\n");
+    fprintf(fp, "   -f, --force                overwrite files without asking\n");
+    fprintf(fp, "   -h, --help                 give this help\n");
+    fprintf(fp, "   -i, --index                compress and create BGZF index\n");
+    fprintf(fp, "   -I, --index-name FILE      name of BGZF index file [file.gz.gzi]\n");
+    fprintf(fp, "   -l, --compress-level INT   Compression level to use when compressing; 0 to 9, or -1 for default [-1]\n");
+    fprintf(fp, "   -r, --reindex              (re)index compressed file\n");
+    fprintf(fp, "   -g, --rebgzip              use an index file to bgzip a file\n");
+    fprintf(fp, "   -s, --size INT             decompress INT bytes (uncompressed size)\n");
+    fprintf(fp, "   -@, --threads INT          number of compression threads to use [1]\n");
+    fprintf(fp, "   -t, --test                 test integrity of compressed file");
+    fprintf(fp, "\n");
+    return status;
 }
 
 int main(int argc, char **argv)
@@ -139,8 +139,8 @@ int main(int argc, char **argv)
 "bgzip (htslib) %s\n"
 "Copyright (C) 2018 Genome Research Ltd.\n", hts_version());
             return EXIT_SUCCESS;
-        case 'h':
-        case '?': return bgzip_main_usage();
+        case 'h': return bgzip_main_usage(stdout, EXIT_SUCCESS);
+        case '?': return bgzip_main_usage(stderr, EXIT_FAILURE);
         }
     }
     if (size >= 0) end = start + size;
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
             }
         }
         else if (!pstdout && isatty(fileno((FILE *)stdout)) )
-            return bgzip_main_usage();
+            return bgzip_main_usage(stderr, EXIT_FAILURE);
         else if ( index && !index_fname )
         {
             fprintf(stderr, "[bgzip] Index file name expected when writing to stdout\n");
@@ -326,7 +326,7 @@ int main(int argc, char **argv)
             }
         }
         else if (!pstdout && isatty(fileno((FILE *)stdin)) )
-            return bgzip_main_usage();
+            return bgzip_main_usage(stderr, EXIT_FAILURE);
         else
         {
             f_dst = fileno(stdout);

--- a/tabix.c
+++ b/tabix.c
@@ -335,33 +335,33 @@ int reheader_file(const char *fname, const char *header, int ftype, tbx_conf_t *
     return 0;
 }
 
-static int usage(void)
+static int usage(FILE *fp, int status)
 {
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Version: %s\n", hts_version());
-    fprintf(stderr, "Usage:   tabix [OPTIONS] [FILE] [REGION [...]]\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Indexing Options:\n");
-    fprintf(stderr, "   -0, --zero-based           coordinates are zero-based\n");
-    fprintf(stderr, "   -b, --begin INT            column number for region start [4]\n");
-    fprintf(stderr, "   -c, --comment CHAR         skip comment lines starting with CHAR [null]\n");
-    fprintf(stderr, "   -C, --csi                  generate CSI index for VCF (default is TBI)\n");
-    fprintf(stderr, "   -e, --end INT              column number for region end (if no end, set INT to -b) [5]\n");
-    fprintf(stderr, "   -f, --force                overwrite existing index without asking\n");
-    fprintf(stderr, "   -m, --min-shift INT        set minimal interval size for CSI indices to 2^INT [14]\n");
-    fprintf(stderr, "   -p, --preset STR           gff, bed, sam, vcf\n");
-    fprintf(stderr, "   -s, --sequence INT         column number for sequence names (suppressed by -p) [1]\n");
-    fprintf(stderr, "   -S, --skip-lines INT       skip first INT lines [0]\n");
-    fprintf(stderr, "\n");
-    fprintf(stderr, "Querying and other options:\n");
-    fprintf(stderr, "   -h, --print-header         print also the header lines\n");
-    fprintf(stderr, "   -H, --only-header          print only the header lines\n");
-    fprintf(stderr, "   -l, --list-chroms          list chromosome names\n");
-    fprintf(stderr, "   -r, --reheader FILE        replace the header with the content of FILE\n");
-    fprintf(stderr, "   -R, --regions FILE         restrict to regions listed in the file\n");
-    fprintf(stderr, "   -T, --targets FILE         similar to -R but streams rather than index-jumps\n");
-    fprintf(stderr, "\n");
-    return 1;
+    fprintf(fp, "\n");
+    fprintf(fp, "Version: %s\n", hts_version());
+    fprintf(fp, "Usage:   tabix [OPTIONS] [FILE] [REGION [...]]\n");
+    fprintf(fp, "\n");
+    fprintf(fp, "Indexing Options:\n");
+    fprintf(fp, "   -0, --zero-based           coordinates are zero-based\n");
+    fprintf(fp, "   -b, --begin INT            column number for region start [4]\n");
+    fprintf(fp, "   -c, --comment CHAR         skip comment lines starting with CHAR [null]\n");
+    fprintf(fp, "   -C, --csi                  generate CSI index for VCF (default is TBI)\n");
+    fprintf(fp, "   -e, --end INT              column number for region end (if no end, set INT to -b) [5]\n");
+    fprintf(fp, "   -f, --force                overwrite existing index without asking\n");
+    fprintf(fp, "   -m, --min-shift INT        set minimal interval size for CSI indices to 2^INT [14]\n");
+    fprintf(fp, "   -p, --preset STR           gff, bed, sam, vcf\n");
+    fprintf(fp, "   -s, --sequence INT         column number for sequence names (suppressed by -p) [1]\n");
+    fprintf(fp, "   -S, --skip-lines INT       skip first INT lines [0]\n");
+    fprintf(fp, "\n");
+    fprintf(fp, "Querying and other options:\n");
+    fprintf(fp, "   -h, --print-header         print also the header lines\n");
+    fprintf(fp, "   -H, --only-header          print only the header lines\n");
+    fprintf(fp, "   -l, --list-chroms          list chromosome names\n");
+    fprintf(fp, "   -r, --reheader FILE        replace the header with the content of FILE\n");
+    fprintf(fp, "   -R, --regions FILE         restrict to regions listed in the file\n");
+    fprintf(fp, "   -T, --targets FILE         similar to -R but streams rather than index-jumps\n");
+    fprintf(fp, "\n");
+    return status;
 }
 
 int main(int argc, char *argv[])
@@ -449,11 +449,13 @@ int main(int argc, char *argv[])
 "tabix (htslib) %s\n"
 "Copyright (C) 2018 Genome Research Ltd.\n", hts_version());
                 return EXIT_SUCCESS;
-            default: return usage();
+            case 2:
+                return usage(stdout, EXIT_SUCCESS);
+            default: return usage(stderr, EXIT_FAILURE);
         }
     }
 
-    if ( optind==argc ) return usage();
+    if ( optind==argc ) return usage(stderr, EXIT_FAILURE);
 
     if ( list_chroms )
         return query_chroms(argv[optind]);


### PR DESCRIPTION
Minor change to make these utilities' `--help` options follow the GNU conventions. And so be conveniently greppable.