### PR TITLE
Change return type of functions that can error (and nothing more).

### DIFF
--- a/bcf_sr_sort.c
+++ b/bcf_sr_sort.c
@@ -226,7 +226,8 @@ static int merge_vsets(sr_sort_t *srt, int ivset, int jvset)
 
     return ivset;
 }
-static void push_vset(sr_sort_t *srt, int ivset)
+
+static int push_vset(sr_sort_t *srt, int ivset)
 {
     varset_t *iv = &srt->vset[ivset];
     int i,j;
@@ -248,6 +249,7 @@ static void push_vset(sr_sort_t *srt, int ivset)
         }
     }
     remove_vset(srt, ivset);
+    return 0; // FIXME: check for errs in this function
 }
 
 static int cmpstringp(const void *p1, const void *p2)
@@ -319,16 +321,16 @@ int bcf_sr_sort_set_active(sr_sort_t *srt, int idx)
     hts_expand(int,idx+1,srt->mactive,srt->active);
     srt->nactive = 1;
     srt->active[srt->nactive - 1] = idx;
-    return 0;
+    return 0; // FIXME: check for errs in this function
 }
 int bcf_sr_sort_add_active(sr_sort_t *srt, int idx)
 {
     hts_expand(int,idx+1,srt->mactive,srt->active);
     srt->nactive++;
     srt->active[srt->nactive - 1] = idx;
-    return 0;
+    return 0; // FIXME: check for errs in this function
 }
