### PR TITLE
Fix the MSYS2 test harness for samtools

### DIFF
--- a/cram/open_trace_file.c
+++ b/cram/open_trace_file.c
@@ -97,7 +97,7 @@ char *tokenise_search_path(char *searchpath) {
     char *newsearch;
     unsigned int i, j;
     size_t len;
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__MSYS__)
     char path_sep = ';';
 #else
     char path_sep = ':';

--- a/hfile.c
+++ b/hfile.c
@@ -686,7 +686,7 @@ static hFILE *hopen_fd_fileuri(const char *url, const char *mode)
     else if (strncmp(url, "file:///", 8) == 0) url += 7;
     else { errno = EPROTONOSUPPORT; return NULL; }
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__MSYS__)
     // For cases like C:/foo
     if (url[0] == '/' && url[2] == ':' && url[3] == '/') url++;
 #endif

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -27,6 +27,9 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef __MSYS__
+#include <strings.h>
+#endif
 #include <errno.h>
 #include <pthread.h>
 #ifndef _WIN32


### PR DESCRIPTION
The MSYS2 default build environment is similar to Cygwin, with the exception of the path style, which is Windows like for MSYS2.
`__MSYS__` macro is only defined for this environment, so it doesn't affect Cygwin, MINGW or Linux builds.
`_WIN32` macro is not defined for this environment, although it is defined for MINGW environments (which can be installed under MSYS2).