### PR TITLE
Fix memory leak in knetfile.c

### DIFF
--- a/knetfile.c
+++ b/knetfile.c
@@ -597,6 +597,7 @@ int knet_close(knetFile *fp)
 	free(fp->host); free(fp->port);
 	free(fp->response); free(fp->retr); // FTP specific
 	free(fp->path); free(fp->http_host); // HTTP specific
+	free(fp->size_cmd);
 	free(fp);
 	return 0;
 }


### PR DESCRIPTION
This fixes a memory leak found by fuzzing tools at Google.  Here's the comment from the team that found this:

fp->size_cmd is set to allocated memory in kftp_parse_url() but this is not freed by knet_close(). The fix should be safe in other cases as these allocate the memory of fp via calloc leaving fp->size_cmd equal to NULL by default, and free(NULL) is a nop (https://linux.die.net/man/3/free).