-static void bcf_sr_sort_set(bcf_srs_t *readers, sr_sort_t *srt, const char *chr, int min_pos)
+static int bcf_sr_sort_set(bcf_srs_t *readers, sr_sort_t *srt, const char *chr, int min_pos)
 {
     if ( !srt->grp_str2int )
     {
@@ -550,6 +552,8 @@ static void bcf_sr_sort_set(bcf_srs_t *readers, sr_sort_t *srt, const char *chr,
 
     srt->chr = chr;
     srt->pos = min_pos;
+
+    return 0;  // FIXME: check for errs in this function
 }
 
 int bcf_sr_sort_next(bcf_srs_t *readers, sr_sort_t *srt, const char *chr, int min_pos)

--- a/errmod.c
+++ b/errmod.c
@@ -53,6 +53,7 @@ static double* logbinomial_table( const int n_size )
     /* this calcs p(k) = {log(n!) - log(k!) - log((n-k)!) */
     int k, n;
     double *logbinom = (double*)calloc(n_size * n_size, sizeof(double));
+    if (!logbinom) return NULL;
     for (n = 1; n < n_size; ++n) {
         double lfn = lfact(n);
         for (k = 1; k <= n; ++k)
@@ -61,7 +62,7 @@ static double* logbinomial_table( const int n_size )
     return logbinom;
 }
 
-static void cal_coef(errmod_t *em, double depcorr, double eta)
+static int cal_coef(errmod_t *em, double depcorr, double eta)
 {
     int k, n, q;
     double sum, sum1;
@@ -69,14 +70,17 @@ static void cal_coef(errmod_t *em, double depcorr, double eta)
 
     // initialize ->fk
     em->fk = (double*)calloc(256, sizeof(double));
+    if (!em->fk) return -1;
     em->fk[0] = 1.0;
     for (n = 1; n < 256; ++n)
         em->fk[n] = pow(1. - depcorr, n) * (1.0 - eta) + eta;
 
     // initialize ->beta
     em->beta = (double*)calloc(256 * 256 * 64, sizeof(double));
+    if (!em->beta) return -1;
 
     lC = logbinomial_table( 256 );
+    if (!lC) return -1;
 
     for (q = 1; q < 64; ++q) {
         double e = pow(10.0, -q/10.0);
@@ -95,10 +99,15 @@ static void cal_coef(errmod_t *em, double depcorr, double eta)
 
     // initialize ->lhet
     em->lhet = (double*)calloc(256 * 256, sizeof(double));
+    if (!em->lhet) {
+        free(lC);
+        return -1;
+    }
     for (n = 0; n < 256; ++n)
         for (k = 0; k < 256; ++k)
             em->lhet[n<<8|k] = lC[n<<8|k] - M_LN2 * n;
     free(lC);
+    return 0;
 }
 
 /**
@@ -108,6 +117,7 @@ errmod_t *errmod_init(double depcorr)
 {
     errmod_t *em;
     em = (errmod_t*)calloc(1, sizeof(errmod_t));
+    if (!em) return NULL;
     em->depcorr = depcorr;
     cal_coef(em, depcorr, 0.03);
     return em;

--- a/htslib/ksort.h
+++ b/htslib/ksort.h
@@ -95,7 +95,7 @@ typedef struct {
 #define KSORT_INIT2(name, SCOPE, type_t, __sort_lt)	KSORT_INIT_(_ ## name, SCOPE, type_t, __sort_lt)
 
 #define KSORT_INIT_(name, SCOPE, type_t, __sort_lt)						\
-	SCOPE void ks_mergesort##name(size_t n, type_t array[], type_t temp[]) \
+	SCOPE int ks_mergesort##name(size_t n, type_t array[], type_t temp[]) \
 	{																	\
 		type_t *a2[2], *a, *b;											\
 		int curr, shift;												\
@@ -142,6 +142,7 @@ typedef struct {
 			for (; p < eb; ++i) *p++ = *i;								\
 		}																\
 		if (temp == 0) free(a2[1]);										\
+		return 0;															\
 	}																	\
 	SCOPE void ks_heapadjust##name(size_t i, size_t n, type_t l[])		\
 	{																	\
@@ -198,17 +199,17 @@ typedef struct {
 		} while (do_swap || gap > 2);									\
 		if (gap != 1) __ks_insertsort##name(a, a + n);					\
 	}																	\
-	SCOPE void ks_introsort##name(size_t n, type_t a[])					\
+	SCOPE int ks_introsort##name(size_t n, type_t a[])					\
 	{																	\
 		int d;															\
 		ks_isort_stack_t *top, *stack;									\
 		type_t rp, swap_tmp;											\
 		type_t *s, *t, *i, *j, *k;										\
 																		\
-		if (n < 1) return;												\
+		if (n < 1) return 0;												\
 		else if (n == 2) {												\
 			if (__sort_lt(a[1], a[0])) { swap_tmp = a[0]; a[0] = a[1]; a[1] = swap_tmp; } \
-			return;														\
+			return 0;														\
 		}																\
 		for (d = 2; 1ul<<d < n; ++d);									\
 		stack = (ks_isort_stack_t*)malloc(sizeof(ks_isort_stack_t) * ((sizeof(size_t)*d)+2)); \
@@ -244,10 +245,11 @@ typedef struct {
 				if (top == stack) {										\
 					free(stack);										\
 					__ks_insertsort##name(a, a+n);						\
-					return;												\
+					return 0;												\
 				} else { --top; s = (type_t*)top->left; t = (type_t*)top->right; d = top->depth; } \
 			}															\
 		}																\
+		return 0;															\
 	}																	\
 	/* This function is adapted from: http://ndevilla.free.fr/median/ */ \
 	/* 0 <= kk < n */													\

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -852,7 +852,7 @@ typedef struct __bam_mplp_t *bam_mplp_t;
      *  is increased to the sum of their qualities (capped at 200), otherwise
      *  it is multiplied by 0.8.
      */
-    void bam_mplp_init_overlaps(bam_mplp_t iter);
+    int bam_mplp_init_overlaps(bam_mplp_t iter);
     void bam_mplp_destroy(bam_mplp_t iter);
     void bam_mplp_set_maxcnt(bam_mplp_t iter, int maxcnt);
     int bam_mplp_auto(bam_mplp_t iter, int *_tid, int *_pos, int *n_plp, const bam_pileup1_t **plp);

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -829,7 +829,7 @@ typedef struct __bam_mplp_t *bam_mplp_t;
                             int (*func)(void *data, const bam1_t *b, bam_pileup_cd *cd));
 
     /// Get pileup padded insertion sequence
-    /*
+    /**
      * @param p       pileup data
      * @param ins     the kstring where the insertion sequence will be written
      * @param del_len location for deletion length
@@ -844,8 +844,12 @@ typedef struct __bam_mplp_t *bam_mplp_t;
     int bam_plp_insertion(const bam_pileup1_t *p, kstring_t *ins, int *del_len) HTS_RESULT_USED;
 
     bam_mplp_t bam_mplp_init(int n, bam_plp_auto_f func, void **data);
+    /// Set up mpileup overlap detection
     /**
-     *  bam_mplp_init_overlaps() - if called, mpileup will detect overlapping
+     * @param iter    mpileup iterator
+     * @return 0 on success; a negative value on error
+     *
+     *  If called, mpileup will detect overlapping
      *  read pairs and for each base pair set the base quality of the
      *  lower-quality base to zero, thus effectively discarding it from
      *  calling. If the two bases are identical, the quality of the other base

--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -341,8 +341,9 @@ int bcf_sr_regions_overlap(bcf_sr_regions_t *reg, const char *seq, int start, in
 /*
  *  bcf_sr_regions_flush() - calls repeatedly regs->missed_reg_handler() until
  *  all remaining records are processed.
+ *  Returns 0 on success, <0 on error.
  */
-void bcf_sr_regions_flush(bcf_sr_regions_t *regs);
+int bcf_sr_regions_flush(bcf_sr_regions_t *regs);
 
 #ifdef __cplusplus
 }

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -497,7 +497,7 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
 
     /** VCF version, e.g. VCFv4.2 */
     const char *bcf_hdr_get_version(const bcf_hdr_t *hdr);
-    void bcf_hdr_set_version(bcf_hdr_t *hdr, const char *version);
+    int bcf_hdr_set_version(bcf_hdr_t *hdr, const char *version);
 
     /**
      *  bcf_hdr_remove() - remove VCF header tag
@@ -539,7 +539,7 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     */
     int bcf_hdr_sync(bcf_hdr_t *h) HTS_RESULT_USED;
     bcf_hrec_t *bcf_hdr_parse_line(const bcf_hdr_t *h, const char *line, int *len);
-    void bcf_hrec_format(const bcf_hrec_t *hrec, kstring_t *str);
+    int bcf_hrec_format(const bcf_hrec_t *hrec, kstring_t *str);
     int bcf_hdr_add_hrec(bcf_hdr_t *hdr, bcf_hrec_t *hrec);
     /**
      *  bcf_hdr_get_hrec() - get header line info
@@ -868,12 +868,12 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     #define bcf_hdr_idinfo_exists(hdr,type,int_id)  ((int_id<0 || bcf_hdr_id2coltype(hdr,type,int_id)==0xf) ? 0 : 1)
     #define bcf_hdr_id2hrec(hdr,dict_type,col_type,int_id)    ((hdr)->id[(dict_type)==BCF_DT_CTG?BCF_DT_CTG:BCF_DT_ID][int_id].val->hrec[(dict_type)==BCF_DT_CTG?0:(col_type)])
 
-    void bcf_fmt_array(kstring_t *s, int n, int type, void *data);
+    int bcf_fmt_array(kstring_t *s, int n, int type, void *data);
     uint8_t *bcf_fmt_sized_array(kstring_t *s, uint8_t *ptr);
 
-    void bcf_enc_vchar(kstring_t *s, int l, const char *a);
-    void bcf_enc_vint(kstring_t *s, int n, int32_t *a, int wsize);
-    void bcf_enc_vfloat(kstring_t *s, int n, float *a);
+    int bcf_enc_vchar(kstring_t *s, int l, const char *a);
+    int bcf_enc_vint(kstring_t *s, int n, int32_t *a, int wsize);
+    int bcf_enc_vfloat(kstring_t *s, int n, float *a);
 
 
     /**************************************************************************

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -497,6 +497,12 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
 
     /** VCF version, e.g. VCFv4.2 */
     const char *bcf_hdr_get_version(const bcf_hdr_t *hdr);
+    /// Set version in bcf header
+    /**
+       @param hdr     BCF header struct
+       @param version Version to set, e.g. "VCFv4.3"
+       @return 0 on success; < 0 on error
+     */
     int bcf_hdr_set_version(bcf_hdr_t *hdr, const char *version);
 
     /**
@@ -539,6 +545,12 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     */
     int bcf_hdr_sync(bcf_hdr_t *h) HTS_RESULT_USED;
     bcf_hrec_t *bcf_hdr_parse_line(const bcf_hdr_t *h, const char *line, int *len);
+    /// Convert a bcf header record to string form
+    /**
+     * @param hrec    Header record
+     * @param str     Destination kstring
+     * @return 0 on success; < 0 on error
+     */
     int bcf_hrec_format(const bcf_hrec_t *hrec, kstring_t *str);
     int bcf_hdr_add_hrec(bcf_hdr_t *hdr, bcf_hrec_t *hrec);
     /**
@@ -867,12 +879,43 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     #define bcf_hdr_id2coltype(hdr,type,int_id) ((hdr)->id[BCF_DT_ID][int_id].val->info[type] & 0xf)
     #define bcf_hdr_idinfo_exists(hdr,type,int_id)  ((int_id<0 || bcf_hdr_id2coltype(hdr,type,int_id)==0xf) ? 0 : 1)
     #define bcf_hdr_id2hrec(hdr,dict_type,col_type,int_id)    ((hdr)->id[(dict_type)==BCF_DT_CTG?BCF_DT_CTG:BCF_DT_ID][int_id].val->hrec[(dict_type)==BCF_DT_CTG?0:(col_type)])
-
+    /// Convert BCF FORMAT data to string form
+    /**
+     * @param s    kstring to write into
+     * @param n    number of items in @p data
+     * @param type type of items in @p data
+     * @param data BCF format data
+     * @return  0 on success
+     *         -1 if out of memory
+     */
     int bcf_fmt_array(kstring_t *s, int n, int type, void *data);
     uint8_t *bcf_fmt_sized_array(kstring_t *s, uint8_t *ptr);
 
+    /// Encode a variable-length char array in BCF format
+    /**
+     * @param s    kstring to write into
+     * @param l    length of input
+     * @param a    input data to encode
+     * @return 0 on success; < 0 on error
+     */
     int bcf_enc_vchar(kstring_t *s, int l, const char *a);
+    /// Encode a variable-length integer array in BCF format
+    /**
+     * @param s      kstring to write into
+     * @param n      total number of items in @p a (<= 0 to encode BCF_BT_NULL)
+     * @param a      input data to encode
+     * @param wsize  vector length (<= 0 is equivalent to @p n)
+     * @return 0 on success; < 0 on error
+     * @note @p n should be an exact multiple of @p wsize
+     */
     int bcf_enc_vint(kstring_t *s, int n, int32_t *a, int wsize);
+    /// Encode a variable-length float array in BCF format
+    /**
+     * @param s      kstring to write into
+     * @param n      total number of items in @p a (<= 0 to encode BCF_BT_NULL)
+     * @param a      input data to encode
+     * @return 0 on success; < 0 on error
+     */
     int bcf_enc_vfloat(kstring_t *s, int n, float *a);
 
 

--- a/htslib/vcfutils.h
+++ b/htslib/vcfutils.h
@@ -54,8 +54,9 @@ int bcf_trim_alleles(const bcf_hdr_t *header, bcf1_t *line);
  *
  *  If you have more than 31 alleles, then the integer bit mask will
  *  overflow, so use bcf_remove_allele_set instead
+ *  Returns 0 on sucess, <0 on error
  */
-void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int mask) HTS_DEPRECATED("Please use bcf_remove_allele_set instead");
+int bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int mask) HTS_DEPRECATED("Please use bcf_remove_allele_set instead");
 
 /**
  *  bcf_remove_allele_set() - remove ALT alleles according to bitset @rm_set

--- a/kstring.c
+++ b/kstring.c
@@ -306,12 +306,14 @@ static int *ksBM_prep(const ubyte_t *pat, int m)
 {
 	int i, *suff, *prep, *bmGs, *bmBc;
 	prep = (int*)calloc(m + 256, sizeof(int));
+    if (!prep) return NULL;
 	bmGs = prep; bmBc = prep + m;
 	{ // preBmBc()
 		for (i = 0; i < 256; ++i) bmBc[i] = m;
 		for (i = 0; i < m - 1; ++i) bmBc[pat[i]] = m - i - 1;
 	}
 	suff = (int*)calloc(m, sizeof(int));
+    if (!suff) { free(prep); return NULL; }
 	{ // suffixes()
 		int f = 0, g;
 		suff[m - 1] = m;
@@ -348,6 +350,7 @@ void *kmemmem(const void *_str, int n, const void *_pat, int m, int **_prep)
 	const ubyte_t *str, *pat;
 	str = (const ubyte_t*)_str; pat = (const ubyte_t*)_pat;
 	prep = (_prep == 0 || *_prep == 0)? ksBM_prep(pat, m) : *_prep;
+    if (!prep) return NULL;
 	if (_prep && *_prep == 0) *_prep = prep;
 	bmGs = prep; bmBc = prep + m;
 	j = 0;

--- a/sam.c
+++ b/sam.c
@@ -3256,7 +3256,7 @@ int bam_mplp_init_overlaps(bam_mplp_t iter)
     int i, r = 0;
     for (i = 0; i < iter->n; ++i)
         r |= bam_plp_init_overlaps(iter->iter[i]);
-    return r;
+    return r == 0 ? 0 : -1;
 }
 
 void bam_mplp_set_maxcnt(bam_mplp_t iter, int maxcnt)

--- a/sam.c
+++ b/sam.c
@@ -2834,9 +2834,10 @@ bam_plp_t bam_plp_init(bam_plp_auto_f func, void *data)
     return iter;
 }
 
-void bam_plp_init_overlaps(bam_plp_t iter)
+int bam_plp_init_overlaps(bam_plp_t iter)
 {
     iter->overlaps = kh_init(olap_hash);  // hash for tweaking quality of bases in overlapping reads
+    return iter->overlaps ? 0 : -1;
 }
 
 void bam_plp_destroy(bam_plp_t iter)
@@ -3250,11 +3251,12 @@ bam_mplp_t bam_mplp_init(int n, bam_plp_auto_f func, void **data)
     return iter;
 }
 
-void bam_mplp_init_overlaps(bam_mplp_t iter)
+int bam_mplp_init_overlaps(bam_mplp_t iter)
 {
-    int i;
+    int i, r = 0;
     for (i = 0; i < iter->n; ++i)
-        bam_plp_init_overlaps(iter->iter[i]);
+        r |= bam_plp_init_overlaps(iter->iter[i]);
+    return r;
 }
 
 void bam_mplp_set_maxcnt(bam_mplp_t iter, int maxcnt)

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -60,7 +60,7 @@ typedef struct
 }
 aux_t;
 
-static void _regions_add(bcf_sr_regions_t *reg, const char *chr, int start, int end);
+static int _regions_add(bcf_sr_regions_t *reg, const char *chr, int start, int end);
 static bcf_sr_regions_t *_regions_init_string(const char *str);
 static int _regions_match_alleles(bcf_sr_regions_t *reg, int als_idx, bcf1_t *rec);
 
@@ -765,7 +765,7 @@ int bcf_sr_set_samples(bcf_srs_t *files, const char *fname, int is_file)
 
 // Add a new region into a list sorted by start,end. On input the coordinates
 // are 1-based, stored 0-based, inclusive.
-static void _regions_add(bcf_sr_regions_t *reg, const char *chr, int start, int end)
+static int _regions_add(bcf_sr_regions_t *reg, const char *chr, int start, int end)
 {
     if ( start==-1 && end==-1 )
     {
@@ -813,6 +813,8 @@ static void _regions_add(bcf_sr_regions_t *reg, const char *chr, int start, int 
         creg->regs[max].end   = end;
         creg->nregs++;
     }
+
+    return 0; // FIXME: check for errs in this function
 }
 
 // File name or a list of genomic locations. If file name, NULL is returned.
@@ -1220,10 +1222,10 @@ int bcf_sr_regions_overlap(bcf_sr_regions_t *reg, const char *seq, int start, in
     return -1;  // no overlap
 }
 
-void bcf_sr_regions_flush(bcf_sr_regions_t *reg)
+int bcf_sr_regions_flush(bcf_sr_regions_t *reg)
 {
-    if ( !reg->missed_reg_handler || reg->prev_seq==-1 ) return;
+    if ( !reg->missed_reg_handler || reg->prev_seq==-1 ) return 0;
     while ( !bcf_sr_regions_next(reg) ) reg->missed_reg_handler(reg, reg->missed_reg_data);
-    return;
+    return 0; // FIXME: check for errs in this function
 }
 

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -480,13 +480,13 @@ static int _readers_next_region(bcf_srs_t *files)
 /*
  *  _reader_fill_buffer() - buffers all records with the same coordinate
  */
