### PR TITLE
Fixed deadlock in thread pool / bgzf error handling.

### DIFF
--- a/thread_pool_internal.h
+++ b/thread_pool_internal.h
@@ -107,6 +107,7 @@ struct hts_tpool_process {
     uint64_t next_serial;            // next serial for output
     uint64_t curr_serial;            // current serial (next input)
 
+    int no_more_input;               // disable dispatching of more jobs
     int n_input;                     // no. items in input queue; was njobs
     int n_output;                    // no. items in output queue
     int n_processing;                // no. items being processed (executing)


### PR DESCRIPTION
In the thread pool, we now set "no_more_input" flag in
hts_tpool_process_destroy as it was possible for deadlocks to occur
with another process hammering the input queue while attempting to
reset and flush prior to destroying the queue.  The shutdown flag
isn't quite sufficient here as that also changes the flush behavior.
We wish to flush correctly (on valid termination), but do not wish to
add more items to the input queue.

In the bgzf side, I also improved the error handling so that
fp->errcode isn't set within bgzf_mt_writer (no intervening lock so
that is a data race).  It now handles this properly with the join
retval.

Fixes #831