### PR TITLE
On travis, add gcc-8 tests, remove MacOS gcc and try to tidy matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,52 @@
 # Control file for continuous integration testing at http://travis-ci.org/
 
 language: c
-compiler:
-  - clang
-  - gcc
-
-os:
-  - linux
-  - osx
-
-env:
-  - USE_CONFIG=no
-  - USE_CONFIG=yes
 
 matrix:
   include:
-  - compiler: gcc
+  - compiler: gcc-8
     os: linux
-    env: USE_CONFIG=yes USE_LIBDEFLATE=yes
+    env: USE_CONFIG=yes CC=gcc-8 AR=gcc-ar-8
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc-8
+
+  - compiler: gcc-8
+    os: linux
+    env: USE_CONFIG=yes USE_LIBDEFLATE=yes CC=gcc-8 AR=gcc-ar-8
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - gcc-8
+
+  - compiler: clang
+    os: osx
+    env: USE_CONFIG=no
+
+  - compiler: clang
+    os: osx
+    env: USE_CONFIG=yes
+
   - compiler: clang
     os: osx
     env: USE_CONFIG=yes USE_LIBDEFLATE=yes
 
-# For linux systems
-addons:
-  apt:
-    packages:
-    - liblzma-dev
-    - libbz2-dev
+  - compiler: gcc
+    os: linux
+    env: USE_CONFIG=no
+
+  - compiler: gcc
+    os: linux
+    env: USE_CONFIG=yes
+
+  - compiler: clang
+    os: linux
+    env: USE_CONFIG=yes
 
 # For MacOSX systems
 before_install:


### PR DESCRIPTION
Add travis tests that use gcc-8 on Linux.  These take about 50 seconds longer than the installed gcc due to the extra apt install needed, so currently there are only two of them.

Remove the gcc tests on MacOS.  It wasn't really running gcc, it was clang with a gcc front-end.

Put all the tests in the 'matrix:' section instead of having them added implicitly.  This is so we get the right settings for each case and can have more control over exactly which tests get run.

The tests get queued in the same order that they appear in the matrix section.  As Mac jobs tend to be a bit slower to start they've been moved up a bit in the hope that they will tile better with the Linux ones and give a faster run time overall.