-static void _reader_fill_buffer(bcf_srs_t *files, bcf_sr_t *reader)
+static int _reader_fill_buffer(bcf_srs_t *files, bcf_sr_t *reader)
 {
     // Return if the buffer is full: the coordinate of the last buffered record differs
-    if ( reader->nbuffer && reader->buffer[reader->nbuffer]->pos != reader->buffer[1]->pos ) return;
+    if ( reader->nbuffer && reader->buffer[reader->nbuffer]->pos != reader->buffer[1]->pos ) return 0;
 
     // No iterator (sequence not present in this file) and not streaming
-    if ( !reader->itr && !files->streaming ) return;
+    if ( !reader->itr && !files->streaming ) return 0;
 
     // Fill the buffer with records starting at the same position
     int i, ret = 0;
@@ -556,6 +556,7 @@ static void _reader_fill_buffer(bcf_srs_t *files, bcf_sr_t *reader)
         tbx_itr_destroy(reader->itr);
         reader->itr = NULL;
     }
+    return 0; // FIXME: Check for more errs in this function
 }
 
 /*

--- a/vcf.c
+++ b/vcf.c
@@ -961,7 +961,7 @@ const char *bcf_hdr_get_version(const bcf_hdr_t *hdr)
     return hrec->value;
 }
 
-void bcf_hdr_set_version(bcf_hdr_t *hdr, const char *version)
+int bcf_hdr_set_version(bcf_hdr_t *hdr, const char *version)
 {
     bcf_hrec_t *hrec = bcf_hdr_get_hrec(hdr, BCF_HL_GEN, "fileformat", NULL, NULL);
     if ( !hrec )
@@ -978,6 +978,7 @@ void bcf_hdr_set_version(bcf_hdr_t *hdr, const char *version)
         hrec->value = strdup(version);
     }
     hdr->dirty = 1;
+    return 0; // FIXME: check for errs in this function
 }
 
 bcf_hdr_t *bcf_hdr_init(const char *mode)
@@ -1855,7 +1856,7 @@ int bcf_hdr_set(bcf_hdr_t *hdr, const char *fname)
     return 1;
 }
 
-static void _bcf_hrec_format(const bcf_hrec_t *hrec, int is_bcf, kstring_t *str)
+static int _bcf_hrec_format(const bcf_hrec_t *hrec, int is_bcf, kstring_t *str)
 {
     if ( !hrec->value )
     {
@@ -1873,11 +1874,13 @@ static void _bcf_hrec_format(const bcf_hrec_t *hrec, int is_bcf, kstring_t *str)
     }
     else
         ksprintf(str,"##%s=%s\n", hrec->key,hrec->value);
+
+    return 0; // FIXME: check for errs in this function
 }
 
-void bcf_hrec_format(const bcf_hrec_t *hrec, kstring_t *str)
+int bcf_hrec_format(const bcf_hrec_t *hrec, kstring_t *str)
 {
-    _bcf_hrec_format(hrec,0,str);
+    return _bcf_hrec_format(hrec,0,str);
 }
 
 int bcf_hdr_format(const bcf_hdr_t *hdr, int is_bcf, kstring_t *str)
@@ -1944,7 +1947,7 @@ int vcf_hdr_write(htsFile *fp, const bcf_hdr_t *h)
  *** Typed value I/O ***
  ***********************/
 
