### PR TITLE
Add checks for missing copyright boilerplate, tabs and trailing spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: c
 
 matrix:
   include:
+  - compiler: gcc
+    os: linux
+    env: DO_MAINTAINER_CHECKS=yes USE_CONFIG=no
+
   - compiler: gcc-8
     os: linux
     env: USE_CONFIG=yes CC=gcc-8 AR=gcc-ar-8
@@ -38,10 +42,6 @@ matrix:
 
   - compiler: gcc
     os: linux
-    env: USE_CONFIG=no
-
-  - compiler: gcc
-    os: linux
     env: USE_CONFIG=yes
 
   - compiler: clang
@@ -56,5 +56,6 @@ before_script:
   - if test "x$USE_LIBDEFLATE" == "xyes" ; then ( cd "$HOME" && git clone --depth 1 https://github.com/ebiggers/libdeflate.git && cd libdeflate && make -j 2 CFLAGS='-fPIC -O3' libdeflate.a ); fi
 
 script:
+  - if test "xDO_MAINTAINER_CHECKS" = "xyes" ; then make maintainer-check ; fi
   - if test "x$USE_LIBDEFLATE" = "xyes" ; then CONFIG_OPTS='CPPFLAGS="-I$HOME/libdeflate" LDFLAGS="-L$HOME/libdeflate" --with-libdeflate' ; else CONFIG_OPTS='--without-libdeflate' ; fi
-  - if test "$USE_CONFIG" = "yes" ; then autoreconf && eval ./configure --enable-werror $CONFIG_OPTS CFLAGS=\"-g -O3\" || { cat config.log ; false ; } ; fi && make -j 2 -e && make test
+  - if test "$USE_CONFIG" = "yes" ; then autoreconf && eval ./configure --enable-werror $CONFIG_OPTS CFLAGS=\"-g -O3\" || { cat config.log ; false ; } ; fi && if test "xDO_MAINTAINER_CHECKS" = "xyes" ; then make maintainer-check ; fi && make -j 2 -e && make test

--- a/Makefile
+++ b/Makefile
@@ -357,6 +357,12 @@ bgzip.o: bgzip.c config.h $(htslib_bgzf_h) $(htslib_hts_h)
 htsfile.o: htsfile.c config.h $(htslib_hfile_h) $(htslib_hts_h) $(htslib_sam_h) $(htslib_vcf_h)
 tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_regidx_h)
 
+# Maintainer source code checks
+# - copyright boilerplate presence
+# - tab and trailing space detection
+maintainer-check:
+	test/maintainer/check_copyright.pl .
+	test/maintainer/check_spaces.pl .
 
 # For tests that might use it, set $REF_PATH explicitly to use only reference
 # areas within the test suite (or set it to ':' to use no reference areas).

