### PR TITLE
New filename extension modification API function in htslib/hfile.h 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for htslib, a C library for high-throughput sequencing data formats.
 #
-#    Copyright (C) 2013-2017 Genome Research Ltd.
+#    Copyright (C) 2013-2018 Genome Research Ltd.
 #
 #    Author: John Marshall <jm18@sanger.ac.uk>
 #
@@ -300,7 +300,7 @@ bgzf.o bgzf.pico: bgzf.c config.h $(htslib_hts_h) $(htslib_bgzf_h) $(htslib_hfil
 errmod.o errmod.pico: errmod.c config.h $(htslib_hts_h) $(htslib_ksort_h) $(htslib_hts_os_h)
 kstring.o kstring.pico: kstring.c config.h $(htslib_kstring_h)
 knetfile.o knetfile.pico: knetfile.c config.h $(htslib_hts_log_h) $(htslib_knetfile_h)
-hfile.o hfile.pico: hfile.c config.h $(htslib_hfile_h) $(hfile_internal_h) $(hts_internal_h) $(htslib_khash_h)
+hfile.o hfile.pico: hfile.c config.h $(htslib_hfile_h) $(hfile_internal_h) $(htslib_kstring_h) $(hts_internal_h) $(htslib_khash_h)
 hfile_gcs.o hfile_gcs.pico: hfile_gcs.c config.h $(htslib_hts_h) $(htslib_kstring_h) $(hfile_internal_h)
 hfile_libcurl.o hfile_libcurl.pico: hfile_libcurl.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_net.o hfile_net.pico: hfile_net.c config.h $(hfile_internal_h) $(htslib_knetfile_h)
@@ -413,7 +413,7 @@ test/test-bcf-translate: test/test-bcf-translate.o libhts.a
 
 test/hts_endian.o: test/hts_endian.c config.h $(htslib_hts_endian_h)
 test/fieldarith.o: test/fieldarith.c config.h $(htslib_sam_h)
-test/hfile.o: test/hfile.c config.h $(htslib_hfile_h) $(htslib_hts_defs_h)
+test/hfile.o: test/hfile.c config.h $(htslib_hfile_h) $(htslib_hts_defs_h) $(htslib_kstring_h)
 test/sam.o: test/sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h)
 test/test_bgzf.o: test/test_bgzf.c config.h $(htslib_bgzf_h) $(htslib_hfile_h) $(hfile_internal_h)
 test/test_kstring.o: test/test_kstring.c $(htslib_kstring_h)