-void bcf_enc_vint(kstring_t *s, int n, int32_t *a, int wsize)
+int bcf_enc_vint(kstring_t *s, int n, int32_t *a, int wsize)
 {
     int32_t max = INT32_MIN, min = INT32_MAX;
     int i;
@@ -1990,6 +1993,8 @@ void bcf_enc_vint(kstring_t *s, int n, int32_t *a, int wsize)
             s->l += n * sizeof(int32_t);
         }
     }
+
+    return 0; // FIXME: check for errs in this function
 }
 
 static inline int serialize_float_array(kstring_t *s, size_t n, const float *a) {
@@ -2010,25 +2015,27 @@ static inline int serialize_float_array(kstring_t *s, size_t n, const float *a) 
     return 0;
 }
 
-void bcf_enc_vfloat(kstring_t *s, int n, float *a)
+int bcf_enc_vfloat(kstring_t *s, int n, float *a)
 {
     assert(n >= 0);
     bcf_enc_size(s, n, BCF_BT_FLOAT);
     serialize_float_array(s, n, a);
+    return 0; // FIXME: check for errs in this function
 }
 
-void bcf_enc_vchar(kstring_t *s, int l, const char *a)
+int bcf_enc_vchar(kstring_t *s, int l, const char *a)
 {
     bcf_enc_size(s, l, BCF_BT_CHAR);
     kputsn(a, l, s);
+    return 0; // FIXME: check for errs in this function
 }
 
