### PR TITLE
Define PATH_MAX as it is done in cram/open_trace_file.c

### DIFF
--- a/cram/open_trace_file.c
+++ b/cram/open_trace_file.c
@@ -72,9 +72,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "cram/os.h"
-#ifndef PATH_MAX
-#  define PATH_MAX 1024
-#endif
 
 #include "cram/open_trace_file.h"
 #include "cram/misc.h"

--- a/cram/os.h
+++ b/cram/os.h
@@ -159,6 +159,13 @@ static inline uint16_t le_int2(uint16_t x) {
 }
 #endif
 
+/*
+ * in case PATH_MAX is not defined (like in hurd)
+ */
+#ifndef PATH_MAX
+#  define PATH_MAX 1024
+#endif
+
 /*-----------------------------------------------------------------------------
  * <inttypes.h> definitions, incase they're not present
  */


### PR DESCRIPTION
Define PATH_MAX as it is done in cram/open_trace_file.c if
not existent.  The definition should be removed from this C file since the
header file affects all three C files where this definition is used.

Co-authored-by: Svante Signell <svante.signell@gmail.com>

Originally from https://sources.debian.org/patches/htslib/1.9-9/define_PATH_MAX.patch/