--- a/bgzf.c
+++ b/bgzf.c
@@ -610,14 +610,14 @@ static int inflate_gzip_block(BGZF *fp)
 {
     // we will set this to true when we detect EOF, so we don't bang against the EOF more than once per call
     int input_eof = 0;
-    
+
     // write to the part of the output buffer after block_offset
     fp->gz_stream->next_out = (Bytef*)fp->uncompressed_block + fp->block_offset;
     fp->gz_stream->avail_out = BGZF_MAX_BLOCK_SIZE - fp->block_offset;
-    
+
     while ( fp->gz_stream->avail_out != 0 ) {
         // until we fill the output buffer (or hit EOF)
-        
+
         if ( !input_eof && fp->gz_stream->avail_in == 0 ) {
             // we are out of input data in the buffer. Get more.
             fp->gz_stream->next_in = fp->compressed_block;
@@ -632,11 +632,11 @@ static int inflate_gzip_block(BGZF *fp)
                 input_eof = 1;
             }
         }
-        
+
         fp->gz_stream->msg = NULL;
         // decompress as much data as we can
         int ret = inflate(fp->gz_stream, Z_SYNC_FLUSH);
-        
+
         if ( (ret < 0 && ret != Z_BUF_ERROR) || ret == Z_NEED_DICT ) {
             // an error occurred, other than running out of space
             hts_log_error("Inflate operation failed: %s", bgzf_zerr(ret, ret == Z_DATA_ERROR ? fp->gz_stream : NULL));
@@ -644,7 +644,7 @@ static int inflate_gzip_block(BGZF *fp)
             return -1;
         } else if ( ret == Z_STREAM_END ) {
             // we finished a GZIP member
-            
+
             // scratch for peeking to see if the file is over
             char c;
             if (fp->gz_stream->avail_in > 0 || hpeek(fp->fp, &c, 1) == 1) {
@@ -667,7 +667,7 @@ static int inflate_gzip_block(BGZF *fp)
             return -1;
         }
     }
-    
+
     // when we get here, the buffer is full or there is an EOF after a complete gzip member
     return BGZF_MAX_BLOCK_SIZE - fp->gz_stream->avail_out;
 }

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -2772,14 +2772,14 @@ static int process_one_read(cram_fd *fd, cram_container *c,
                 break;
 
             case BAM_CDEL:
-		if (MD && ref) {
+                if (MD && ref) {
                     kputuw(apos - MD_last, MD);
-		    if (apos < c->ref_end) {
+                    if (apos < c->ref_end) {
                         kputc_('^', MD);
                         kputsn(&ref[apos], MIN(c->ref_end - apos, cig_len), MD);
-		    }
-		}
-		NM += cig_len;
+                    }
+                }
+                NM += cig_len;
 
                 if (cram_add_deletion(c, s, cr, spos, cig_len, &seq[spos]))
                     return -1;

--- a/test/compare_sam.pl
+++ b/test/compare_sam.pl
@@ -89,14 +89,14 @@ while ($ln1 && $ln2) {
     # 2: if file 2 has NM/MD keep in file 1, othewise discard from file1
     # 3: if file 1 and file 2 both have NM/MD keep, otherwise discard.
     if (exists $opts{partialmd}) {
-	if ($opts{partialmd} & 2) {
-	    $ln1 =~ s/\tNM:i:\d+//        unless ($ln2 =~ /\tNM:i:\d+/);
-	    $ln1 =~ s/\tMD:Z:[A-Z0-9^]*// unless ($ln2 =~ /\tMD:Z:[A-Z0-9^]*/);
-	}
-	if ($opts{partialmd} & 1) {
-	    $ln2 =~ s/\tNM:i:\d+//        unless ($ln1 =~ /\tNM:i:\d+/);
-	    $ln2 =~ s/\tMD:Z:[A-Z0-9^]*// unless ($ln1 =~ /\tMD:Z:[A-Z0-9^]*/);
-	}
+        if ($opts{partialmd} & 2) {
+            $ln1 =~ s/\tNM:i:\d+//        unless ($ln2 =~ /\tNM:i:\d+/);
+            $ln1 =~ s/\tMD:Z:[A-Z0-9^]*// unless ($ln2 =~ /\tMD:Z:[A-Z0-9^]*/);
+        }
+        if ($opts{partialmd} & 1) {
+            $ln2 =~ s/\tNM:i:\d+//        unless ($ln1 =~ /\tNM:i:\d+/);
+            $ln2 =~ s/\tMD:Z:[A-Z0-9^]*// unless ($ln1 =~ /\tMD:Z:[A-Z0-9^]*/);
+        }
     }
 
     my @ln1 = split("\t", $ln1);

--- a/test/cross_validate.sh
+++ b/test/cross_validate.sh
@@ -1,5 +1,24 @@
 #!/bin/sh
 
+#     Copyright (C) 2015 Genome Research Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
 #
 # -----------------------------------------------------------------------------
 # Author: James Bonfield.

--- a/test/maintainer/check_copyright.pl
+++ b/test/maintainer/check_copyright.pl
@@ -1,0 +1,95 @@
+#!/usr/bin/perl
+# check_copyright.pl : Basic source file checks for copyright boilerplate
+#
+#     Author : Rob Davies <rmd@sanger.ac.uk>
+#
+#     Copyright (C) 2018 Genome Research Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+use strict;
+use warnings;
+use File::Find;
+use Getopt::Long;
+
+my $verbose = 0;
+GetOptions('v' => \$verbose);
+
+my ($root) = @ARGV;
+if (!$root) {
+    die "Usage: $0 [-v] <directory>\n";
+}
+my $errors = 0;
+find({ wanted => \&check, no_chdir=>1}, $root);
+exit($errors ? 1 : 0);
+
+sub check {
+    # Only check C, perl and shell files
+    return unless (/(?:\.[ch]|\.pl|\.sh)$/);
+
+    # Exclusions:
+    my %exclude = map { ("$root/$_", 1) } (
+'config.h',         # Auto-generated
+'version.h',        # Auto-generated
+'cram/rANS_byte.h', # "Public domain"
+'os/lzma_stub.h',   # "Public domain"
+'os/rand.c');       # drand48 license
+    return if exists($exclude{$_});
+
+    my $remove_left = /\.[ch]$/ ? qr/\s*\*?\s*/ : qr/\s*#\s*/;
+
+    return unless (-f $_);      # Only check plain files
+    my $in;
+    if (!open($in, '<', $_)) {
+        print STDERR "Couldn't open $_ : $!\n";
+        $errors++;
+        return;
+    }
+    my $count = 0;
+    my $copyright_found = 0;
+    my $license_found = "";
+    my $line;
+    while ($count < 100 && ($line = <$in>)) {
+        $count++;
+        $line =~ s/^$remove_left//;
+        $line =~ s/\s+/ /g;
+        if ($line =~ /^Copyright\s+\([cC]\)\s+(?:19|20)\d\d[-, ]/) {
+            $copyright_found = 1;
+        } elsif ($line =~ /^Redistribution and use in source and binary forms/) {
+            $license_found = "BSD";
+        } elsif ($line =~ /^Permission is hereby granted, free of charge/) {
+            $license_found = "MIT";
+        }
+        last if ($copyright_found && $license_found);
+    }
+    if (!close($in)) {
+        print STDERR "Error on closing $_ : $!\n";
+        $errors++;
+        return;
+    }
+    my $failed = (!$copyright_found || !$license_found);
+    if ($verbose || $failed) {
+        printf("$_ : %s%s\n",
+               $license_found ? $license_found : "no_license",
+               $copyright_found ? "" : " no_copyright_line");
+    }
+    if ($failed) {
+        $errors++;
+    }
+}

--- a/test/maintainer/check_spaces.pl
+++ b/test/maintainer/check_spaces.pl
@@ -1,0 +1,92 @@
+#!/usr/bin/perl
+# check_spaces.pl : Check source files for tabs and trailing spaces
+#
+#     Author : Rob Davies <rmd@sanger.ac.uk>
+#
+#     Copyright (C) 2018 Genome Research Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+use strict;
+use warnings;
+use File::Find;
+use Getopt::Long;
+
+my $verbose = 0;
+GetOptions('v' => \$verbose);
+
+my ($root) = @ARGV;
+if (!$root) {
+    die "Usage: $0 [-v] <directory>\n";
+}
+my $errors = 0;
+find({ wanted => \&check, no_chdir=>1}, $root);
+exit($errors ? 1 : 0);
+
+sub check {
+    # Only check C, perl and shell files
+    return unless (/(?:\.[ch]|\.pl|\.sh)$/);
+
+    my %allow_tabs = map { ("$root/$_", 1) } (
+'kfunc.c',
+'knetfile.c',
+'kstring.c',
+'md5.c',
+'htslib/khash.h',
+'htslib/kseq.h',
+'htslib/ksort.h',
+'htslib/kstring.h',
+'htslib/knetfile.h',
+'htslib/klist.h',
+'htslib/kbitset.h',
+'os/rand.c',
+);
+
+    my $check_tabs = !exists($allow_tabs{$_});
+
+    my $in;
+    if (!open($in, '<', $_)) {
+        print STDERR "Couldn't open $_ : $!\n";
+        $errors++;
+        return;
+    }
+    my $tab = 0;
+    my $trailing = 0;
+    while (my $line = <$in>) {
+        chomp($line);
+        if ($check_tabs && $line =~ /\t/)  { $tab = 1; }
+        if ($line =~ /\s$/) { $trailing = 1; }
+    }
+    if (!close($in)) {
+        print STDERR "Error on closing $_ : $!\n";
+        $errors++;
+        return;
+    }
+    my $failed = ($tab || $trailing);
+    if ($verbose || $failed) {
+        my $msg = ($failed ? join(" ",
+                                  $tab ? ("includes_tabs") : (),
+                                  $trailing ? "trailing_spaces" : ())
+                   : "ok");
+        print "$_ : $msg\n";
+    }
+    if ($failed) {
+        $errors++;
+    }
+}

--- a/test/pileup.c
+++ b/test/pileup.c
@@ -80,7 +80,7 @@ static int print_pileup_seq(const bam_pileup1_t *p, int n) {
 
         if (p->is_head)
             putchar('^'), putchar('!'+MIN(p->b->core.qual,93));
-        
+
         if (p->is_del)
             putchar(p->is_refskip ? (is_rev ? '<' : '>') : '*');
         else {

--- a/test/simple_test_driver.sh
+++ b/test/simple_test_driver.sh
@@ -35,96 +35,96 @@ run_test() {
     y=""
     if [ "x$test_iter" = "x" ]
     then
-	test_iter=1
+        test_iter=1
     else
-	test_iter=`expr $test_iter + 1`
+        test_iter=`expr $test_iter + 1`
     fi
     result=`eval ${@+"$@"} 2>_err.tmp > _out.tmp`
     if [ $? != 0 ]
     then
-	if [ "$p" != "N" ]
-	then
-	    # Expected zero exit code, got non-zero
-	    r="F"
-	    y="exit_code"
-	else
-	    # Expected non-zero exit code and got it
-	    r="P"
-	fi
+        if [ "$p" != "N" ]
+        then
+            # Expected zero exit code, got non-zero
+            r="F"
+            y="exit_code"
+        else
+            # Expected non-zero exit code and got it
+            r="P"
+        fi
     elif [ "$p" = "N" ]
     then
-	# Expected non-zero exit code, but got zero
-	r="F"
-	y="exit_code"
+        # Expected non-zero exit code, but got zero
+        r="F"
+        y="exit_code"
     elif [ "x$e" != "x" -a "$e" != "." ]
     then
         sed -n 's/.*/&/p' _out.tmp > _out.tmp2
-	if cmp -s _out.tmp2 "$e"
-	then
-	    # Output was as expected
-	    r="P"
-	    rm -f _out.tmp _out.tmp2 _err.tmp
-	else
-	    # Output differed
-	    r="F"
-	    y="output"
-	fi
+        if cmp -s _out.tmp2 "$e"
+        then
+            # Output was as expected
+            r="P"
+            rm -f _out.tmp _out.tmp2 _err.tmp
+        else
+            # Output differed
+            r="F"
+            y="output"
+        fi
     else
-	# Expected zero exit code and got it.
-	r="P"
-	rm -f _out.tmp _out.tmp2 _err.tmp
+        # Expected zero exit code and got it.
+        r="P"
+        rm -f _out.tmp _out.tmp2 _err.tmp
     fi
 
     if [ "$r" = "F" ]
     then
-	# Test failed
-	case "$p" in
-	    [PN])
-		echo "FAIL : $@"
-		if [ "x$e" != "x" -a "$e" != "." ]
-		then
-		    keep_output="FAIL-$e.${test_iter}"
-		else
-		    keep_output="FAIL.${test_iter}"
-		fi
-		mv _out.tmp "${keep_output}.out"
-		mv _err.tmp "${keep_output}.err"
-		nufail=`expr $nufail + 1`
-		if [ "$y" = "exit_code" ]
-		then
-		    if [ "$p" != "N" ]
-		    then
-			echo "Got non-zero exit code"
-		    else
-			echo "Got unexpected zero exit code"
-		    fi
-		    echo "See ${keep_output}.{out,err} for output"
-		else
-		    echo "Output differed from expected result"
-		    echo "Compare $e ${keep_output}.out"
-		fi
-		;;
-	    *)
-		echo "XFAIL: $@"
-		nefail=`expr $nefail + 1`
-		;;
-	esac
+        # Test failed
+        case "$p" in
+            [PN])
+                echo "FAIL : $@"
+                if [ "x$e" != "x" -a "$e" != "." ]
+                then
+                    keep_output="FAIL-$e.${test_iter}"
+                else
+                    keep_output="FAIL.${test_iter}"
+                fi
+                mv _out.tmp "${keep_output}.out"
+                mv _err.tmp "${keep_output}.err"
+                nufail=`expr $nufail + 1`
+                if [ "$y" = "exit_code" ]
+                then
+                    if [ "$p" != "N" ]
+                    then
+                        echo "Got non-zero exit code"
+                    else
+                        echo "Got unexpected zero exit code"
+                    fi
+                    echo "See ${keep_output}.{out,err} for output"
+                else
+                    echo "Output differed from expected result"
+                    echo "Compare $e ${keep_output}.out"
+                fi
+                ;;
+            *)
+                echo "XFAIL: $@"
+                nefail=`expr $nefail + 1`
+                ;;
+        esac
     else
-	# Test passed
-	case "$p" in
-	    "P")
-		echo "PASS : $@"
-		nepass=`expr $nepass + 1`
-		;;
-	    "N")
-		echo "PASS : $@ (must exit non-zero)"
-		nepass=`expr $nepass + 1`
-		;;
-	    *)
-		echo "XPASS: $@"
-		nupass=`expr $nupass + 1`
-		;;
-	esac
+        # Test passed
+        case "$p" in
+            "P")
+                echo "PASS : $@"
+                nepass=`expr $nepass + 1`
+                ;;
+            "N")
+                echo "PASS : $@ (must exit non-zero)"
+                nepass=`expr $nepass + 1`
+                ;;
+            *)
+                echo "XPASS: $@"
+                nupass=`expr $nupass + 1`
+                ;;
+        esac
     fi
 }
 