-void bcf_fmt_array(kstring_t *s, int n, int type, void *data)
+int bcf_fmt_array(kstring_t *s, int n, int type, void *data)
 {
     int j = 0;
     if (n == 0) {
         kputc('.', s);
-        return;
+        return 0;
     }
     if (type == BCF_BT_CHAR)
     {
@@ -2061,6 +2068,7 @@ void bcf_fmt_array(kstring_t *s, int n, int type, void *data)
         }
         #undef BRANCH
     }
+    return 0; // FIXME: check for errs in this function
 }
 
 uint8_t *bcf_fmt_sized_array(kstring_t *s, uint8_t *ptr)

--- a/vcf_sweep.c
+++ b/vcf_sweep.c
@@ -66,7 +66,7 @@ static inline int sw_rec_equal(bcf_sweep_t *sw, bcf1_t *rec)
     return 1;
 }
 
-static void sw_rec_save(bcf_sweep_t *sw, bcf1_t *rec)
+static int sw_rec_save(bcf_sweep_t *sw, bcf1_t *rec)
 {
     sw->lrid  = rec->rid;
     sw->lpos  = rec->pos;
@@ -78,11 +78,13 @@ static void sw_rec_save(bcf_sweep_t *sw, bcf1_t *rec)
     sw->lals_len = len;
     hts_expand(char, len, sw->mlals, sw->lals);
     memcpy(sw->lals, rec->d.allele[0], len);
+
+    return 0; // FIXME: check for errs in this function
 }
 
