### PR TITLE
tabix coordinates fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 Noteworthy changes in release a.b
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* tabix uses an internal 0-based exclusive representation of the regions (-R)
+  and targets (-T) files and consequently enforces stricter checks at both ends
+  when detecting overlaps. Thus, some of the resulted lines obtained by using
+  a targets file may be removed now, especially the ones overlapping at the
+  boundary of a region.
+
 Noteworthy changes in release 1.9 (18th July 2018)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tabix.c
+++ b/tabix.c
@@ -115,7 +115,9 @@ static char **parse_regions(char *regions_fname, char **argv, int argc, int *nre
             while ( itr.i < itr.n )
             {
                 str.l = 0;
-                ksprintf(&str, "%s:%d-%d", seqs[iseq], REGITR_START(itr)+1, REGITR_END(itr)+1);
+                // transform the internal representation (0-based exclusive)
+                // into 1-based inclusive, used by the CLI
+                ksprintf(&str, "%s:%d-%d", seqs[iseq], REGITR_START(itr)+1, REGITR_END(itr));
                 regs[ireg++] = strdup(str.s);
                 itr.i++;
             }
@@ -136,6 +138,7 @@ static char **parse_regions(char *regions_fname, char **argv, int argc, int *nre
         }
     }
 
+    // region coordinates taken from the CLI are 1-based inclusive
     for (iseq=0; iseq<argc; iseq++) regs[ireg++] = strdup(argv[iseq]);
     return regs;
 }

--- a/test/test-regidx.c
+++ b/test/test-regidx.c
@@ -94,20 +94,20 @@ int main(int argc, char **argv)
     int from, to;
 
     from = to = 10000000;
-    if ( !regidx_overlap(idx,"1",from-1,to-1,&itr) ) error("query failed: 1:%d-%d\n",from,to);
+    if ( !regidx_overlap(idx,"1",from-1,to,&itr) ) error("query failed: 1:%d-%d\n",from,to);
     if ( strcmp("1:10000000-10000000",REGITR_PAYLOAD(itr,char*)) ) error("query failed: 1:%d-%d vs %s\n", from,to,REGITR_PAYLOAD(itr,char*));
-    if ( !regidx_overlap(idx,"1",from-2,to-1,&itr) ) error("query failed: 1:%d-%d\n",from-1,to);
-    if ( !regidx_overlap(idx,"1",from-2,to+3,&itr) ) error("query failed: 1:%d-%d\n",from-1,to+2);
-    if ( regidx_overlap(idx,"1",from-2,to-2,&itr) ) error("query failed: 1:%d-%d\n",from-1,to-1);
+    if ( !regidx_overlap(idx,"1",from-2,to,&itr) ) error("query failed: 1:%d-%d\n",from-1,to);
+    if ( !regidx_overlap(idx,"1",from-2,to+4,&itr) ) error("query failed: 1:%d-%d\n",from-1,to+2);
+    if ( regidx_overlap(idx,"1",from-2,to-1,&itr) ) error("query failed: 1:%d-%d\n",from-1,to-1);
 
     from = to = 20000000;
-    if ( !regidx_overlap(idx,"1",from-1,to-1,&itr) ) error("query failed: 1:%d-%d\n",from,to);
+    if ( !regidx_overlap(idx,"1",from-1,to,&itr) ) error("query failed: 1:%d-%d\n",from,to);
 
     from = to = 20000002;
-    if ( !regidx_overlap(idx,"1",from-1,to-1,&itr) ) error("query failed: 1:%d-%d\n",from,to);
+    if ( !regidx_overlap(idx,"1",from-1,to,&itr) ) error("query failed: 1:%d-%d\n",from,to);
 
     from = to = 30000000;
-    if ( !regidx_overlap(idx,"1",from-1,to-1,&itr) ) error("query failed: 1:%d-%d\n",from,to);
+    if ( !regidx_overlap(idx,"1",from-1,to,&itr) ) error("query failed: 1:%d-%d\n",from,to);
 
     // Clean up
     regidx_destroy(idx);


### PR DESCRIPTION
Use 0-based exclusive representation of coordinates from regions and targets files.
Fixes #753 