### PR TITLE
Make hts_hfile method visible outside htslib.

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -978,7 +978,7 @@ const char *hts_format_file_extension(const htsFormat *format) {
     }
 }
 
-static hFILE *hts_hfile(htsFile *fp) {
+hFILE *hts_hfile(htsFile *fp) {
     switch (fp->format.format) {
     case binary_format: // fall through; still valid if bcf?
     case bam:          return bgzf_hfile(fp->fp.bgzf);

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -531,6 +531,8 @@ int hts_set_fai_filename(htsFile *fp, const char *fn_aux);
 */
 int hts_check_EOF(htsFile *fp);
 
+struct hFILE *hts_hfile(htsFile *fp);
+
 /************
  * Indexing *
  ************/


### PR DESCRIPTION
Needed by https://github.com/samtools/samtools/pull/1007