-static void sw_fill_buffer(bcf_sweep_t *sw)
+static int sw_fill_buffer(bcf_sweep_t *sw)
 {
-    if ( !sw->iidx ) return;
+    if ( !sw->iidx ) return 0;
     sw->iidx--;
 
     int ret = hts_useek(sw->file, sw->idx[sw->iidx], 0);
@@ -102,6 +104,8 @@ static void sw_fill_buffer(bcf_sweep_t *sw)
         rec = &sw->rec[sw->nrec];
     }
     sw_rec_save(sw, &sw->rec[0]);
+
+    return 0; // FIXME: check for errs in this function
 }
 
 bcf_sweep_t *bcf_sweep_init(const char *fname)

--- a/vcfutils.c
+++ b/vcfutils.c
@@ -222,7 +222,7 @@ clean:
     return ret ? ret : nrm;
 }
 
-void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
+int bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
 {
     int i;
     kbitset_t *rm_set = kbs_init(line->n_allele);
@@ -231,6 +231,8 @@ void bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int rm_mask)
 
     bcf_remove_allele_set(header, line, rm_set);
     kbs_destroy(rm_set);
+
+    return 0; // FIXME: check for errs in this function
 }
 
 int bcf_remove_allele_set(const bcf_hdr_t *header, bcf1_t *line, const struct kbitset_t *rm_set)


### PR DESCRIPTION
There are numerous places where we call e.g. hts_expand, kh_init, kh_put, malloc/calloc, and so on, but the function has void return type.  Clearly these can fail.

What this commit specifically does NOT do is add error checking.  It is simply a placeholder that changes the return types, and thus technically the ABI, permitting us to do the full checks at a later
stage.  That PR will be much larger and more time consuming, hence splitting in two.

Every function that now returns a dummy 0 (success) value now contains a comment "_FIXME: check for errs in this function_" so we can grep for these and fix them in later releases.

We also do not add explicit HTS_RESULT_USED statements, because doing so will force us to start adding error checking in our own code; please refer to the earlier statement about what this commit is **not** doing.  (Adding HTS_RESULT_USED results in a further 58 problems to resolve.  I checked to ensure all those functions already had return values.)

Related to #246.  This doesn't fix the remaining issues, but it's step 1 down that path.