### PR TITLE
Fix libdeflate build using gcc-8 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 
   - compiler: gcc-8
     os: linux
+    dist: xenial
     env: USE_CONFIG=yes USE_LIBDEFLATE=yes CC=gcc-8 AR=gcc-ar-8
     addons:
       apt:


### PR DESCRIPTION
Since libdeflate commit 73017f0 it needs an up to date binutils so that the assembler understands avx512 instructions.  This is necessary even if gcc options do not enable avx512 as libdeflate uses inline assembly.  Using the "xenial" distribution supported by travis is the easiest way to get a new enough binutils.

Pull requests will need to be rebased over this commit for the gcc-8 build with libdeflate to work.