@@ -150,29 +150,29 @@ test_driver() {
     exec 9<"$1"
     while read -r line <&9
     do
-	set -- $line
-	case $1 in
+        set -- $line
+        case $1 in
             "#"*) # skip comments
-		;;
+                ;;
             "")   # skip blank lines too
-		;;
+                ;;
 
-	    "INIT")
-		shift
-		eval ${@+"$@"} > /dev/null
-		if [ $? != 0 ]
-		then
-		    echo "INIT FAIL: $@"
-		    return 1
-		fi
-		;;
+            "INIT")
+                shift
+                eval ${@+"$@"} > /dev/null
+                if [ $? != 0 ]
+                then
+                    echo "INIT FAIL: $@"
+                    return 1
+                fi
+                ;;
 
             *)
-		p=$1;shift
-		o=$1;shift
-		run_test "$p" "$o" ${@+"$@"}
-		;;
-	esac
+                p=$1;shift
+                o=$1;shift
+                run_test "$p" "$o" ${@+"$@"}
+                ;;
+        esac
     done
     exec 9<&-
 
@@ -183,8 +183,8 @@ test_driver() {
     echo "Unexpected failures: $nufail"
     if [ "$nupass" -gt 0 -o "$nufail" -gt 0 ]
     then
-	return 1
+        return 1
     else
-	return 0
+        return 0
     fi
 }

