### PR TITLE
Improve c++ compatibility of htslib header files

### DIFF
--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -151,7 +151,8 @@ static inline char *ks_release(kstring_t *s)
 
 static inline int kputsn(const char *p, size_t l, kstring_t *s)
 {
-    if (l > SIZE_MAX - 2 - s->l || ks_resize(s, s->l + l + 2) < 0)
+	size_t new_sz = s->l + l + 2;
+	if (new_sz < s->l || ks_resize(s, new_sz) < 0)
 		return EOF;
 	memcpy(s->s + s->l, p, l);
 	s->l += l;
@@ -183,7 +184,8 @@ static inline int kputc_(int c, kstring_t *s)
 
 static inline int kputsn_(const void *p, size_t l, kstring_t *s)
 {
-	if (l > SIZE_MAX - s->l || ks_resize(s, s->l + l) < 0)
+	size_t new_sz = s->l + l;
+	if (new_sz < s->l || ks_resize(s, new_sz) < 0)
 		return EOF;
 	memcpy(s->s + s->l, p, l);
 	s->l += l;
@@ -208,7 +210,7 @@ static inline int kputuw(unsigned x, kstring_t *s)
 #else
     uint64_t m;
 #endif
-    static const char kputuw_dig2r[200] =
+    static const char kputuw_dig2r[] =
         "00010203040506070809"
         "10111213141516171819"
         "20212223242526272829"

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -876,14 +876,25 @@ typedef struct {
     enables to handle correctly vectors with different ploidy in presence of
     missing values.
  */
-#define bcf_int8_vector_end  (INT8_MIN+1)
-#define bcf_int16_vector_end (INT16_MIN+1)
-#define bcf_int32_vector_end (INT32_MIN+1)
+#define bcf_int8_vector_end  (-127)         /* INT8_MIN  + 1 */
+#define bcf_int16_vector_end (-32767)       /* INT16_MIN + 1 */
+#define bcf_int32_vector_end (-2147483647)  /* INT32_MIN + 1 */
 #define bcf_str_vector_end   0
-#define bcf_int8_missing     INT8_MIN
-#define bcf_int16_missing    INT16_MIN
-#define bcf_int32_missing    INT32_MIN
+#define bcf_int8_missing     (-128)          /* INT8_MIN  */
+#define bcf_int16_missing    (-32767-1)      /* INT16_MIN */
+#define bcf_int32_missing    (-2147483647-1) /* INT32_MIN */
 #define bcf_str_missing      0x07
+
+// Limits on BCF values stored in given types.  Max values are the same
+// as for the underlying type.  Min values are slightly different as
+// the last 8 values for each type were reserved by BCFv2.2.
+#define BCF_MAX_BT_INT8  (0x7f)        /* INT8_MAX  */
+#define BCF_MAX_BT_INT16 (0x7fff)      /* INT16_MAX */
+#define BCF_MAX_BT_INT32 (0x7fffffff)  /* INT32_MAX */
+#define BCF_MIN_BT_INT8  (-120)        /* INT8_MIN  + 8 */
+#define BCF_MIN_BT_INT16 (-32760)      /* INT16_MIN + 8 */
+#define BCF_MIN_BT_INT32 (-2147483640) /* INT32_MIN + 8 */
+
 extern uint32_t bcf_float_vector_end;
 extern uint32_t bcf_float_missing;
 static inline void bcf_float_set(float *ptr, uint32_t value)
@@ -953,8 +964,8 @@ static inline void bcf_enc_size(kstring_t *s, int size, int type)
 
 static inline int bcf_enc_inttype(long x)
 {
-    if (x <= INT8_MAX && x >= INT8_MIN + 8) return BCF_BT_INT8;
-    if (x <= INT16_MAX && x >= INT16_MIN + 8) return BCF_BT_INT16;
+    if (x <= BCF_MAX_BT_INT8 && x >= BCF_MIN_BT_INT8) return BCF_BT_INT8;
+    if (x <= BCF_MAX_BT_INT16 && x >= BCF_MIN_BT_INT16) return BCF_BT_INT16;
     return BCF_BT_INT32;
 }
 
@@ -966,10 +977,10 @@ static inline void bcf_enc_int1(kstring_t *s, int32_t x)
     } else if (x == bcf_int32_missing) {
         bcf_enc_size(s, 1, BCF_BT_INT8);
         kputc(bcf_int8_missing, s);
-    } else if (x <= INT8_MAX && x >= INT8_MIN + 8) {
+    } else if (x <= BCF_MAX_BT_INT8 && x >= BCF_MIN_BT_INT8) {
         bcf_enc_size(s, 1, BCF_BT_INT8);
         kputc(x, s);
-    } else if (x <= INT16_MAX && x >= INT16_MIN + 8) {
+    } else if (x <= BCF_MAX_BT_INT16 && x >= BCF_MIN_BT_INT16) {
         int16_t z = x;
         bcf_enc_size(s, 1, BCF_BT_INT16);
         kputsn((char*)&z, 2, s);

--- a/vcf.c
+++ b/vcf.c
@@ -1731,7 +1731,7 @@ int vcf_hdr_write(htsFile *fp, const bcf_hdr_t *h)
 
 void bcf_enc_vint(kstring_t *s, int n, int32_t *a, int wsize)
 {
-    int32_t max = INT32_MIN + 1, min = INT32_MAX;
+    int32_t max = INT32_MIN, min = INT32_MAX;
     int i;
     if (n <= 0) bcf_enc_size(s, 0, BCF_BT_NULL);
     else if (n == 1) bcf_enc_int1(s, a[0]);
@@ -1742,13 +1742,13 @@ void bcf_enc_vint(kstring_t *s, int n, int32_t *a, int wsize)
             if (max < a[i]) max = a[i];
             if (min > a[i]) min = a[i];
         }
-        if (max <= INT8_MAX && min >= INT8_MIN + 8) {
+        if (max <= BCF_MAX_BT_INT8 && min >= BCF_MIN_BT_INT8) {
             bcf_enc_size(s, wsize, BCF_BT_INT8);
             for (i = 0; i < n; ++i)
                 if ( a[i]==bcf_int32_vector_end ) kputc(bcf_int8_vector_end, s);
                 else if ( a[i]==bcf_int32_missing ) kputc(bcf_int8_missing, s);
                 else kputc(a[i], s);
-        } else if (max <= INT16_MAX && min >= INT16_MIN + 8) {
+        } else if (max <= BCF_MAX_BT_INT16 && min >= BCF_MIN_BT_INT16) {
             uint8_t *p;
             bcf_enc_size(s, wsize, BCF_BT_INT16);
             ks_resize(s, s->l + n * sizeof(int16_t));


### PR DESCRIPTION
Allow room in kputuw_dig2r for the nul byte on the end of the string used to initialize it.  gcc doesn't mind it being dropped but g++ complains.

Fix missing stdint.h limit macros when including htslib/kstring.h and htslib/vcf.h in a c++ compilation.  The C99 standard says c++ implementations should only define them if __STDC_LIMIT_MACROS
is also defined.  C++11 later put them back, but older versions of libc may not provide them without this.

As we can't be sure we're the first to include stdint.h, defining it in our header files may be too late. Instead suitable definitions are added for the macros that are used by each header.

Fixes #771 (kstring.h error: initializer-string for array of chars is too long)