--- a/hfile.c
+++ b/hfile.c
@@ -1,6 +1,6 @@
 /*  hfile.c -- buffered low-level input/output streams.
 
-    Copyright (C) 2013-2016 Genome Research Ltd.
+    Copyright (C) 2013-2018 Genome Research Ltd.
 
     Author: John Marshall <jm18@sanger.ac.uk>
 
@@ -35,6 +35,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "htslib/hfile.h"
 #include "hfile_internal.h"
+#include "htslib/kstring.h"
 
 #ifndef ENOTSUP
 #define ENOTSUP EINVAL
@@ -1048,4 +1049,40 @@ int hisremote(const char *fname)
 {
     const struct hFILE_scheme_handler *handler = find_scheme_handler(fname);
     return handler? handler->isremote(fname) : 0;
+}
+
+// Remove an extension, if any, from the basename part of [start,limit).
+// Note: Doesn't notice percent-encoded '.' and '/' characters. Don't do that.
+static const char *strip_extension(const char *start, const char *limit)
+{
+    const char *s = limit;
+    while (s > start) {
+        --s;
+        if (*s == '.') return s;
+        else if (*s == '/') break;
+    }
+    return limit;
+}
+
+char *haddextension(struct kstring_t *buffer, const char *filename,
+                    int replace, const char *new_extension)
+{
+    const char *trailing, *end;
+
+    if (find_scheme_handler(filename)) {
+        // URL, so alter extensions before any trailing query or fragment parts
+        trailing = filename + strcspn(filename, "?#");
+    }
+    else {
+        // Local path, so alter extensions at the end of the filename
+        trailing = strchr(filename, '\0');
+    }
+
+    end = replace? strip_extension(filename, trailing) : trailing;
+
+    buffer->l = 0;
+    if (kputsn(filename, end - filename, buffer) >= 0 &&
+        kputs(new_extension, buffer) >= 0 &&
+        kputs(trailing, buffer) >= 0) return buffer->s;
+    else return NULL;
 }

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -3,7 +3,7 @@
 /*
    Copyright (c) 2008 Broad Institute / Massachusetts Institute of Technology
                  2011, 2012 Attractive Chaos <attractor@live.co.uk>
-   Copyright (C) 2009, 2013, 2014,2017 Genome Research Ltd
+   Copyright (C) 2009, 2013, 2014, 2017, 2018 Genome Research Ltd
 
    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
@@ -53,6 +53,7 @@ extern "C" {
 
 struct hFILE;
 struct hts_tpool;
+struct kstring_t;
 struct bgzf_mtaux_t;
 typedef struct __bgzidx_t bgzidx_t;
 typedef struct bgzf_cache_t bgzf_cache_t;
@@ -76,14 +77,6 @@ struct BGZF {
 #ifndef HTS_BGZF_TYPEDEF
 typedef struct BGZF BGZF;
 #define HTS_BGZF_TYPEDEF
-#endif
-
-#ifndef KSTRING_T
-#define KSTRING_T kstring_t
-typedef struct __kstring_t {
-    size_t l, m;
-    char *s;
-} kstring_t;
 #endif
 
     /******************
@@ -275,7 +268,7 @@ typedef struct __kstring_t {
      * @param str    string to write to; must be initialized
      * @return       length of the string; -1 on end-of-file; <= -2 on error
      */
-    int bgzf_getline(BGZF *fp, int delim, kstring_t *str);
+    int bgzf_getline(BGZF *fp, int delim, struct kstring_t *str);
 
     /**
      * Read the next BGZF block.

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -1,7 +1,7 @@
 /// @file htslib/hfile.h
 /// Buffered low-level input/output streams.
 /*
-    Copyright (C) 2013-2016 Genome Research Ltd.
+    Copyright (C) 2013-2018 Genome Research Ltd.
 
     Author: John Marshall <jm18@sanger.ac.uk>
 
@@ -37,6 +37,8 @@ extern "C" {
 #endif
 
 struct hFILE_backend;
+struct kstring_t;
+
 /// Low-level input/output stream handle
 /** The fields of this structure are declared here solely for the benefit
 of the hFILE-related inline functions.  They may change in future releases.
@@ -81,6 +83,20 @@ hFILE *hdopen(int fd, const char *mode) HTS_RESULT_USED;
 that callers may wish to cache such files' contents locally.
 */
 int hisremote(const char *filename) HTS_RESULT_USED;
+
+/// Append an extension or replace an existing extension
+/** @param buffer     The kstring to be used to store the modified filename
+    @param filename   The filename to be (copied and) adjusted
+    @param replace    If non-zero, one extension (if any) is removed first
+    @param extension  The extension to be added (e.g. ".csi")
+    @return  The modified filename (i.e., `buffer->s`), or NULL on error.
+    @since   1.10
+
+If _filename_ is an URL, alters extensions at the end of the `hier-part`,
+leaving any trailing `?query` or `#fragment` unchanged.
+*/
+char *haddextension(struct kstring_t *buffer, const char *filename,
+                    int replace, const char *extension) HTS_RESULT_USED;
 
 /// Flush (for output streams) and close the stream
 /** @return  0 if successful, or `EOF` (with _errno_ set) if an error occurred.

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -48,7 +48,7 @@ struct hts_tpool;
 
 #ifndef KSTRING_T
 #define KSTRING_T kstring_t
-typedef struct __kstring_t {
+typedef struct kstring_t {
     size_t l, m;
     char *s;
 } kstring_t;

--- a/htslib/kseq.h
+++ b/htslib/kseq.h
@@ -89,7 +89,7 @@
 
 #ifndef KSTRING_T
 #define KSTRING_T kstring_t
-typedef struct __kstring_t {
+typedef struct kstring_t {
 	size_t l, m;
 	char *s;
 } kstring_t;

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -70,7 +70,7 @@
  * destroyed with  free(str.s);  */
 #ifndef KSTRING_T
 #define KSTRING_T kstring_t
