### PR TITLE
Multi-region iterator interface merger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,8 @@ LIBHTS_OBJS = \
 	cram/pooled_alloc.o \
 	cram/rANS_static.o \
 	cram/sam_header.o \
-	cram/string_alloc.o
+	cram/string_alloc.o \
+	region.o
 
 PLUGIN_EXT  =
 PLUGIN_OBJS =
@@ -343,6 +344,7 @@ cram/rANS_static.o cram/rANS_static.pico: cram/rANS_static.c config.h cram/rANS_
 cram/sam_header.o cram/sam_header.pico: cram/sam_header.c config.h $(htslib_hts_log_h) $(cram_sam_header_h) cram/string_alloc.h
 cram/string_alloc.o cram/string_alloc.pico: cram/string_alloc.c config.h cram/string_alloc.h
 thread_pool.o thread_pool.pico: thread_pool.c config.h $(thread_pool_internal_h)
+region.o region.pico: region.c $(htslib_hts_h) $(htslib_khash_h)
 
 
 bgzip: bgzip.o libhts.a

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -877,9 +877,11 @@ hts_itr_t *hts_itr_regions(const hts_idx_t *idx, hts_reglist_t *reglist, int cou
 int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r);
 
 /// Create a region list from a char array
-/** @param argv       Char array of region:interval elements, e.g. chr1:2500-3600, chr1:5100, chr2
-    @param argc       Number of items in the array
-    @param r_count    Pointer to the number of items in the resulting region list
+/** @param argv      Char array of target:interval elements, e.g. chr1:2500-3600, chr1:5100, chr2
+    @param argc      Number of items in the array
+    @param r_count   Pointer to the number of items in the resulting region list
+    @param hdr       Header for the sam/bam/cram file
+    @param getid     Callback to convert target names to target ids.
     @return  A region list on success, NULL on failure
  */
 hts_reglist_t *hts_reglist_create(char **argv, int argc, int *r_count, void *hdr,  hts_name2id_f getid);

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -578,8 +578,8 @@ typedef struct {
 
 typedef struct {
     const char *reg;
-    int tid;
     hts_pair32_t *intervals;
+    int tid;
     uint32_t count;
     uint32_t min_beg, max_end;
 } hts_reglist_t;

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -876,6 +876,14 @@ hts_itr_t *hts_itr_regions(const hts_idx_t *idx, hts_reglist_t *reglist, int cou
  */
 int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r);
 
+/// Create a region list from a char array
+/** @param argv       Char array of region:interval elements, e.g. chr1:2500-3600, chr1:5100, chr2
+    @param argc       Number of items in the array
+    @param r_count    Pointer to the number of items in the resulting region list
+    @return  A region list on success, NULL on failure
+ */
+hts_reglist_t *hts_reglist_create(char **argv, int argc, int *r_count, void *hdr,  hts_name2id_f getid);
+
 /// Free a region list
 /** @param reglist    Region list
     @param count      Number of items in the list

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -419,7 +419,7 @@ hts_itr_t *sam_itr_queryi(const hts_idx_t *idx, int tid, int beg, int end);
 Regions are parsed by hts_parse_reg(), and take one of the following forms:
 
 region          | Outputs
---------------- | -------------  
+--------------- | -------------
 REF             | All reads with RNAME REF
 REF:            | All reads with RNAME REF
 REF:START       | Reads with RNAME REF overlapping START to end of REF
@@ -449,6 +449,31 @@ The iterator will return all reads overlapping the given regions.  If a read
 overlaps more than one region, it will only be returned once.
  */
 hts_itr_t *sam_itr_regions(const hts_idx_t *idx, bam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount);
+
+/// Create a multi-region iterator
+/** @param idx       Index
+    @param hdr       Header
+    @param regarray  Array of ref:interval region specifiers
+    @param regcount  Number of items in regarray
+
+Each @p regarray entry is parsed by hts_parse_reg(), and takes one of the
+following forms:
+
+region          | Outputs
+--------------- | -------------
+REF             | All reads with RNAME REF
+REF:            | All reads with RNAME REF
+REF:START       | Reads with RNAME REF overlapping START to end of REF
+REF:-END        | Reads with RNAME REF overlapping start of REF to END
+REF:START-END   | Reads with RNAME REF overlapping START to END
+.               | All reads from the start of the file
+*               | Unmapped reads at the end of the file (RNAME '*' in SAM)
+
+The form `REF:` should be used when the reference name itself contains a colon.
+
+The iterator will return all reads overlapping the given regions.  If a read
+overlaps more than one region, it will only be returned once.
+ */
 hts_itr_t *sam_itr_regarray(const hts_idx_t *idx, bam_hdr_t *hdr, char **regarray, unsigned int regcount);
 
 /// Get the next read from a SAM/BAM/CRAM iterator

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -448,7 +448,7 @@ in.
 The iterator will return all reads overlapping the given regions.  If a read
 overlaps more than one region, it will only be returned once.
  */
-hts_itr_multi_t *sam_itr_regions(const hts_idx_t *idx, bam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount);
+hts_itr_t *sam_itr_regions(const hts_idx_t *idx, bam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount);
 
 /// Get the next read from a SAM/BAM/CRAM iterator
 /** @param htsfp       Htsfile pointer for the input file
@@ -461,7 +461,15 @@ static inline int sam_itr_next(htsFile *htsfp, hts_itr_t *itr, bam1_t *r) {
         hts_log_error("%s not BGZF compressed", htsfp->fn ? htsfp->fn : "File");
         return -1;
     }
-    return hts_itr_next(htsfp->is_bgzf ? htsfp->fp.bgzf : NULL, itr, r, htsfp);
+    if (!itr) {
+        hts_log_error("Null iterator");
+        return -1;
+    }
+
+    if (itr->multi)
+        return hts_itr_multi_next(htsfp, itr, r);
+    else
+        return hts_itr_next(htsfp->is_bgzf ? htsfp->fp.bgzf : NULL, itr, r, htsfp);
 }
 
 /// Get the next read from a BAM/CRAM multi-iterator
@@ -470,7 +478,7 @@ static inline int sam_itr_next(htsFile *htsfp, hts_itr_t *itr, bam1_t *r) {
     @param r           Pointer to a bam1_t struct
     @return >= 0 on success; -1 when there is no more data; < -1 on error
  */
-#define sam_itr_multi_next(htsfp, itr, r) hts_itr_multi_next((htsfp), (itr), (r))
+#define sam_itr_multi_next(htsfp, itr, r) sam_itr_next(htsfp, itr, r)
 
     /***************
      *** SAM I/O ***

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -449,6 +449,7 @@ The iterator will return all reads overlapping the given regions.  If a read
 overlaps more than one region, it will only be returned once.
  */
 hts_itr_t *sam_itr_regions(const hts_idx_t *idx, bam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount);
+hts_itr_t *sam_itr_regarray(const hts_idx_t *idx, bam_hdr_t *hdr, char **regarray, unsigned int regcount);
 
 /// Get the next read from a SAM/BAM/CRAM iterator
 /** @param htsfp       Htsfile pointer for the input file

--- a/region.c
+++ b/region.c
@@ -1,0 +1,276 @@
+/*  region.c -- Functions to create and free region lists
+
+    Copyright (C) 2019 Genome Research Ltd.
+
+    Author: Valeriu Ohan <vo2@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include "htslib/hts.h"
+#include "htslib/khash.h"
+
+typedef struct reglist
+{
+    uint32_t n, m;
+    uint64_t *a;
+} reglist_t;
+
+KHASH_MAP_INIT_STR(reg, reglist_t)
+typedef kh_reg_t reghash_t;
+
+int compare_uint64 (const void * a, const void * b)
+{
+    if (*(uint64_t *)a < *(uint64_t *)b) return -1;
+    if (*(uint64_t *)a > *(uint64_t *)b) return 1;
+
+    return 0;
+}
+
+#if 0
+/**
+ * Good to have around for debugging
+ */
+static void reg_print(reghash_t *h) {
+    reglist_t *p;
+    khint_t k;
+    uint32_t i;
+    const char *reg;
+    uint32_t beg, end;
+
+    if (!h) {
+        fprintf(stderr, "Hash table is empty!\n");
+        return;
+    }
+    for (k = kh_begin(h); k < kh_end(h); k++) {
+        if (kh_exist(h,k)) {
+            reg = kh_key(h,k);
+            fprintf(stderr, "Region: '%s'\n", reg);
+            if ((p = &kh_val(h,k)) != NULL && p->n > 0) {
+                for (i=0; i<p->n; i++) {
+                    beg = (uint32_t)(p->a[i]>>32);
+                    end = (uint32_t)(p->a[i]);
+                    fprintf(stderr, "\tinterval[%d]: %d-%d\n", i, beg, end);
+                }
+            } else {
+                fprintf(stderr, "Region '%s' has no intervals!\n", reg);
+            }
+        }
+    }
+}
+#endif
+
+/**
+ * Sort and merge overlapping or adjacent intervals.
+ */
+static int reg_compact(reghash_t *h) {
+    khint_t i;
+    uint32_t j, new_n;
+    reglist_t *p;
+    int count = 0;
+
+    if (!h)
+        return 0;
+
+    for (i = kh_begin(h); i < kh_end(h); i++) {
+        if (!kh_exist(h,i) || !(p = &kh_val(h,i)) || !(p->n))
+            continue;
+
+        qsort(p->a, p->n, sizeof(uint64_t), compare_uint64);
+        for (new_n = 0, j = 1; j < p->n; j++) {
+            if ((uint32_t)p->a[new_n] < (uint32_t)(p->a[j]>>32)) {
+                p->a[++new_n] = p->a[j];
+            } else {
+                if ((uint32_t)p->a[new_n] < (uint32_t)p->a[j])
+                    p->a[new_n] = (p->a[new_n] & 0xFFFFFFFF00000000) | (uint32_t)(p->a[j]);
+            }
+        }
+        p->n = ++new_n;
+        count++;
+    }
+
+    return count;
+}
+
+static int reg_insert(reghash_t *h, char *reg, unsigned int beg, unsigned int end) {
+
+    khint_t k;
+    reglist_t *p;
+
+    if (!h)
+        return -1;
+
+    // Put reg in the hash table if not already there
+    k = kh_get(reg, h, reg); //looks strange, but only the second reg is the actual region name.
+    if (k == kh_end(h)) { // absent from the hash table
+        int ret;
+        char *s = strdup(reg);
+        if (NULL == s) return -1;
+        k = kh_put(reg, h, s, &ret);
+        if (-1 == ret) {
+            free(s);
+            return -1;
+        }
+        memset(&kh_val(h, k), 0, sizeof(reglist_t));
+    }
+    p = &kh_val(h, k);
+
+    // Add beg and end to the list
+    if (p->n == p->m) {
+        uint32_t new_m = p->m ? p->m<<1 : 4;
+        if (new_m == 0) return -1;
+        uint64_t *new_a = realloc(p->a, new_m * sizeof(uint64_t));
+        if (new_a == NULL) return -1;
+        p->m = new_m;
+        p->a = new_a;
+    }
+    p->a[p->n++] = (uint64_t)beg<<32 | end;
+
+    return 0;
+}
+
+static void reg_destroy(reghash_t *h) {
+
+    khint_t k;
+
+    if (!h)
+        return;
+
+    for (k = 0; k < kh_end(h); ++k) {
+        if (kh_exist(h, k)) {
+            free(kh_val(h, k).a);
+            free((char*)kh_key(h, k));
+        }
+    }
+    kh_destroy(reg, h);
+}
+
+/**
+ * Take a char array of reg:interval elements and produce a hts_reglis_t with r_count elements.
+ */
+hts_reglist_t *hts_reglist_create(char **argv, int argc, int *r_count, void *hdr,  hts_name2id_f getid) {
+
+    if (!argv || argc < 1)
+        return NULL;
+
+    reghash_t *h = NULL;
+    reglist_t *p;
+    hts_reglist_t *h_reglist = NULL;
+
+    khint_t k;
+    int i, l_count = 0;
+    uint32_t j;
+    char reg[1024];
+    const char *q;
+    int beg, end;
+
+    /* First, transform the char array into a hash table */
+    h = kh_init(reg);
+    if (!h) {
+        hts_log_error("Error when creating the region hash table");
+        return NULL;
+    }
+
+    for (i=0; i<argc; i++) {
+        q = hts_parse_reg(argv[i], &beg, &end);
+        if (q) {
+            if (q - argv[i] > sizeof(reg) - 1) {
+                hts_log_error("Region name '%s' is too long (bigger than %d)", argv[i], (int) sizeof(reg) - 1);
+                continue;
+            }
+            memcpy(reg, argv[i], q - argv[i]);
+            reg[q - argv[i]] = 0;
+        } else {
+            // not parsable as a region, but possibly a sequence named "foo:a"
+            if (strlen(argv[i]) > sizeof(reg) - 1) {
+                hts_log_error("Region name '%s' is too long (bigger than %d)", argv[i], (int) sizeof(reg) - 1);
+                continue;
+            }
+            strcpy(reg, argv[i]);
+            beg = 0; end = INT_MAX;
+        }
+
+        if (reg_insert(h, reg, beg, end) != 0) {
+            hts_log_error("Error when inserting region='%s' in the bed hash table at address=%p", argv[i], h);
+            goto fail;
+        }
+    }
+
+    *r_count = reg_compact(h);
+    if (!*r_count)
+        return NULL;
+
+    /* Transform the hash table into a list */
+    h_reglist = (hts_reglist_t *)calloc(*r_count, sizeof(hts_reglist_t));
+    if (!h_reglist)
+        return NULL;
+
+    for (k = kh_begin(h); k < kh_end(h) && l_count < *r_count; k++) {
+        if (!kh_exist(h,k) || !(p = &kh_val(h,k)))
+            continue;
+
+        char *reg_name = (char *)kh_key(h,k);
+        if (!strcmp(reg_name, ".")) {
+            h_reglist[l_count].tid = HTS_IDX_START;
+        } else if (!strcmp(reg_name, "*")) {
+            h_reglist[l_count].tid = HTS_IDX_NOCOOR;
+        } else {
+            h_reglist[l_count].tid = getid(hdr, reg_name);
+            if (h_reglist[l_count].tid < 0)
+                hts_log_warning("Region '%s' specifies an unknown reference name. Continue anyway", reg_name);
+        }
+
+        h_reglist[l_count].intervals = (hts_pair32_t *)calloc(p->n, sizeof(hts_pair32_t));
+        if(!(h_reglist[l_count].intervals)) {
+            hts_log_error("Could not allocate memory for intervals for region='%s'", kh_key(h,k));
+            goto fail;
+        }
+        h_reglist[l_count].count = p->n;
+        h_reglist[l_count].max_end = 0;
+
+        for (j = 0; j < p->n; j++) {
+            h_reglist[l_count].intervals[j].beg = (uint32_t)(p->a[j]>>32);
+            h_reglist[l_count].intervals[j].end = (uint32_t)(p->a[j]);
+
+            if (h_reglist[l_count].intervals[j].end > h_reglist[l_count].max_end)
+                h_reglist[l_count].max_end = h_reglist[l_count].intervals[j].end;
+        }
+        l_count++;
+    }
+    reg_destroy(h);
+
+    return h_reglist;
+
+fail:
+    reg_destroy(h);
+    if(h_reglist) hts_reglist_free(h_reglist, l_count);
+
+    return NULL;
+}
+
+void hts_reglist_free(hts_reglist_t *reglist, int count) {
+
+    int i;
+    if(reglist) {
+        for (i = 0; i < count; i++) {
+            if (reglist[i].intervals)
+                free(reglist[i].intervals);
+        }
+        free(reglist);
+    }
+}

--- a/sam.c
+++ b/sam.c
@@ -967,9 +967,13 @@ hts_itr_t *sam_itr_querys(const hts_idx_t *idx, bam_hdr_t *hdr, const char *regi
                           sam_readrec);
 }
 
