### PR TITLE
Use new haddexension API when fetching remote indices.

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -2775,33 +2775,46 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_multi_t *iter, void *r)
 /**********************
  *** Retrieve index ***
  **********************/
+// Local_fn and local_len will return a sub-region of 'fn'.
+// Eg http://elsewhere/dir/foo.bam.bai?a=b may return
+// foo.bam.bai via local_fn and local_len.
+//
 // Returns -1 if index couldn't be opened.
 //         -2 on other errors
-static int test_and_fetch(const char *fn, const char **local_fn)
+static int test_and_fetch(const char *fn, const char **local_fn, int *local_len)
 {
     hFILE *remote_hfp;
     FILE *local_fp = NULL;
     uint8_t *buf = NULL;
     int save_errno;
+    kstring_t s = {0};
 
     if (hisremote(fn)) {
         const int buf_size = 1 * 1024 * 1024;
         int l;
-        const char *p;
-        for (p = fn + strlen(fn) - 1; p >= fn; --p)
-            if (*p == '/') break;
-        ++p; // p now points to the local file name
+        const char *p, *e;
+        // Ignore ?# params: eg any file.fmt?param=val
+        e = fn + strcspn(fn, "?#");
+        // Find the previous slash from there.
+        p = e;
+        while (p > fn && *p != '/') p--;
+        if (*p == '/') p++;
+        *local_len = e-p;
+
         // Attempt to open local file first
-        if ((local_fp = fopen((char*)p, "rb")) != 0)
+        kputsn(p, e-p, &s);
+        if ((local_fp = fopen(s.s, "rb")) != 0)
         {
             fclose(local_fp);
+            free(s.s);
             *local_fn = p;
             return 0;
         }
+
         // Attempt to open remote file. Stay quiet on failure, it is OK to fail when trying first .csi then .tbi index.
         if ((remote_hfp = hopen(fn, "r")) == 0) return -1;
-        if ((local_fp = fopen(p, "w")) == 0) {
-            hts_log_error("Failed to create file %s in the working directory", p);
+        if ((local_fp = fopen(s.s, "w")) == 0) {
+            hts_log_error("Failed to create file %s in the working directory", s.s);
             goto fail;
         }
         hts_log_info("Downloading file %s to local directory", fn);
@@ -2827,12 +2840,14 @@ static int test_and_fetch(const char *fn, const char **local_fn)
             hts_log_error("Failed to close remote file %s", fn);
         }
         *local_fn = p;
+        free(s.s);
         return 0;
     } else {
         hFILE *local_hfp;
         if ((local_hfp = hopen(fn, "r")) == 0) return -1;
         hclose_abruptly(local_hfp);
         *local_fn = fn;
+        *local_len = strlen(fn);
         return 0;
     }
 
@@ -2841,35 +2856,39 @@ static int test_and_fetch(const char *fn, const char **local_fn)
     hclose_abruptly(remote_hfp);
     if (local_fp) fclose(local_fp);
     free(buf);
+    free(s.s);
     errno = save_errno;
     return -2;
 }
 
 char *hts_idx_getfn(const char *fn, const char *ext)
 {
-    int i, l_fn, l_ext, ret;
+    int ret, local_len;
     char *fnidx;
     const char *local_fn = NULL;
-    l_fn = strlen(fn); l_ext = strlen(ext);
-    fnidx = (char*)calloc(l_fn + l_ext + 1, 1);
-    if (!fnidx) return NULL;
+    kstring_t buffer = {0};
+
     // First try : append `ext` to `fn`
-    strcpy(fnidx, fn); strcpy(fnidx + l_fn, ext);
-    if ((ret = test_and_fetch(fnidx, &local_fn)) == -1) {
-        // Second try : replace suffix of `fn` with `ext`
-        for (i = l_fn - 1; i > 0; --i)
-            if (fnidx[i] == '.' || fnidx[i] == '/') break;
-        if (fnidx[i] == '.') {
-            strcpy(fnidx + i, ext);
-            ret = test_and_fetch(fnidx, &local_fn);
-        }
-    }
-    if (ret < 0) {
-        free(fnidx);
+    if (!(fnidx = haddextension(&buffer, fn, 0, ext))) {
+        free(buffer.s);
         return NULL;
     }
-    l_fn = strlen(local_fn);
-    memmove(fnidx, local_fn, l_fn + 1);
+    if ((ret = test_and_fetch(fnidx, &local_fn, &local_len)) == -1) {
+        // Second try : replace suffix of `fn` with `ext`
+        if (!(fnidx = haddextension(&buffer, fn, 1, ext))) {
+            free(buffer.s);
+            return NULL;
+        }
+        ret = test_and_fetch(fnidx, &local_fn, &local_len);
+    }
+
+    if (ret < 0) {
+        free(buffer.s);
+        return NULL;
+    }
+
+    memmove(fnidx, local_fn, local_len);
+    fnidx[local_len] = 0;
     return fnidx;
 }
 


### PR DESCRIPTION
Specifically range querying e.g. https://server/a/b/c.bam?param=val
will now retrieve https://server/a/b/c.bam.bai?param=val and locally
write this to c.bam.bai.

Fixes #784

I confess however it is not without problem, but whether it is a problem that needs fixing in this PR or is a separate issue I do not know.  Specifically file:// URIs are questionable in their use of percents.  https://tools.ietf.org/html/rfc8089 states that UTF8 files SHOULD be percent encoded, but then goes on to discuss heuristics and explicit knowledge for decisions when not to percent encode.  I assume percent itself however must always be encoded...

The very first file I chose to test file: on happened to be `file:///nfs/sam_scratch/jkb/data/9827_2#49.bam`.  It worked before, and doesn't now due to the `#`.  Furthermore, we cannot escape that with %23 instead.

I don't know what the best solution is here (other than to not use file: URIs).  Possible choices are to not do the ?# trimming on file URIs (technically we should), or to do so local hackery trying with/without and see what works (messy).