### PR TITLE
Fix possible string truncation warnings

### DIFF
--- a/cram/string_alloc.c
+++ b/cram/string_alloc.c
@@ -148,7 +148,7 @@ char *string_ndup(string_alloc_t *a_str, char *instr, size_t len) {
 
     if (NULL == str) return NULL;
 
-    strncpy(str, instr, len);
+    memcpy(str, instr, len);
     str[len] = 0;
 
     return str;


### PR DESCRIPTION
Detected on Windows after MinGW upgraded to gcc 8.2.0.

string_ndup() now uses memcpy() instead of strncpy() so it
will now copy len bytes even if the string contains a NUL.  This
could only possibly happen in one use of this function (to store
paired read names in process_one_read, if the name illegally
includes an embedded NUL), and even in that case it will not read
any uninitialised memory.