--- a/test/simple_test_driver.sh
+++ b/test/simple_test_driver.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# simple_test_driver.sh -- shell functions for test scripts
 #
 #    Copyright (C) 2017 Genome Research Ltd.
 #

--- a/test/test-bcf-sr.pl
+++ b/test/test-bcf-sr.pl
@@ -1,9 +1,27 @@
 #!/usr/bin/env perl
+# test-bcf-sr.pl -- Test bcf synced reader's allele pairing
 #
-# Author: petr.danecek@sanger
+#     Copyright (C) 2017 Genome Research Ltd.
 #
-# Test bcf synced reader's allele pairing
+#     Author: petr.danecek@sanger
 #
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
 
 use strict;
 use warnings;

--- a/test/test.pl
+++ b/test/test.pl
@@ -108,8 +108,8 @@ sub parse_params
     $$opts{bin}  = $FindBin::RealBin;
     $$opts{bin}  =~ s{/test/?$}{};
     if ($^O =~ /^msys/) {
-	$$opts{path} = cygpath($$opts{path});
-	$$opts{bin}  = cygpath($$opts{bin});
+        $$opts{path} = cygpath($$opts{path});
+        $$opts{bin}  = cygpath($$opts{bin});
     }
 
     return $opts;
@@ -129,9 +129,9 @@ sub _cmd
     }
     else
     {
-	# Example of how to embed Valgrind into the testing framework.
-	# TEST_PRECMD="valgrind --leak-check=full --suppressions=$ENV{HOME}/valgrind.supp" make check
-	$cmd = "$ENV{TEST_PRECMD} $cmd" if exists $ENV{TEST_PRECMD};
+        # Example of how to embed Valgrind into the testing framework.
+        # TEST_PRECMD="valgrind --leak-check=full --suppressions=$ENV{HOME}/valgrind.supp" make check
+        $cmd = "$ENV{TEST_PRECMD} $cmd" if exists $ENV{TEST_PRECMD};
 
         # child
         exec('bash', '-o','pipefail','-c', $cmd) or error("Cannot execute the command [/bin/sh -o pipefail -c $cmd]: $!");
@@ -315,8 +315,8 @@ sub test_view
         # CRAM2 -> CRAM3
         testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.0 $cram.cram > $cram";
 
-	# CRAM3 -> CRAM3 + multi-slice
-	testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.0 -o seqs_per_slice=7 -o slices_per_container=5 $cram.cram > $cram";
+        # CRAM3 -> CRAM3 + multi-slice
+        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.0 -o seqs_per_slice=7 -o slices_per_container=5 $cram.cram > $cram";
         testv $opts, "./test_view $tv_args $cram > $cram.sam_";
         testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
 
@@ -355,9 +355,9 @@ sub test_view
     testv $opts, "./compare_sam.pl range.tmp range.out";
 
     if ($test_view_failures == 0) {
-	passed($opts, "range.cram tests");
+        passed($opts, "range.cram tests");
     } else {
-	failed($opts, "range.cram tests", "$test_view_failures subtests failed");
+        failed($opts, "range.cram tests", "$test_view_failures subtests failed");
     }
 }
 
