### PR TITLE
Add file copy facility to htsfile

### DIFF
--- a/htsfile.1
+++ b/htsfile.1
@@ -28,6 +28,10 @@ htsfile \- identify high-throughput sequencing data files
 .B htsfile
 .RB [ -chHv ]
 .IR FILE ...
+.br
+.B htsfile --copy
+.RB [ -v ]
+.I FILE DESTFILE
 .SH DESCRIPTION
 The \fBhtsfile\fR utility attempts to identify what kind of high-throughput
 sequencing data files the specified files are, and provides minimal viewing
@@ -52,6 +56,11 @@ only headers or only data records, but has no other filtering capabilities.
 Use \fBsamtools\fR or \fBbcftools\fR if you need more extensive viewing or
 filtering capabilities.
 .P
+Alternatively, when \fB--copy\fR is used, \fBhtsfile\fR takes exactly two
+arguments and performs a byte-for-byte copy from \fIFILE\fR to \fIDESTFILE\fR.
+This is similar to \fBcp\fR(1), but HTSlib's remote file access facilities
+are available for both source and destination.
+.P
 The following options are accepted:
 .TP 4n
 .BR -c ", " --view
@@ -62,6 +71,11 @@ By default, \fB--view\fR refuses to display files in unknown formats.
 When \fB--verbose\fR is also given, the raw contents of such files are
 displayed, with non-printable characters shown via C-style "\\x" hexadecimal
 escape sequences.
+.TP
+.BR -C ", " --copy
+Instead of identifying or displaying the specified files, copy the source
+\fIFILE\fR to the destination \fIDESTFILE\fR.
+Only \fB--verbose\fR may be used in conjunction with \fB--copy\fR.
 .TP
 .BR -h ", " --header-only
 Display data file headers only.

--- a/htsfile.c
+++ b/htsfile.c
@@ -236,7 +236,7 @@ int main(int argc, char **argv)
         { "no-header", no_argument, NULL, 'H' },
         { "view", no_argument, NULL, 'c' },
         { "verbose", no_argument, NULL, 'v' },
-        { "help", no_argument, NULL, '?' },
+        { "help", no_argument, NULL, 2 },
         { "version", no_argument, NULL, 1 },
         { NULL, 0, NULL, 0 }
     };
@@ -244,7 +244,7 @@ int main(int argc, char **argv)
     int c, i;
 
     status = EXIT_SUCCESS;
-    while ((c = getopt_long(argc, argv, "cChHv?", options, NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "cChHv", options, NULL)) >= 0)
         switch (c) {
         case 'c': mode = view_all; break;
         case 'C': mode = copy; break;
@@ -258,7 +258,7 @@ int main(int argc, char **argv)
                    hts_version());
             exit(EXIT_SUCCESS);
             break;
-        case '?': usage(stdout, EXIT_SUCCESS); break;
+        case 2:   usage(stdout, EXIT_SUCCESS); break;
         default:  usage(stderr, EXIT_FAILURE); break;
         }
 


### PR DESCRIPTION
Add `htsfile --copy` option that does byte-for-byte file copies. This exercises hFILE writing as well as reading, and provides a useful utility to copy files between HTSlib-implemented URLs.

And a small option-handling bug fix.