### PR TITLE
Allow splitting of MD5 string in cram REF_PATH URLs

### DIFF
--- a/cram/open_trace_file.c
+++ b/cram/open_trace_file.c
@@ -168,45 +168,48 @@ char *tokenise_search_path(char *searchpath) {
     return newsearch;
 }
 
+static char *expand_path(char *file, char *dirname, int max_s_digits);
+
 mFILE *find_file_url(char *file, char *url) {
-    char buf[8192], *cp;
+    char *path = NULL, buf[8192];
     mFILE *mf = NULL;
-    int maxlen = 8190 - strlen(file), len;
-    hFILE *hf;
+    ssize_t len;
+    hFILE *hf = NULL;
 
-    /* Expand %s for the trace name */
-    for (cp = buf; *url && cp - buf < maxlen; url++) {
-        if (*url == '%' && *(url+1) == 's') {
-            url++;
-            cp += strlen(strcpy(cp, file));
-        } else {
-            *cp++ = *url;
-        }
-    }
-    *cp++ = 0;
+    /* Expand %s for the trace name.  Only one digit is allowed between
+       The % and s to avoid ambiguity with percent-encoded URLs */
 
-    if (!(hf = hopen(buf, "r"))) {
-        if (errno != ENOENT)
-            hts_log_warning("Failed to open reference \"%s\": %s", buf, strerror(errno));
+    path = expand_path(file, url, 1);
+    if (!path)
         return NULL;
+
+    if (!(hf = hopen(path, "r"))) {
+        if (errno != ENOENT)
+            hts_log_warning("Failed to open reference \"%s\": %s", path, strerror(errno));
+        goto fail;
     }
 
     if (NULL == (mf = mfcreate(NULL, 0)))
-        return NULL;
-    while ((len = hread(hf, buf, 8192)) > 0) {
+        goto fail;
+    while ((len = hread(hf, buf, sizeof(buf))) > 0) {
         if (mfwrite(buf, len, 1, mf) <= 0) {
             hclose_abruptly(hf);
-            mfdestroy(mf);
-            return NULL;
+            goto fail;
         }
     }
     if (hclose(hf) < 0 || len < 0) {
-        mfdestroy(mf);
-        return NULL;
+        hts_log_warning("Failed to read reference \"%s\": %s", path, strerror(errno));
+        goto fail;
     }
 
+    free(path);
     mrewind(mf);
     return mf;
+
+ fail:
+    mfdestroy(mf);
+    free(path);
+    return NULL;
 }
 
 /*
@@ -215,14 +218,16 @@ mFILE *find_file_url(char *file, char *url) {
  *
  * Returns expanded pathname or NULL for malloc failure.
  */
-static char *expand_path(char *file, char *dirname) {
+static char *expand_path(char *file, char *dirname, int max_s_digits) {
     size_t len = strlen(dirname);
     size_t lenf = strlen(file);
     char *cp, *path;
 
     path = malloc(len+lenf+2); // worst expansion DIR/FILE
-    if (!path)
+    if (!path) {
+        hts_log_error("Out of memory");
         return NULL;
+    }
 
     if (dirname[len-1] == '/')
         len--;
@@ -237,7 +242,7 @@ static char *expand_path(char *file, char *dirname) {
         while ((cp = strchr(dirname, '%'))) {
             char *endp;
             long l = strtol(cp+1, &endp, 10);
-            if (*endp != 's') {
+            if (*endp != 's' || endp - cp - 1 > max_s_digits) {
                 strncpy(path_end, dirname, (endp+1)-dirname);
                 path_end += (endp+1)-dirname;
                 dirname = endp+1;
@@ -283,7 +288,9 @@ static mFILE *find_file_dir(char *file, char *dirname) {
     char *path;
     mFILE *mf = NULL;
 
-    path = expand_path(file, dirname);
+    path = expand_path(file, dirname, INT_MAX);
+    if (!path)
+        return NULL;
 
     if (is_file(path))
         mf = mfopen(path, "rbm");
@@ -407,7 +414,7 @@ char *find_path(char *file, char *path) {
             !strncmp(ele2, "ftp:", 4)) {
             continue;
         } else {
-            outpath = expand_path(file, ele2);
+            outpath = expand_path(file, ele2, INT_MAX);
             if (is_file(outpath)) {
                 free(newsearch);
                 return outpath;


### PR DESCRIPTION
When expanding file names in REF_PATH, it's possible to substitute %Ns (where N is a number) to include the next N characters of the reference hex MD5 checksum. Using %s with no digit adds all of the remaining characters.

For some reason, http:// etc. URLs in REF_PATH only allowed the %s substitution.  This pull request allows the %Ns version as well, with the minor difference that N can only be a single digit (to avoid
URL percent-encodings like %25 that are followed by an 's' character from being misinterpreted).

This is implemented by making find_file_url() use the same expand_path() function as find_file_dir().  expand_path() gets an extra parameter so the URL version can limit the number
of digits between the '%' and 's'.  find_file_url() gets some extra error handling code to free up the memory returned by expand_path().