@@ -378,45 +378,45 @@ sub test_MD
         $test_view_failures = 0;
         $cram = "$base.tmp.cram";
 
-	# Forcibly store MD and NM and don't auto-generate.
-	# ALL NM/MD should match and be present only when originally present
+        # Forcibly store MD and NM and don't auto-generate.
+        # ALL NM/MD should match and be present only when originally present
         testv $opts, "./test_view -o store_nm=1 -o store_md=1 -t $ref -C $sam > $cram";
         testv $opts, "./test_view -i decode_md=0 -D $cram > $cram.sam_";
         testv $opts, "./compare_sam.pl $sam $cram.sam_";
 
         # Skip auto-MD generation; check MD iff in output file.
-	# (NB this does not check that all erroneous values are stored.)
+        # (NB this does not check that all erroneous values are stored.)
         testv $opts, "./test_view -t $ref -C $sam > $cram";
         testv $opts, "./test_view -i decode_md=0 -D $cram > $cram.sam_";
         testv $opts, "./compare_sam.pl -partialmd=2 $sam $cram.sam_";
 
-	# Also check we haven't added NM or MD needlessly for xx#MD.sam.
-	# This file has no errors so without auto-generation there must be
-	# no NM or MD records.
-	if ($sam eq "xx#MD.sam") {
-	    print "  Checking for MD/NM in $sam\n";
-	    open(my $fh, "<$cram.sam_") || die;
-	    while (<$fh>) {
-		if (/(MD|NM):/) {
-		    print STDERR "Failed\nLine contains MD/NM:\n$_";
-		    $test_view_failures++;
-		    last;
-		}
-	    }
-	    close($fh);
-	}
+        # Also check we haven't added NM or MD needlessly for xx#MD.sam.
+        # This file has no errors so without auto-generation there must be
+        # no NM or MD records.
+        if ($sam eq "xx#MD.sam") {
+            print "  Checking for MD/NM in $sam\n";
+            open(my $fh, "<$cram.sam_") || die;
+            while (<$fh>) {
+                if (/(MD|NM):/) {
+                    print STDERR "Failed\nLine contains MD/NM:\n$_";
+                    $test_view_failures++;
+                    last;
+                }
+            }
+            close($fh);
+        }
 