-hts_itr_multi_t *sam_itr_regions(const hts_idx_t *idx, bam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount)
+hts_itr_t *sam_itr_regions(const hts_idx_t *idx, bam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount)
 {
     const hts_cram_idx_t *cidx = (const hts_cram_idx_t *) idx;
+
+    if(!cidx || !hdr || !reglist)
+        return NULL;
+
     if (cidx->fmt == HTS_FMT_CRAI)
         return hts_itr_regions(idx, reglist, regcount, cram_name2id, cidx->cram,
                    hts_itr_multi_cram, cram_readrec, cram_pseek, cram_ptell);

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -188,20 +188,20 @@ int sam_loop(int argc, char **argv, int optind, struct opts *opts, htsFile *in, 
                     r->max_end = end;
             }
 
-            hts_itr_multi_t *iter = sam_itr_regions(idx, h, reg_list, reg_count);
+            hts_itr_t *iter = sam_itr_regions(idx, h, reg_list, reg_count);
             if (!iter)
                 goto fail;
             reg_list = NULL; // Now owned by iterator
-            while ((r = sam_itr_multi_next(in, iter, b)) >= 0) {
+            while ((r = sam_itr_next(in, iter, b)) >= 0) {
                 if (!opts->benchmark && sam_write1(out, h, b) < 0) {
                     fprintf(stderr, "Error writing output.\n");
-                    hts_itr_multi_destroy(iter);
+                    hts_itr_destroy(iter);
                     goto fail;
                 }
                 if (opts->nreads && --opts->nreads == 0)
                     break;
             }
-            hts_itr_multi_destroy(iter);
+            hts_itr_destroy(iter);
             if (r < -1) {
                 fprintf(stderr, "Error reading input.\n");
                 goto fail;


### PR DESCRIPTION
Merge the two iterator structures (`hts_itr_t` and `hts_itr_multi_t`) into one.
Add a method for creating a `hts_reglist_t` out of a char array of reg:interval elements.
Fixes #785 