### PR TITLE
Fix memory leak in cram_read_SAM_hdr

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3638,8 +3638,10 @@ SAM_hdr *cram_read_SAM_hdr(cram_fd *fd) {
         if (header_len < 0 || NULL == (header = malloc((size_t) header_len+1)))
             return NULL;
 
-        if (header_len != hread(fd->fp, header, header_len))
+        if (header_len != hread(fd->fp, header, header_len)) {
+	    free(header)
             return NULL;
+	}
         header[header_len] = '\0';
 
         fd->first_container += 4 + header_len;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3639,7 +3639,7 @@ SAM_hdr *cram_read_SAM_hdr(cram_fd *fd) {
             return NULL;
 
         if (header_len != hread(fd->fp, header, header_len)) {
-	    free(header)
+            free(header)
             return NULL;
 	}
         header[header_len] = '\0';


### PR DESCRIPTION
Memory allocated on line 3561 in cram_io.c is not cleaned up if the
early-return condition on line 35564 is taken.

More details with the relevant code-snippet:

    if (header_len < 0 || NULL == (header = malloc((size_t) header_len+1)))
            return NULL;

    if (header_len != hread(fd->fp, header, header_len))
            return NULL;

The malloc on the first condition (line 2561) may succeed, but if the following
condition fails the function return's NULL without calling free().