-typedef struct __kstring_t {
+typedef struct kstring_t {
 	size_t l, m;
 	char *s;
 } kstring_t;

--- a/test/hfile.c
+++ b/test/hfile.c
@@ -1,6 +1,6 @@
 /*  test/hfile.c -- Test cases for low-level input/output streams.
 
-    Copyright (C) 2013-2014, 2016 Genome Research Ltd.
+    Copyright (C) 2013-2014, 2016, 2018 Genome Research Ltd.
 
     Author: John Marshall <jm18@sanger.ac.uk>
 
@@ -33,6 +33,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "htslib/hfile.h"
 #include "htslib/hts_defs.h"
+#include "htslib/kstring.h"
 
 void HTS_NORETURN fail(const char *format, ...)
 {
@@ -278,6 +279,29 @@ int main(void)
 "of knowledge, exceeds the short vehemence of any carnal pleasure.") != 0)
         fail("hread result for base64");
     if (hclose(fin) != 0) fail("hclose(\"data:;base64,...\")");
+
+    kstring_t kstr = { 0, 0, NULL };
+
+    if (strcmp(haddextension(&kstr, "foo/bar.bam", 0, ".bai"),
+               "foo/bar.bam.bai") != 0) fail("haddextension foo/bar.bam[.bai]");
+    if (strcmp(haddextension(&kstr, "foo/bar.bam", 1, ".bai"),
+               "foo/bar.bai") != 0) fail("haddextension foo/bar[.bai]");
+    if (strcmp(haddextension(&kstr, "foo.bar/baz", 1, ".bai"),
+               "foo.bar/baz.bai") != 0) fail("haddextension foo.bar/baz[.bai]");
+    if (strcmp(haddextension(&kstr, "foo#bar.bam", 0, ".bai"),
+               "foo#bar.bam.bai") != 0) fail("haddextension foo#bar.bam[.bai]");
+    if (strcmp(haddextension(&kstr, ".bam", 1, ".bai"),
+               ".bai") != 0) fail("haddextension [.bai]");
+    if (strcmp(haddextension(&kstr, "foo", 1, ".csi"),
+               "foo.csi") != 0) fail("haddextension foo[.csi]");
+
+    if (strcmp(haddextension(&kstr, "http://host/bar.cram?a&b&c", 0, ".crai"),
+               "http://host/bar.cram.crai?a&b&c") != 0)
+        fail("haddextension http://host/bar.cram[.crai]?a&b&c");
+
+    if (strcmp(haddextension(&kstr, "http://host/bar.cram#frag", 1, ".crai"),
+               "http://host/bar.crai#frag") != 0)
+        fail("haddextension http://host/bar[.crai]#frag");
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
As noted in #784, HTSlib would benefit from an URL-aware function to add/replace filename extensions.

`hisremote()` is precedent for _hfile.h_ functions not directly associated with I/O, and similarly `haddextension()` can reuse the same URL-detection infrastructure — so _hfile.c_ is a good place for it. So here is a suggested API.

I previously tried to keep `kstring_t` out of _hfile.h_ :smile:, but with the first commit enabling better forward `struct kstring_t` declarations it's less invasive.

This will misrecognise filenames like `foo:bar?baz` as URLs, but there's not much that can be done about it (the library doesn't know which if any file should exist, so `access(2)` doesn't help), such filenames deserve what they get, and `./foo:bar?baz` is a workaround to ensure it's recognised as a file path.