### PR TITLE
Check if fp is NULL in tabix file_type()

### DIFF
--- a/tabix.c
+++ b/tabix.c
@@ -79,6 +79,15 @@ int file_type(const char *fname)
     else if (l>=4 && strcasecmp(fname+l-5, ".cram") == 0) return IS_CRAM;
 
     htsFile *fp = hts_open(fname,"r");
+    if (!fp) {
+        if (errno == ENOEXEC) {
+            // hts_open() uses this to report that it didn't understand the
+            // file format.
+            error("Couldn't understand format of \"%s\"\n", fname);
+        } else {
+            error("Couldn't open \"%s\" : %s\n", fname, strerror(errno));
+        }
+    }
     enum htsExactFormat format = fp->format.format;
     hts_close(fp);
     if ( format == bcf ) return IS_BCF;


### PR DESCRIPTION
hts_open() returns NULL if it does not recognise the file type of the input.  Add a check for this in file_type() to fix a segfault that would otherwise occur when it tries to dereference the
result from hts_open().

Fixes #810 

This just bails out if hts_open() fails, which is the minimal fix.  It will only fail on files that would previously have made it crash.

Ideally this function should be rewritten to only open the input file once, but that's a rather bigger job.