### PR TITLE
Fix seq_nt16_table[(unsigned char) foo] cast

### DIFF
--- a/realn.c
+++ b/realn.c
@@ -50,7 +50,7 @@ int sam_cap_mapq(bam1_t *b, const char *ref, int ref_len, int thres)
             for (j = 0; j < l; ++j) {
                 int c1, c2, z = y + j;
                 if (x+j >= ref_len || ref[x+j] == '\0') break; // out of bounds
-                c1 = bam_seqi(seq, z), c2 = seq_nt16_table[(int)ref[x+j]];
+                c1 = bam_seqi(seq, z), c2 = seq_nt16_table[(unsigned char)ref[x+j]];
                 if (c2 != 15 && c1 != 15 && qual[z] >= 13) { // not ambiguous
                     ++len;
                     if (c1 && c1 != c2 && qual[z] >= 13) { // mismatch


### PR DESCRIPTION
`sam_cap_mapq()` might be called with arbitrary data in _ref_, including characters '\x80'..'\xFF' that are negative on many platforms.

All uses of `seq_nt16_table[]` in htslib are now cast appropriately.

OTOH there are lots of `seq_nt16_table[(int) ref[x]]` in the SAMtools codebase still. For most of these, `ref` has come from `fai_fetch()` et al, which returns only `isgraph()` characters, so for the typical POSIX/C locale problematic characters won't occur. (Not that this makes such code right…)

All this somewhat suggests that HTSlib could usefully have a wrapper function around `seq_nt16_table` that does this casting for you…