-	# Force auto-MD generation; check MD iff in input file.
-	# This will ensure any erroneous values have been round-tripped.
+        # Force auto-MD generation; check MD iff in input file.
+        # This will ensure any erroneous values have been round-tripped.
         testv $opts, "./test_view -t $ref -C $sam > $cram";
         testv $opts, "./test_view -i decode_md=1 -D $cram > $cram.sam_";
         testv $opts, "./compare_sam.pl -partialmd=1 $sam $cram.sam_";
 
-	if ($test_view_failures == 0) {
-	    passed($opts, "$sam MD tests");
-	} else {
-	    failed($opts, "$sam MD tests", "$test_view_failures subtests failed");
-	}
+        if ($test_view_failures == 0) {
+            passed($opts, "$sam MD tests");
+        } else {
+            failed($opts, "$sam MD tests", "$test_view_failures subtests failed");
+        }
     }
 }
 
@@ -455,19 +455,19 @@ sub write_multiblock_bgzf {
     my $tmp = "$name.tmp";
     open(my $out, '>', $name) || die "Couldn't open $name $!\n";
     for (my $i = 0; $i < @$frags; $i++) {
-	local $/;
-	open(my $f, '>', $tmp) || die "Couldn't open $tmp : $!\n";
-	print $f $frags->[$i];
-	close($f) || die "Error writing to $tmp: $!\n";
-	open(my $bgz, '-|', "$$opts{bin}/bgzip -c $tmp")
-	    || die "Couldn't open pipe to bgzip: $!\n";
-	my $compressed = <$bgz>;
-	close($bgz) || die "Error running bgzip\n";
-	if ($i < $#$frags) {
-	    # Strip EOF block
-	    $compressed =~ s/\x1f\x8b\x08\x04\x00{5}\xff\x06\x00\x42\x43\x02\x00\x1b\x00\x03\x00{9}$//;
-	}
-	print $out $compressed;
+        local $/;
+        open(my $f, '>', $tmp) || die "Couldn't open $tmp : $!\n";
+        print $f $frags->[$i];
+        close($f) || die "Error writing to $tmp: $!\n";
+        open(my $bgz, '-|', "$$opts{bin}/bgzip -c $tmp")
+            || die "Couldn't open pipe to bgzip: $!\n";
+        my $compressed = <$bgz>;
+        close($bgz) || die "Error running bgzip\n";
+        if ($i < $#$frags) {
+            # Strip EOF block
+            $compressed =~ s/\x1f\x8b\x08\x04\x00{5}\xff\x06\x00\x42\x43\x02\x00\x1b\x00\x03\x00{9}$//;
+        }
+        print $out $compressed;
     }
     close($out) || die "Error writing to $name: $!\n";
     unlink($tmp);
@@ -486,14 +486,14 @@ sub test_rebgzip
     my ($ret, $out) = _cmd("cmp $mb $$opts{path}/bgziptest.txt.gz");
 
     if (!$ret && $out eq '') { # If it does, use the original
-	test_cmd($opts, %args, out => "bgziptest.txt.gz",
-		 cmd => "$$opts{bin}/bgzip -I $$opts{path}/bgziptest.txt.gz.gzi -c -g $$opts{path}/bgziptest.txt");
+        test_cmd($opts, %args, out => "bgziptest.txt.gz",
+                 cmd => "$$opts{bin}/bgzip -I $$opts{path}/bgziptest.txt.gz.gzi -c -g $$opts{path}/bgziptest.txt");
     } else {
-	# Otherwise index the one we just made and test that
-	print "test_rebgzip: Alternate zlib/deflate library detected\n";
-	cmd("$$opts{bin}/bgzip -I $mb.gzi -r $mb");
-	test_cmd($opts, %args, out => "bgziptest.txt.tmp.gz",
-		 cmd => "$$opts{bin}/bgzip -I $mb.gzi -c -g $$opts{path}/bgziptest.txt");
+        # Otherwise index the one we just made and test that
+        print "test_rebgzip: Alternate zlib/deflate library detected\n";
+        cmd("$$opts{bin}/bgzip -I $mb.gzi -r $mb");
+        test_cmd($opts, %args, out => "bgziptest.txt.tmp.gz",
+                 cmd => "$$opts{bin}/bgzip -I $mb.gzi -c -g $$opts{path}/bgziptest.txt");
     }
 }
 

