### PR TITLE
Prevent vcf_parse_format int overflow on huge input

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -2052,7 +2052,8 @@ uint8_t *bcf_fmt_sized_array(kstring_t *s, uint8_t *ptr)
  ********************/
 
 typedef struct {
-    int key, max_m, size, offset;
+    int key, max_m;
+    size_t size, offset;
     uint64_t is_gt:1, max_g:31, max_l:32;
     uint32_t y;
     uint8_t *buf;


### PR DESCRIPTION
Upgrade variables in an internal data structure from int to size_t. The subsequent code multiplies/adds these with other values in order to calculate buffer sizes and positions. When we parse extremely large VCF sites (e.g. *N*>100k samples, *k*>100 alternate alleles, perhaps a O(*Nkk*) PL field for good measure) these operations were liable to overflow 32-bit int (>2GiB buffers) causing segfaults.