### PR TITLE
Make bgzf_useek() work with threads

### DIFF
--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -201,6 +201,9 @@ typedef struct BGZF BGZF;
      * @param pos    virtual file offset returned by bgzf_tell()
      * @param whence must be SEEK_SET
      * @return       0 on success and -1 on error
+     *
+     * @note It is not permitted to seek on files open for writing,
+     * or files compressed with gzip (as opposed to bgzip).
      */
     int64_t bgzf_seek(BGZF *fp, int64_t pos, int whence) HTS_RESULT_USED;
 
@@ -317,9 +320,12 @@ typedef struct BGZF BGZF;
      *
      *  @param fp           BGZF file handler; must be opened for reading
      *  @param uoffset      file offset in the uncompressed data
-     *  @param where        SEEK_SET supported atm
+     *  @param where        must be SEEK_SET
      *
      *  Returns 0 on success and -1 on error.
+     *
+     *  @note It is not permitted to seek on files open for writing,
+     *  or files compressed with gzip (as opposed to bgzip).
      */
     int bgzf_useek(BGZF *fp, long uoffset, int where) HTS_RESULT_USED;
 

--- a/test/test_bgzf.c
+++ b/test/test_bgzf.c
@@ -764,9 +764,8 @@ int main(int argc, char **argv) {
     if (test_index_seek_getc(&f, "w", 1000000, 0) != 0) goto out;
 
     // Index building on the fly and bgzf_useek, with threads
-    // ** Not implemented yet **
-    // if (test_index_seek_getc(&f, "w", 1000000, 1) != 0) goto out;
-    // if (test_index_seek_getc(&f, "w", 1000000, 2) != 0) goto out;
+    if (test_index_seek_getc(&f, "w", 1000000, 1) != 0) goto out;
+    if (test_index_seek_getc(&f, "w", 1000000, 2) != 0) goto out;
 
     // bgzf_useek on an uncompressed file
     if (test_index_seek_getc(&f, "wu", 0, 0) != 0) goto out;


### PR DESCRIPTION
The seeking part has quite a lot in common with bgzf_seek(), so put it into new function bgzf_seek_common() which both call.

Enable bgzf_useek() with threads tests in test/test_bgzf.c