--- a/test/test_kstring.c
+++ b/test/test_kstring.c
@@ -1,3 +1,26 @@
+/*  test_kstring.c -- kstring unit tests
+
+    Copyright (C) 2018 Genome Research Ltd.
+
+    Author: Rob Davies <rmd@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>
@@ -5,6 +28,7 @@
 #include <inttypes.h>
 #include <getopt.h>
 
+#include <config.h>
 #include <htslib/kstring.h>
 
 static inline void clamp(int64_t *val, int64_t min, int64_t max) {

--- a/version.sh
+++ b/version.sh
@@ -45,9 +45,9 @@ then
     v3=`expr "$VERSION" : '[0-9]*.[0-9]*.\([0-9]*\)'`
     if [ -z "`expr "$VERSION" : '^\([0-9.]*\)$'`" ]
     then
-	VERSION="$v1.$v2.255"
+        VERSION="$v1.$v2.255"
     else
-	VERSION="$v1.$v2${v3:+.}$v3"
+        VERSION="$v1.$v2${v3:+.}$v3"
     fi
 fi
 

--- a/version.sh
+++ b/version.sh
@@ -1,4 +1,27 @@
 #!/bin/sh
+# version.sh -- Script to build the htslib version string
+#
+#     Author : James Bonfield <jkb@sanger.ac.uk>
+#
+#     Copyright (C) 2017 Genome Research Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
 
 # Master version, for use in tarballs or non-git source copies
 VERSION=1.9


### PR DESCRIPTION
Adds scripts `check_copyright.pl` and `check_spaces.pl` to look for missing copyright boilerplate, tabs and trailing spaces.  They can be run using `make maintainer-check` in the source tree.  One of the travis runs is updated to do this so we can spot any problems in pull requests (the rest are left unchanged so we also get to see that the PR otherwise works).  The copyright check is very basic - it just looks for the copyright line and the first few words of the license text - but it should be good enough.

The scripts are currently not part of `make test` so that the normal test harness doesn't break due to random bits of script lying around in source trees that will never by pushed upstream.

Also includes fixes for problems in the existing source found while developing the scripts.