### PR TITLE
Update S3 code to use version 4 signatures.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for htslib, a C library for high-throughput sequencing data formats.
 #
-#    Copyright (C) 2013-2018 Genome Research Ltd.
+#    Copyright (C) 2013-2019 Genome Research Ltd.
 #
 #    Author: John Marshall <jm18@sanger.ac.uk>
 #
@@ -307,6 +307,7 @@ hfile.o hfile.pico: hfile.c config.h $(htslib_hfile_h) $(hfile_internal_h) $(hts
 hfile_gcs.o hfile_gcs.pico: hfile_gcs.c config.h $(htslib_hts_h) $(htslib_kstring_h) $(hfile_internal_h)
 hfile_libcurl.o hfile_libcurl.pico: hfile_libcurl.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_net.o hfile_net.pico: hfile_net.c config.h $(hfile_internal_h) $(htslib_knetfile_h)
+hfile_s3_write.o hfile_s3_write.pico: hfile_s3_write.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
 hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
 hts.o hts.pico: hts.c config.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_hts_endian_h) version.h $(hts_internal_h) $(hfile_internal_h) $(htslib_hts_os_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h) $(htslib_tbx_h)
 hts_os.o hts_os.pico: hts_os.c config.h os/rand.c

--- a/NEWS
+++ b/NEWS
@@ -48,6 +48,28 @@ Noteworthy changes in release a.b
   example, "/path1/my_data.bam##idx##/path2/my_index.csi" will open bam file
   "/path1/my_data.bam" and index file "/path2/my_index.csi".
 
+* Changes to hfile_s3, which provides support for the AWS S3 API.
+
+  - hfile_s3 now uses version 4 signatures by default.  Attempting to write to
+    an S3 bucket will also now work correctly.  It is possible to force
+    version 2 signatures by creating environment variable HTS_S3_V2 (the exact
+    value does not matter, it just has to exist).  Note that writing depends
+    on features that need version 4 signatures, so forcing version 2 will
+    disable writes.
+
+  - hfile_s3 will automatically retry requests where the region endpoint
+    was not specified correctly, either by following the 301 redirect (when
+    using path-style requests) or reading the 400 response (when using
+    virtual-hosted style requests and version 4 signatures).  The first
+    region to try can be set by using the AWS_DEFAULT_REGION environment
+    variable, by setting "region" in ".aws/credentials" or by setting
+    "bucket_location" in ".s3cfg".
+
+  - hfile_s3 now percent-escapes the path component of s3:// URLs.  For
+    backwards-compatibility it will ignore any paths that have already
+    been escaped (detected by looking for '%' followed by two hexadecimal
+    digits.)
+
 * Fixed bug where some 8 or 16-bit negative integers were stored using values
   reserved by the BCF specification.  These numbers are now promoted to the
   next size up, so -121 to -128 are stored using at least 16 bits, and -32761

--- a/config.mk.in
+++ b/config.mk.in
@@ -1,6 +1,6 @@
 #  Optional configure Makefile overrides for htslib.
 #
-#    Copyright (C) 2015-2017 Genome Research Ltd.
+#    Copyright (C) 2015-2017, 2019 Genome Research Ltd.
 #
 #    Author: John Marshall <jm18@sanger.ac.uk>
 #
@@ -74,10 +74,12 @@ endif
 
 ifeq "s3-@s3@" "s3-enabled"
 plugin_OBJS += hfile_s3.o
+plugin_OBJS += hfile_s3_write.o
 
 CRYPTO_LIBS = @CRYPTO_LIBS@
 noplugin_LIBS += $(CRYPTO_LIBS)
 hfile_s3$(PLUGIN_EXT): LIBS += $(CRYPTO_LIBS)
+hfile_s3_write$(PLUGIN_EXT): LIBS += $(CRYPTO_LIBS) $(LIBCURL_LIBS)
 endif
 
 ifeq "plugins-@enable_plugins@" "plugins-yes"
@@ -94,6 +96,7 @@ plugin.o plugin.pico: CPPFLAGS += -DPLUGINPATH=\"$(pluginpath)\"
 hfile_gcs.o hfile_gcs.pico: version.h
 hfile_libcurl.o hfile_libcurl.pico: version.h
 hfile_s3.o hfile_s3.pico: version.h
+hfile_s3_write.o hfile_s3_write.pico: version.h
 
 # Windows DLL plugins depend on the import library, built as a byproduct.
 $(plugin_OBJS:.o=.cygdll): cyghts-$(LIBHTS_SOVERSION).dll

--- a/hfile.c
+++ b/hfile.c
@@ -972,6 +972,7 @@ static void load_hfile_plugins()
 #endif
 #ifdef ENABLE_S3
     init_add_plugin(NULL, hfile_plugin_init_s3, "s3");
+    init_add_plugin(NULL, hfile_plugin_init_s3_write, "s3w");
 #endif
 
 #endif

--- a/hfile_internal.h
+++ b/hfile_internal.h
@@ -169,6 +169,7 @@ extern int hfile_plugin_init(struct hFILE_plugin *self);
 extern int hfile_plugin_init_gcs(struct hFILE_plugin *self);
 extern int hfile_plugin_init_libcurl(struct hFILE_plugin *self);
 extern int hfile_plugin_init_s3(struct hFILE_plugin *self);
+extern int hfile_plugin_init_s3_write(struct hFILE_plugin *self);
 #endif
 
 /* This one is never built as a separate plugin.  */
@@ -178,6 +179,18 @@ extern int hfile_plugin_init_net(struct hFILE_plugin *self);
 // to allow s3 to renew tokens when seeking.  Kept internal for now,
 // although we may consider exposing it in the API later.
 typedef int (* hts_httphdr_callback) (void *cb_data, char ***hdrs);
+
+/** Callback for handling 3xx redirect responses from http connections.
+
+    @param data       is passed to the callback
+    @param response   http response code (e.g. 301)
+    @param headers    http response headers
+    @param new_url    the callback should write the url to switch to in here
+
+    Currently used by s3 to handle switching region endpoints.
+*/
+typedef int (*redirect_callback) (void *data, long response,
+                                  kstring_t *headers, kstring_t *new_url);
 
 #ifdef __cplusplus
 }

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -1,6 +1,6 @@
 /*  hfile_s3.c -- Amazon S3 backend for low-level file streams.
 
-    Copyright (C) 2015-2017 Genome Research Ltd.
+    Copyright (C) 2015-2017, 2019 Genome Research Ltd.
 
     Author: John Marshall <jm18@sanger.ac.uk>
 
@@ -30,6 +30,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <time.h>
 
+#include <errno.h>
+
 #include "hfile_internal.h"
 #ifdef ENABLE_PLUGINS
 #include "version.h"
@@ -37,16 +39,23 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/hts.h"  // for hts_version() and hts_verbose
 #include "htslib/kstring.h"
 
-typedef struct {
+typedef struct s3_auth_data {
     kstring_t id;
     kstring_t token;
     kstring_t secret;
+    kstring_t region;
+    kstring_t canonical_query_string;
+    kstring_t host;
     char *bucket;
     kstring_t auth_hdr;
     time_t auth_time;
     char date[40];
+    char date_long[17];
+    char date_short[9];
+    kstring_t date_html;
     char mode;
-    char *headers[3];
+    char *headers[4];
+    int refcount;
 } s3_auth_data;
 
 #define AUTH_LIFETIME 60
@@ -56,6 +65,8 @@ typedef struct {
 #include <CommonCrypto/CommonHMAC.h>
 
 #define DIGEST_BUFSIZ CC_SHA1_DIGEST_LENGTH
+#define SHA256_DIGEST_BUFSIZE CC_SHA256_DIGEST_LENGTH
+#define HASH_LENGTH_SHA256 (SHA256_DIGEST_BUFSIZE * 2) + 1
 
 static size_t
 s3_sign(unsigned char *digest, kstring_t *key, kstring_t *message)
@@ -64,11 +75,26 @@ s3_sign(unsigned char *digest, kstring_t *key, kstring_t *message)
     return CC_SHA1_DIGEST_LENGTH;
 }
 
+
+static void s3_sha256(const unsigned char *in, size_t length, unsigned char *out) {
+    CC_SHA256(in, length, out);
+}
+
+
+static void s3_sign_sha256(const void *key, int key_len, const unsigned char *d, int n, unsigned char *md, unsigned int *md_len) {
+    CCHmac(kCCHmacAlgSHA256, key, key_len, d, n, md);
+    *md_len = CC_SHA256_DIGEST_LENGTH;
+}
+
+
 #elif defined HAVE_HMAC
 
 #include <openssl/hmac.h>
+#include <openssl/sha.h>
 
 #define DIGEST_BUFSIZ EVP_MAX_MD_SIZE
+#define SHA256_DIGEST_BUFSIZE SHA256_DIGEST_LENGTH
+#define HASH_LENGTH_SHA256 (SHA256_DIGEST_BUFSIZE * 2) + 1
 
 static size_t
 s3_sign(unsigned char *digest, kstring_t *key, kstring_t *message)
@@ -77,6 +103,16 @@ s3_sign(unsigned char *digest, kstring_t *key, kstring_t *message)
     HMAC(EVP_sha1(), key->s, key->l,
          (unsigned char *) message->s, message->l, digest, &len);
     return len;
+}
+
+
+static void s3_sha256(const unsigned char *in, size_t length, unsigned char *out) {
+    SHA256(in, length, out);
+}
+
+
+static void s3_sign_sha256(const void *key, int key_len, const unsigned char *d, int n, unsigned char *md, unsigned int *md_len) {
+    HMAC(EVP_sha256(), key, key_len, d, n, md, md_len);
 }
 
 #else
@@ -122,7 +158,7 @@ static void base64_kput(const unsigned char *data, size_t len, kstring_t *str)
     kputsn("==", pad, str);
 }
 
-static int is_dns_compliant(const char *s0, const char *slim)
+static int is_dns_compliant(const char *s0, const char *slim, int is_https)
 {
     int has_nondigit = 0, len = 0;
     const char *s;
@@ -137,6 +173,7 @@ static int is_dns_compliant(const char *s0, const char *slim)
         else if (isdigit_c(*s))
             ;
         else if (*s == '.') {
+            if (is_https) return 0;
             if (s == s0 || ! isalnum_c(s[-1])) return 0;
             if (s+1 == slim || ! isalnum_c(s[1])) return 0;
         }
@@ -244,11 +281,19 @@ static int copy_auth_headers(s3_auth_data *ad, char ***hdrs) {
 }
 
 static void free_auth_data(s3_auth_data *ad) {
+    if (ad->refcount > 0) {
+        --ad->refcount;
+        return;
+    }
     free(ad->id.s);
     free(ad->token.s);
     free(ad->secret.s);
+    free(ad->region.s);
+    free(ad->canonical_query_string.s);
+    free(ad->host.s);
     free(ad->bucket);
     free(ad->auth_hdr.s);
+    free(ad->date_html.s);
     free(ad);
 }
 
@@ -283,7 +328,7 @@ static int auth_header_callback(void *ctx, char ***hdrs) {
         return copy_auth_headers(ad, hdrs);
     }
 
-    if (ksprintf(&message, "%s\n\n\n%s\n%s%s%s/%s",
+    if (ksprintf(&message, "%s\n\n\n%s\n%s%s%s%s",
                  ad->mode == 'r' ? "GET" : "PUT", ad->date + 6,
                  ad->token.l ? "x-amz-security-token:" : "",
                  ad->token.l ? ad->token.s : "",
@@ -307,17 +352,108 @@ static int auth_header_callback(void *ctx, char ***hdrs) {
     return -1;
 }
 
-static hFILE * s3_rewrite(const char *s3url, const char *mode, va_list *argsp)
+
+static char *escape_path(const char *path) {
+    size_t i, j = 0, length;
+    char *escaped;
+
+    length = strlen(path);
+
+    if ((escaped = malloc(length * 3 + 1)) == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < length; i++) {
+        int c = path[i];
+
+        if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+             c == '_' || c == '-' || c == '~' || c == '.' || c == '/') {
+            escaped[j++] = c;
+        } else {
+            sprintf(escaped + j, "%%%02X", c);
+            j += 3;
+        }
+    }
+    escaped[j] = '\0';
+
+    return escaped;
+}
+
+
+static int is_escaped(const char *str) {
+    const char *c = str;
+    int escaped = 0;
+    int needs_escape = 0;
+
+    while (*c != '\0') {
+        if (*c == '%' && c[1] != '\0' && c[2] != '\0') {
+            if (isxdigit(c[1]) && isxdigit(c[2])) {
+                escaped = 1;
+                c += 3;
+                continue;
+            } else {
+                // only escaped if all % signs are escaped
+                escaped = 0;
+            }
+        }
+        if (!((*c >= '0' && *c <= '9') || (*c >= 'A' && *c <= 'Z')
+              || (*c >= 'a' && *c <= 'z') ||
+              *c == '_' || *c == '-' || *c == '~' || *c == '.' || *c == '/')) {
+            needs_escape = 1;
+        }
+        c++;
+    }
+
+    return escaped || !needs_escape;
+}
+
+static int redirect_endpoint_callback(void *auth, long response,
+                                      kstring_t *header, kstring_t *url) {
+    s3_auth_data *ad = (s3_auth_data *)auth;
+    char *new_region;
+    char *end;
+    int ret = -1;
+
+    // get the new region from the reply header
+    if ((new_region = strstr(header->s, "x-amz-bucket-region: "))) {
+
+        new_region += strlen("x-amz-bucket-region: ");
+        end = new_region;
+
+        while (isalnum(*end) || ispunct(*end)) end++;
+
+        *end = 0;
+
+        if (strstr(ad->host.s, "amazonaws.com")) {
+            ad->region.l = 0;
+            kputs(new_region, &ad->region);
+
+            ad->host.l = 0;
+            ksprintf(&ad->host, "s3.%s.amazonaws.com", new_region);
+
+            if (ad->region.l && ad->host.l) {
+               url->l = 0;
+               kputs(ad->host.s, url);
+               kputsn(ad->bucket, strlen(ad->bucket), url);
+
+               ret = 0;
+            }
+        }
+    }
+
+    return ret;
+}
+
+static s3_auth_data * setup_auth_data(const char *s3url, const char *mode,
+                                      int sigver, kstring_t *url)
 {
-    const char *bucket, *path;
-    char *header_list[4], **header = header_list;
-
-    kstring_t url = { 0, 0, NULL };
-    kstring_t profile = { 0, 0, NULL };
-    kstring_t host_base = { 0, 0, NULL };
-    kstring_t token_hdr = { 0, 0, NULL };
-
     s3_auth_data *ad = calloc(1, sizeof(*ad));
+    const char *bucket, *path;
+    char *escaped = NULL;
+    kstring_t profile = { 0, 0, NULL };
+    size_t url_path_pos;
+    ptrdiff_t bucket_len;
+    int is_https = 1, dns_compliant;
 
     if (!ad)
         return NULL;
@@ -327,15 +463,21 @@ static hFILE * s3_rewrite(const char *s3url, const char *mode, va_list *argsp)
 
     if (s3url[2] == '+') {
         bucket = strchr(s3url, ':') + 1;
-        kputsn(&s3url[3], bucket - &s3url[3], &url);
+        if (bucket == NULL) {
+            free(ad);
+            return NULL;
+        }
+        kputsn(&s3url[3], bucket - &s3url[3], url);
+        is_https = strncmp(url->s, "https:", 6) == 0;
     }
     else {
-        kputs("https:", &url);
+        kputs("https:", url);
         bucket = &s3url[3];
     }
-    while (*bucket == '/') kputc(*bucket++, &url);
+    while (*bucket == '/') kputc(*bucket++, url);
 
     path = bucket + strcspn(bucket, "/?#@");
+
     if (*path == '@') {
         const char *colon = strpbrk(bucket, ":@");
         if (*colon != ':') {
@@ -358,6 +500,7 @@ static hFILE * s3_rewrite(const char *s3url, const char *mode, va_list *argsp)
         if ((v = getenv("AWS_ACCESS_KEY_ID")) != NULL) kputs(v, &ad->id);
         if ((v = getenv("AWS_SECRET_ACCESS_KEY")) != NULL) kputs(v, &ad->secret);
         if ((v = getenv("AWS_SESSION_TOKEN")) != NULL) kputs(v, &ad->token);
+        if ((v = getenv("AWS_DEFAULT_REGION")) != NULL) kputs(v, &ad->region);
 
         if ((v = getenv("AWS_DEFAULT_PROFILE")) != NULL) kputs(v, &profile);
         else if ((v = getenv("AWS_PROFILE")) != NULL) kputs(v, &profile);
@@ -369,29 +512,107 @@ static hFILE * s3_rewrite(const char *s3url, const char *mode, va_list *argsp)
         parse_ini(v? v : "~/.aws/credentials", profile.s,
                   "aws_access_key_id", &ad->id,
                   "aws_secret_access_key", &ad->secret,
-                  "aws_session_token", &ad->token, NULL);
+                  "aws_session_token", &ad->token,
+                  "region", &ad->region, NULL);
     }
     if (ad->id.l == 0)
         parse_ini("~/.s3cfg", profile.s, "access_key", &ad->id,
                   "secret_key", &ad->secret, "access_token", &ad->token,
-                  "host_base", &host_base, NULL);
+                  "host_base", &ad->host,
+                  "bucket_location", &ad->region, NULL);
     if (ad->id.l == 0)
         parse_simple("~/.awssecret", &ad->id, &ad->secret);
 
-    if (host_base.l == 0)
-        kputs("s3.amazonaws.com", &host_base);
+    dns_compliant = is_dns_compliant(bucket, path, is_https);
+
+    if (ad->host.l == 0)
+        kputs("s3.amazonaws.com", &ad->host);
+
+    if (!dns_compliant && ad->region.l > 0
+        && strcmp(ad->host.s, "s3.amazonaws.com") == 0) {
+        // Can avoid a redirection by including the region in the host name
+        // (assuming the right one has been specified)
+        ad->host.l = 0;
+        ksprintf(&ad->host, "s3.%s.amazonaws.com", ad->region.s);
+    }
+
+    if (ad->region.l == 0)
+        kputs("us-east-1", &ad->region);
+
+    if (!is_escaped(path)) {
+        escaped = escape_path(path);
+        if (escaped == NULL) {
+            goto error;
+        }
+    }
+
+    bucket_len = path - bucket;
+
     // Use virtual hosted-style access if possible, otherwise path-style.
-    if (is_dns_compliant(bucket, path)) {
-        kputsn(bucket, path - bucket, &url);
-        kputc('.', &url);
-        kputs(host_base.s, &url);
+    if (dns_compliant) {
+        size_t url_host_pos = url->l;
+        // Append "bucket.host" to url
+        kputsn_(bucket, bucket_len, url);
+        kputc('.', url);
+        kputsn(ad->host.s, ad->host.l, url);
+        url_path_pos = url->l;
+
+        if (sigver == 4) {
+            // Copy back to ad->host to use when making the signature
+            ad->host.l = 0;
+            kputsn(url->s + url_host_pos, url->l - url_host_pos, &ad->host);
+        }
     }
     else {
-        kputs(host_base.s, &url);
-        kputc('/', &url);
-        kputsn(bucket, path - bucket, &url);
+        // Append "host/bucket" to url
+        kputsn(ad->host.s, ad->host.l, url);
+        url_path_pos = url->l;
+        kputc('/', url);
+        kputsn(bucket, bucket_len, url);
     }
-    kputs(path, &url);
+
+    kputs(escaped == NULL ? path : escaped, url);
+
+    if (sigver == 4 || !dns_compliant) {
+        ad->bucket = malloc(url->l - url_path_pos + 1);
+        if (ad->bucket == NULL) {
+            goto error;
+        }
+        memcpy(ad->bucket, url->s + url_path_pos, url->l - url_path_pos + 1);
+    }
+    else {
+        ad->bucket = malloc(url->l - url_path_pos + bucket_len + 2);
+        if (ad->bucket == NULL) {
+            goto error;
+        }
+        ad->bucket[0] = '/';
+        memcpy(ad->bucket + 1, bucket, bucket_len);
+        memcpy(ad->bucket + bucket_len + 1,
+               url->s + url_path_pos, url->l - url_path_pos + 1);
+    }
+
+    free(profile.s);
+    free(escaped);
+
+    return ad;
+
+ error:
+    free(profile.s);
+    free(escaped);
+    free_auth_data(ad);
+    return NULL;
+}
+
+static hFILE * s3_rewrite(const char *s3url, const char *mode, va_list *argsp)
+{
+    char *header_list[4], **header = header_list;
+
+    kstring_t url = { 0, 0, NULL };
+    kstring_t token_hdr = { 0, 0, NULL };
+    s3_auth_data *ad = setup_auth_data(s3url, mode, 2, &url);
+
+    if (!ad)
+        return NULL;
 
     if (ad->token.l > 0) {
         kputs("X-Amz-Security-Token: ", &token_hdr);
@@ -399,48 +620,484 @@ static hFILE * s3_rewrite(const char *s3url, const char *mode, va_list *argsp)
         *header++ = token_hdr.s;
     }
 
-    ad->bucket = strdup(bucket);
-    if (!ad->bucket)
-        goto fail;
-
     *header = NULL;
     hFILE *fp = hopen(url.s, mode, "va_list", argsp, "httphdr:v", header_list,
                       "httphdr_callback", auth_header_callback,
-                      "httphdr_callback_data", ad, NULL);
+                      "httphdr_callback_data", ad,
+                      "redirect_callback", redirect_endpoint_callback,
+                      "redirect_callback_data", ad,
+                      NULL);
     if (!fp) goto fail;
 
     free(url.s);
-    free(profile.s);
-    free(host_base.s);
     free(token_hdr.s);
     return fp;
 
  fail:
     free(url.s);
-    free(profile.s);
-    free(host_base.s);
     free(token_hdr.s);
     free_auth_data(ad);
     return NULL;
 }
 
+/***************************************************************
+
+AWS S3 sig version 4 writing code
+
+****************************************************************/
+
+static void hash_string(char *in, size_t length, char *out) {
+    unsigned char hashed[SHA256_DIGEST_BUFSIZE];
+    int i, j;
+
+    s3_sha256((const unsigned char *)in, length, hashed);
+
+    for (i = 0, j = 0; i < SHA256_DIGEST_BUFSIZE; i++, j+= 2) {
+        sprintf(out + j, "%02x", hashed[i]);
+    }
+}
+
+static void ksinit(kstring_t *s) {
+    s->l = 0;
+    s->m = 0;
+    s->s = NULL;
+}
+
+
+static void ksfree(kstring_t *s) {
+    free(s->s);
+    ksinit(s);
+}
+
+
+static int make_signature(s3_auth_data *ad, kstring_t *string_to_sign, char *signature_string) {
+    unsigned char date_key[SHA256_DIGEST_BUFSIZE];
+    unsigned char date_region_key[SHA256_DIGEST_BUFSIZE];
+    unsigned char date_region_service_key[SHA256_DIGEST_BUFSIZE];
+    unsigned char signing_key[SHA256_DIGEST_BUFSIZE];
+    unsigned char signature[SHA256_DIGEST_BUFSIZE];
+
+    const unsigned char service[] = "s3";
+    const unsigned char request[] = "aws4_request";
+
+    kstring_t secret_access_key = {0, 0, NULL};
+    unsigned int len;
+    unsigned int i, j;
+
+    ksprintf(&secret_access_key, "AWS4%s", ad->secret.s);
+
+    if (secret_access_key.l == 0) {
+        return -1;
+    }
+
+    s3_sign_sha256(secret_access_key.s, secret_access_key.l, (const unsigned char *)ad->date_short, strlen(ad->date_short), date_key, &len);
+    s3_sign_sha256(date_key, len, (const unsigned char *)ad->region.s, ad->region.l, date_region_key, &len);
+    s3_sign_sha256(date_region_key, len, service, 2, date_region_service_key, &len);
+    s3_sign_sha256(date_region_service_key, len, request, 12, signing_key, &len);
+    s3_sign_sha256(signing_key, len, (const unsigned char *)string_to_sign->s, string_to_sign->l, signature, &len);
+
+    for (i = 0, j = 0; i < len; i++, j+= 2) {
+        sprintf(signature_string + j, "%02x", signature[i]);
+    }
+
+    ksfree(&secret_access_key);
+
+    return 0;
+}
+
+
+static int make_authorisation(s3_auth_data *ad, char *http_request, char *content, kstring_t *auth) {
+    kstring_t signed_headers = {0, 0, NULL};
+    kstring_t canonical_headers = {0, 0, NULL};
+    kstring_t canonical_request = {0, 0, NULL};
+    kstring_t scope = {0, 0, NULL};
+    kstring_t string_to_sign = {0, 0, NULL};
+    char cr_hash[HASH_LENGTH_SHA256];
+    char signature_string[HASH_LENGTH_SHA256];
+    int ret = -1;
+
+
+    if (!ad->token.l) {
+        kputs("host;x-amz-content-sha256;x-amz-date", &signed_headers);
+    } else {
+        kputs("host;x-amz-content-sha256;x-amz-date;x-amz-security-token", &signed_headers);
+    }
+
+    if (signed_headers.l == 0) {
+        return -1;
+    }
+
+
+    if (!ad->token.l) {
+        ksprintf(&canonical_headers, "host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n",
+        ad->host.s, content, ad->date_long);
+    } else {
+        ksprintf(&canonical_headers, "host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\nx-amz-security-token:%s\n",
+        ad->host.s, content, ad->date_long, ad->token.s);
+    }
+
+    if (canonical_headers.l == 0) {
+        goto cleanup;
+    }
+
+
+    // bucket == canonical_uri
+    ksprintf(&canonical_request, "%s\n%s\n%s\n%s\n%s\n%s",
+        http_request, ad->bucket, ad->canonical_query_string.s,
+        canonical_headers.s, signed_headers.s, content);
+
+    if (canonical_request.l == 0) {
+        goto cleanup;
+    }
+
+    hash_string(canonical_request.s, canonical_request.l, cr_hash);
+
+    ksprintf(&scope, "%s/%s/s3/aws4_request", ad->date_short, ad->region.s);
+
+    if (scope.l == 0) {
+        goto cleanup;
+    }
+
+    ksprintf(&string_to_sign, "AWS4-HMAC-SHA256\n%s\n%s\n%s", ad->date_long, scope.s, cr_hash);
+
+    if (string_to_sign.l == 0) {
+        goto cleanup;
+    }
+
+    if (make_signature(ad, &string_to_sign, signature_string)) {
+        goto cleanup;
+    }
+
+    ksprintf(auth, "Authorization: AWS4-HMAC-SHA256 Credential=%s/%s/%s/s3/aws4_request,SignedHeaders=%s,Signature=%s",
+                ad->id.s, ad->date_short, ad->region.s, signed_headers.s, signature_string);
+
+    if (auth->l == 0) {
+        goto cleanup;
+    }
+
+    ret = 0;
+
+ cleanup:
+    ksfree(&signed_headers);
+    ksfree(&canonical_headers);
+    ksfree(&canonical_request);
+    ksfree(&scope);
+    ksfree(&string_to_sign);
+
+    return ret;
+}
+
+
+static int update_time(s3_auth_data *ad) {
+    int ret = -1;
+    time_t now = time(NULL);
+#ifdef HAVE_GMTIME_R
+    struct tm tm_buffer;
+    struct tm *tm = gmtime_r(&now, &tm_buffer);
+#else
+    struct tm *tm = gmtime(&now);
+#endif
+
+    if (now - ad->auth_time > AUTH_LIFETIME) {
+        // update timestamp
+        ad->auth_time = now;
+
+        if (strftime(ad->date_long, 17, "%Y%m%dT%H%M%SZ", tm) != 16) {
+            return -1;
+        }
+
+        if (strftime(ad->date_short, 9, "%Y%m%d", tm) != 8) {
+            return -1;;
+        }
+
+        ad->date_html.l = 0;
+        ksprintf(&ad->date_html, "x-amz-date: %s", ad->date_long);
+    }
+
+    if (ad->date_html.l) ret = 0;
+
+    return ret;
+}
+
+
+static int write_authorisation_callback(void *auth, char *request, kstring_t *content, char *cqs,
+                                        kstring_t *hash, kstring_t *auth_str, kstring_t *date, kstring_t *token) {
+    s3_auth_data *ad = (s3_auth_data *)auth;
+    char content_hash[HASH_LENGTH_SHA256];
+
+    if (request == NULL) {
+        // signal to free auth data
+        free_auth_data(ad);
+        return 0;
+    }
+
+    if (update_time(ad)) {
+        return -1;
+    }
+
+    if (content) {
+        hash_string(content->s, content->l, content_hash);
+    } else {
+        // empty hash
+        hash_string("", 0, content_hash);
+    }
+
+    ad->canonical_query_string.l = 0;
+    kputs(cqs, &ad->canonical_query_string);
+
+    if (ad->canonical_query_string.l == 0) {
+        return -1;
+    }
+
+    if (make_authorisation(ad, request, content_hash, auth_str)) {
+        return -1;
+    }
+
+    kputs(ad->date_html.s, date);
+    kputsn(content_hash, HASH_LENGTH_SHA256, hash);
+
+    if (date->l == 0 || hash->l == 0) {
+        return -1;
+    }
+
+    if (ad->token.l) {
+        ksprintf(token, "x-amz-security-token: %s", ad->token.s);
+    }
+
+    return 0;
+}
+
+
+static int v4_auth_header_callback(void *ctx, char ***hdrs) {
+    s3_auth_data *ad = (s3_auth_data *) ctx;
+    char content_hash[HASH_LENGTH_SHA256];
+    kstring_t content = {0, 0, NULL};
+    kstring_t authorisation = {0, 0, NULL};
+    char *date_html = NULL;
+
+    if (!hdrs) { // Closing connection
+        free_auth_data(ad);
+        return 0;
+    }
+
+    if (update_time(ad)) {
+        return -1;
+    }
+
+    hash_string("", 0, content_hash); // empty hash
+
+    ad->canonical_query_string.l = 0;
+    kputs("", &ad->canonical_query_string);
+
+    if (make_authorisation(ad, "GET", content_hash, &authorisation)) {
+        return -1;
+    }
+
+    ksprintf(&content, "x-amz-content-sha256: %s", content_hash);
+    date_html = strdup(ad->date_html.s);
+
+    if (content.l == 0 || date_html == NULL) {
+        ksfree(&authorisation);
+        ksfree(&content);
+        free(date_html);
+        return -1;
+    }
+
+    *hdrs = &ad->headers[0];
+    ad->headers[0] = ks_release(&authorisation);
+    ad->headers[1] = date_html;
+    ad->headers[2] = ks_release(&content);
+    ad->headers[3] = NULL;
+
+    return 0;
+}
+
+static int handle_400_response(hFILE *fp, s3_auth_data *ad) {
+    // v4 signatures in virtual hosted mode return 400 Bad Request if the
+    // wrong region is used to make the signature.  The response is an xml
+    // document which includes the name of the correct region.  This can
+    // be extracted and used to generate a corrected signature.
+    // As the xml is fairly simple, go with something "good enough" instead
+    // of trying to parse it properly.
+
+    char buffer[1024], *region, *reg_end;
+    ssize_t bytes;
+
+    bytes = hread(fp, buffer, sizeof(buffer) - 1);
+    if (bytes < 0) {
+        return -1;
+    }
+    buffer[bytes] = '\0';
+    region = strstr(buffer, "<Region>");
+    if (region == NULL) {
+        return -1;
+    }
+    region += 8;
+    while (isspace((unsigned char) *region)) ++region;
+    reg_end = strchr(region, '<');
+    if (reg_end == NULL || strncmp(reg_end + 1, "/Region>", 8) != 0) {
+        return -1;
+    }
+    while (reg_end > region && isspace((unsigned char) reg_end[-1])) --reg_end;
+    ad->region.l = 0;
+    kputsn(region, reg_end - region, &ad->region);
+    if (ad->region.l == 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int set_region(void *adv, kstring_t *region) {
+    s3_auth_data *ad = (s3_auth_data *) adv;
+
+    ad->region.l = 0;
+    return kputsn(region->s, region->l, &ad->region) < 0;
+}
+
+static int http_status_errno(int status)
+{
+    if (status >= 500)
+        switch (status) {
+        case 501: return ENOSYS;
+        case 503: return EBUSY;
+        case 504: return ETIMEDOUT;
+        default:  return EIO;
+        }
+    else if (status >= 400)
+        switch (status) {
+        case 401: return EPERM;
+        case 403: return EACCES;
+        case 404: return ENOENT;
+        case 405: return EROFS;
+        case 407: return EPERM;
+        case 408: return ETIMEDOUT;
+        case 410: return ENOENT;
+        default:  return EINVAL;
+        }
+    else return 0;
+}
+
+static hFILE *s3_open_v4(const char *s3url, const char *mode, va_list *argsp) {
+    kstring_t url = { 0, 0, NULL };
+    kstring_t token_hdr = { 0, 0, NULL };
+
+    char *header_list[4], **header = header_list;
+    s3_auth_data *ad = setup_auth_data(s3url, mode, 4, &url);
+    hFILE *fp = NULL;
+
+    if (ad == NULL) {
+        return NULL;
+    }
+
+    if (ad->mode == 'r') {
+        long http_response = 0;
+
+        if (ad->token.l > 0) {
+            kputs("x-amz-security-token: ", &token_hdr);
+            kputs(ad->token.s, &token_hdr);
+            *header++ = token_hdr.s;
+        }
+
+        *header = NULL;
+        fp = hopen(url.s, mode, "va_list", argsp, "httphdr:v", header_list,
+                   "httphdr_callback", v4_auth_header_callback,
+                   "httphdr_callback_data", ad,
+                   "redirect_callback", redirect_endpoint_callback,
+                   "redirect_callback_data", ad,
+                   "http_response_ptr", &http_response,
+                   "fail_on_error", 0,
+                   NULL);
+
+        if (fp == NULL) goto error;
+
+        if (http_response == 400) {
+            ad->refcount = 1;
+            if (handle_400_response(fp, ad) != 0) {
+                goto error;
+            }
+            hclose_abruptly(fp);
+            fp = hopen(url.s, mode, "va_list", argsp, "httphdr:v", header_list,
+                       "httphdr_callback", v4_auth_header_callback,
+                       "httphdr_callback_data", ad,
+                       "redirect_callback", redirect_endpoint_callback,
+                       "redirect_callback_data", ad,
+                       NULL);
+        } else if (http_response > 400) {
+            ad->refcount = 1;
+            errno = http_status_errno(http_response);
+            goto error;
+        }
+
+        if (fp == NULL) goto error;
+    } else {
+        kstring_t final_url = {0, 0, NULL};
+
+         // add the scheme marker
+        ksprintf(&final_url, "s3w+%s", url.s);
+
+        if(final_url.l == 0) goto error;
+
+        fp = hopen(final_url.s, mode, "va_list", argsp,
+                   "s3_auth_callback",  write_authorisation_callback,
+                   "s3_auth_callback_data", ad,
+                   "redirect_callback", redirect_endpoint_callback,
+                   "set_region_callback", set_region,
+                   NULL);
+        free(final_url.s);
+
+        if (fp == NULL) goto error;
+    }
+
+    free(url.s);
+    free(token_hdr.s);
+ 
+    return fp;
+
+  error:
+
+    if (fp) hclose_abruptly(fp);
+    free(url.s);
+    free(token_hdr.s);
+    free_auth_data(ad);
+
+    return NULL;
+}
+
+
 static hFILE *s3_open(const char *url, const char *mode)
 {
+    hFILE *fp;
+
     kstring_t mode_colon = { 0, 0, NULL };
     kputs(mode, &mode_colon);
     kputc(':', &mode_colon);
-    hFILE *fp = s3_rewrite(url, mode_colon.s, NULL);
+
+    if (getenv("HTS_S3_V2") == NULL) { // Force the v2 signature code
+        fp = s3_open_v4(url, mode_colon.s, NULL);
+    } else {
+        fp = s3_rewrite(url, mode_colon.s, NULL);
+    }
+
     free(mode_colon.s);
+
     return fp;
 }
 
 static hFILE *s3_vopen(const char *url, const char *mode_colon, va_list args0)
 {
+    hFILE *fp;
     // Need to use va_copy() as we can only take the address of an actual
     // va_list object, not that of a parameter whose type may have decayed.
     va_list args;
     va_copy(args, args0);
-    hFILE *fp = s3_rewrite(url, mode_colon, &args);
+
+    if (getenv("HTS_S3_V2") == NULL) { // Force the v2 signature code
+        fp = s3_open_v4(url, mode_colon, &args);
+    } else {
+        fp = s3_rewrite(url, mode_colon, &args);
+    }
+
     va_end(args);
     return fp;
 }

--- a/hfile_s3_write.c
+++ b/hfile_s3_write.c
@@ -1,0 +1,857 @@
+/*
+    hfile_s3_write.c - Code to handle mulitpart uploading to S3.
+
+    Copyright (C) 2019 Genome Research Ltd.
+
+    Author: Andrew Whitwham <aw7@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE
+
+
+S3 Multipart Upload
+-------------------
+
+There are several steps in the Mulitipart upload.
+
+
+1) Initiate Upload
+------------------
+
+Initiate the upload and get an upload ID.  This ID is used in all other steps.
+
+
+2) Upload Part
+--------------
+
+Upload a part of the data.  5Mb minimum part size (except for the last part).
+Each part is numbered and a succesful upload returns an Etag header value that
+needs to used for the completion step.
+
+Step repeated till all data is uploaded.
+
+
+3) Completion
+-------------
+
+Complete the upload by sending all the part numbers along with their associated
+Etag values.
+
+
+Optional - Abort
+----------------
+
+If something goes wrong this instructs the server to delete all the partial
+uploads and abandon the upload process.
+
+
+Andrew Whitwham, January 2019
+*/
+
+#include <config.h>
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef __MSYS__
+#include <strings.h>
+#endif
+#include <errno.h>
+#include <pthread.h>
+
+#include "hfile_internal.h"
+#ifdef ENABLE_PLUGINS
+#include "version.h"
+#endif
+#include "htslib/hts.h"
+#include "htslib/kstring.h"
+#include "htslib/khash.h"
+
+#include <curl/curl.h>
+
+#define MINIMUM_S3_WRITE_SIZE 5242880
+#define S3_MOVED_PERMANENTLY 301
+#define S3_BAD_REQUEST 400
+
+static struct {
+    kstring_t useragent;
+    CURLSH *share;
+    pthread_mutex_t share_lock;
+} curl = { { 0, 0, NULL }, NULL, PTHREAD_MUTEX_INITIALIZER };
+
+static void share_lock(CURL *handle, curl_lock_data data,
+                       curl_lock_access access, void *userptr) {
+    pthread_mutex_lock(&curl.share_lock);
+}
+
+static void share_unlock(CURL *handle, curl_lock_data data, void *userptr) {
+    pthread_mutex_unlock(&curl.share_lock);
+}
+
+typedef int (*s3_auth_callback) (void *auth_data, char *, kstring_t*, char*, kstring_t*, kstring_t*, kstring_t*, kstring_t*);
+
+typedef int (*set_region_callback) (void *auth_data, kstring_t *region);
+
+typedef struct {
+    s3_auth_callback callback;
+    redirect_callback redirect_callback;
+    set_region_callback set_region_callback;
+    void *callback_data;
+} s3_authorisation;
+
+typedef struct {
+    hFILE base;
+    CURL *curl;
+    CURLcode ret;
+    s3_authorisation *au;
+    kstring_t buffer;
+    kstring_t url;
+    kstring_t upload_id;
+    kstring_t completion_message;
+    int part_no;
+    int aborted;
+    size_t index;
+    long verbose;
+} hFILE_s3_write;
+
+
+static void ksinit(kstring_t *s) {
+    s->l = 0;
+    s->m = 0;
+    s->s = NULL;
+}
+
+
+static void ksfree(kstring_t *s) {
+    free(s->s);
+    ksinit(s);
+}
+
+
+static size_t response_callback(void *contents, size_t size, size_t nmemb, void *userp) {
+    size_t realsize = size * nmemb;
+    kstring_t *resp = (kstring_t *)userp;
+
+    if (kputsn((const char *)contents, realsize, resp) == EOF) {
+        return 0;
+    }
+
+    return realsize;
+}
+
+
+static int get_entry(char *in, char *start_tag, char *end_tag, kstring_t *out) {
+    char *start;
+    char *end;
+
+    if (!in) {
+        return EOF;
+    }
+
+    start = strstr(in, start_tag);
+
+    if (start) {
+        start += strlen(start_tag);
+        end = strstr(start, end_tag);
+    }
+
+    if (!start || !end) return EOF;
+
+    return kputsn(start, end - start, out);
+}
+
+
+static void cleanup_local(hFILE_s3_write *fp) {
+    ksfree(&fp->buffer);
+    ksfree(&fp->url);
+    ksfree(&fp->upload_id);
+    ksfree(&fp->completion_message);
+    curl_easy_cleanup(fp->curl);
+    free(fp->au);
+
+}
+
+
+static void cleanup(hFILE_s3_write *fp) {
+    // free up authorisation data
+    fp->au->callback(fp->au->callback_data,  NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    cleanup_local(fp);
+}
+
+
+struct curl_slist *set_html_headers(hFILE_s3_write *fp, kstring_t *auth, kstring_t *date, kstring_t *content, kstring_t *token) {
+    struct curl_slist *headers = NULL;
+
+    headers = curl_slist_append(headers, "Content-Type:"); // get rid of this
+    headers = curl_slist_append(headers, "Expect:");       // and this
+    headers = curl_slist_append(headers, auth->s);
+    headers = curl_slist_append(headers, date->s);
+    headers = curl_slist_append(headers, content->s);
+
+    if (token->l) {
+        headers = curl_slist_append(headers, token->s);
+    }
+
+    curl_easy_setopt(fp->curl, CURLOPT_HTTPHEADER, headers);
+
+    return headers;
+}
+
+
+/*
+    The partially uploaded file will hang around unless the delete command is sent.
+*/
+static int abort_upload(hFILE_s3_write *fp) {
+    kstring_t content_hash = {0, 0, NULL};
+    kstring_t authorisation = {0, 0, NULL};
+    kstring_t url = {0, 0, NULL};
+    kstring_t content = {0, 0, NULL};
+    kstring_t canonical_query_string = {0, 0, NULL};
+    kstring_t date = {0, 0, NULL};
+    kstring_t token = {0, 0, NULL};
+    int ret = -1;
+    struct curl_slist *headers = NULL;
+    char http_request[] = "DELETE";
+
+    if (ksprintf(&canonical_query_string, "uploadId=%s", fp->upload_id.s) < 0) {
+        goto out;
+    }
+
+    if (fp->au->callback(fp->au->callback_data,  http_request, NULL,
+                         canonical_query_string.s, &content_hash,
+                         &authorisation, &date, &token) != 0) {
+        goto out;
+    }
+
+    if (ksprintf(&url, "%s?%s", fp->url.s, canonical_query_string.s) < 0) {
+        goto out;
+    }
+
+    if (ksprintf(&content, "x-amz-content-sha256: %s", content_hash.s) < 0) {
+        goto out;
+    }
+
+    curl_easy_reset(fp->curl);
+    curl_easy_setopt(fp->curl, CURLOPT_CUSTOMREQUEST, http_request);
+    curl_easy_setopt(fp->curl, CURLOPT_USERAGENT, curl.useragent.s);
+    curl_easy_setopt(fp->curl, CURLOPT_URL, url.s);
+
+    curl_easy_setopt(fp->curl, CURLOPT_VERBOSE, fp->verbose);
+
+    headers = set_html_headers(fp, &authorisation, &date, &content, &token);
+    fp->ret = curl_easy_perform(fp->curl);
+
+    if (fp->ret == CURLE_OK) {
+        ret = 0;
+    }
+
+ out:
+    ksfree(&authorisation);
+    ksfree(&content);
+    ksfree(&content_hash);
+    ksfree(&url);
+    ksfree(&date);
+    ksfree(&canonical_query_string);
+    ksfree(&token);
+    curl_slist_free_all(headers);
+
+    fp->aborted = 1;
+    cleanup(fp);
+
+    return ret;
+}
+
+
+static int complete_upload(hFILE_s3_write *fp, kstring_t *resp) {
+    kstring_t content_hash = {0, 0, NULL};
+    kstring_t authorisation = {0, 0, NULL};
+    kstring_t url = {0, 0, NULL};
+    kstring_t content = {0, 0, NULL};
+    kstring_t canonical_query_string = {0, 0, NULL};
+    kstring_t date = {0, 0, NULL};
+    kstring_t token = {0, 0, NULL};
+    int ret = -1;
+    struct curl_slist *headers = NULL;
+    char http_request[] = "POST";
+
+    if (ksprintf(&canonical_query_string, "uploadId=%s", fp->upload_id.s) < 0) {
+        return -1;
+    }
+
+    // finish off the completion reply
+    if (kputs("</CompleteMultipartUpload>\n", &fp->completion_message) < 0) {
+        goto out;
+    }
+
+    if (fp->au->callback(fp->au->callback_data,  http_request,
+                         &fp->completion_message, canonical_query_string.s,
+                         &content_hash, &authorisation, &date, &token) != 0) {
+        goto out;
+    }
+
+    if (ksprintf(&url, "%s?%s", fp->url.s, canonical_query_string.s) < 0) {
+        goto out;
+    }
+
+    if (ksprintf(&content, "x-amz-content-sha256: %s", content_hash.s) < 0) {
+        goto out;
+    }
+
+    curl_easy_reset(fp->curl);
+    curl_easy_setopt(fp->curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(fp->curl, CURLOPT_POSTFIELDS, fp->completion_message.s);
+    curl_easy_setopt(fp->curl, CURLOPT_POSTFIELDSIZE, fp->completion_message.l);
+    curl_easy_setopt(fp->curl, CURLOPT_WRITEFUNCTION, response_callback);
+    curl_easy_setopt(fp->curl, CURLOPT_WRITEDATA, (void *)resp);
+    curl_easy_setopt(fp->curl, CURLOPT_URL, url.s);
+    curl_easy_setopt(fp->curl, CURLOPT_USERAGENT, curl.useragent.s);
+
+    curl_easy_setopt(fp->curl, CURLOPT_VERBOSE, fp->verbose);
+
+    headers = set_html_headers(fp, &authorisation, &date, &content, &token);
+    fp->ret = curl_easy_perform(fp->curl);
+
+    if (fp->ret == CURLE_OK) {
+        ret = 0;
+    }
+
+ out:
+    ksfree(&authorisation);
+    ksfree(&content);
+    ksfree(&content_hash);
+    ksfree(&url);
+    ksfree(&date);
+    ksfree(&token);
+    ksfree(&canonical_query_string);
+    curl_slist_free_all(headers);
+
+    return ret;
+}
+
+
+static size_t upload_callback(void *ptr, size_t size, size_t nmemb, void *stream) {
+    size_t realsize = size * nmemb;
+    hFILE_s3_write *fp = (hFILE_s3_write *)stream;
+    size_t read_length;
+
+    if (realsize > (fp->buffer.l - fp->index)) {
+        read_length = fp->buffer.l - fp->index;
+    } else {
+        read_length = realsize;
+    }
+
+    memcpy(ptr, fp->buffer.s + fp->index, read_length);
+    fp->index += read_length;
+
+    return read_length;
+}
+
+
+static int upload_part(hFILE_s3_write *fp, kstring_t *resp) {
+    kstring_t content_hash = {0, 0, NULL};
+    kstring_t authorisation = {0, 0, NULL};
+    kstring_t url = {0, 0, NULL};
+    kstring_t content = {0, 0, NULL};
+    kstring_t canonical_query_string = {0, 0, NULL};
+    kstring_t date = {0, 0, NULL};
+    kstring_t token = {0, 0, NULL};
+    int ret = -1;
+    struct curl_slist *headers = NULL;
+    char http_request[] = "PUT";
+
+    if (ksprintf(&canonical_query_string, "partNumber=%d&uploadId=%s", fp->part_no, fp->upload_id.s) < 0) {
+        return -1;
+    }
+
+    if (fp->au->callback(fp->au->callback_data, http_request, &fp->buffer,
+                         canonical_query_string.s, &content_hash,
+                         &authorisation, &date, &token) != 0) {
+        goto out;
+    }
+
+    if (ksprintf(&url, "%s?%s", fp->url.s, canonical_query_string.s) < 0) {
+        goto out;
+    }
+
+    fp->index = 0;
+    if (ksprintf(&content, "x-amz-content-sha256: %s", content_hash.s) < 0) {
+        goto out;
+    }
+
+    curl_easy_reset(fp->curl);
+
+    curl_easy_setopt(fp->curl, CURLOPT_UPLOAD, 1L);
+    curl_easy_setopt(fp->curl, CURLOPT_READFUNCTION, upload_callback);
+    curl_easy_setopt(fp->curl, CURLOPT_READDATA, fp);
+    curl_easy_setopt(fp->curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)fp->buffer.l);
+    curl_easy_setopt(fp->curl, CURLOPT_HEADERFUNCTION, response_callback);
+    curl_easy_setopt(fp->curl, CURLOPT_HEADERDATA, (void *)resp);
+    curl_easy_setopt(fp->curl, CURLOPT_URL, url.s);
+    curl_easy_setopt(fp->curl, CURLOPT_USERAGENT, curl.useragent.s);
+
+    curl_easy_setopt(fp->curl, CURLOPT_VERBOSE, fp->verbose);
+
+    headers = set_html_headers(fp, &authorisation, &date, &content, &token);
+    fp->ret = curl_easy_perform(fp->curl);
+
+    if (fp->ret == CURLE_OK) {
+        ret = 0;
+    }
+
+ out:
+    ksfree(&authorisation);
+    ksfree(&content);
+    ksfree(&content_hash);
+    ksfree(&url);
+    ksfree(&date);
+    ksfree(&token);
+    ksfree(&canonical_query_string);
+    curl_slist_free_all(headers);
+
+    return ret;
+}
+
+
+static ssize_t s3_write(hFILE *fpv, const void *bufferv, size_t nbytes) {
+    hFILE_s3_write *fp = (hFILE_s3_write *)fpv;
+    const char *buffer  = (const char *)bufferv;
+
+    if (kputsn(buffer, nbytes, &fp->buffer) == EOF) {
+        return -1;
+    }
+
+    if (fp->buffer.l > MINIMUM_S3_WRITE_SIZE) {
+        // time to write out our data
+        kstring_t response = {0, 0, NULL};
+        int ret;
+
+        ret = upload_part(fp, &response);
+
+        if (!ret) {
+            long response_code;
+            kstring_t etag = {0, 0, NULL};
+
+            curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
+
+            if (response_code > 200) {
+                ret = -1;
+            } else {
+                if (get_entry(response.s, "ETag: \"", "\"", &etag) == EOF) {
+                    ret = -1;
+                } else {
+                    ksprintf(&fp->completion_message, "\t<Part>\n\t\t<PartNumber>%d</PartNumber>\n\t\t<ETag>%s</ETag>\n\t</Part>\n",
+                        fp->part_no, etag.s);
+
+                    ksfree(&etag);
+                }
+            }
+        }
+
+        ksfree(&response);
+
+        if (ret) {
+            abort_upload(fp);
+            return -1;
+        }
+
+        fp->part_no++;
+        fp->buffer.l = 0;
+    }
+
+    return nbytes;
+}
+
+
+static int s3_close(hFILE *fpv) {
+    hFILE_s3_write *fp = (hFILE_s3_write *)fpv;
+    kstring_t response = {0, 0, NULL};
+    int ret = 0;
+
+    if (!fp->aborted) {
+
+        if (fp->buffer.l) {
+            // write the last part
+
+            ret = upload_part(fp, &response);
+
+            if (!ret) {
+                long response_code;
+                kstring_t etag = {0, 0, NULL};
+
+                curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
+
+                if (response_code > 200) {
+                    ret = -1;
+                } else {
+                    if (get_entry(response.s, "ETag: \"", "\"", &etag) == EOF) {
+                        ret = -1;
+                    } else {
+                        ksprintf(&fp->completion_message, "\t<Part>\n\t\t<PartNumber>%d</PartNumber>\n\t\t<ETag>%s</ETag>\n\t</Part>\n",
+                            fp->part_no, etag.s);
+
+                        ksfree(&etag);
+                    }
+                }
+            }
+
+            ksfree(&response);
+
+            if (ret) {
+                abort_upload(fp);
+                return -1;
+            }
+
+            fp->part_no++;
+        }
+
+        if (fp->part_no > 1) {
+            ret = complete_upload(fp, &response);
+
+            if (!ret) {
+                if (strstr(response.s, "CompleteMultipartUploadResult") == NULL) {
+                    ret = -1;
+                }
+            }
+        } else {
+            ret = -1;
+        }
+
+        if (ret) {
+            abort_upload(fp);
+        } else {
+            cleanup(fp);
+        }
+    }
+
+    ksfree(&response);
+
+    return ret;
+}
+
+
+static int redirect_endpoint(hFILE_s3_write *fp, kstring_t *head) {
+    int ret = -1;
+
+    if (fp->au->redirect_callback) {
+        ret = fp->au->redirect_callback(fp->au->callback_data, 301, head, &fp->url);
+    }
+
+    return ret;
+}
+
+static int handle_bad_request(hFILE_s3_write *fp, kstring_t *resp) {
+    kstring_t region = {0, 0, NULL};
+    int ret = -1;
+
+    if (fp->au->set_region_callback) {
+        if (get_entry(resp->s, "<Region>", "</Region>", &region) == EOF) {
+            return -1;
+        }
+
+        ret = fp->au->set_region_callback(fp->au->callback_data, &region);
+
+        ksfree(&region);
+    }
+
+    return ret;
+}
+
+static int initialise_upload(hFILE_s3_write *fp, kstring_t *head, kstring_t *resp) {
+    kstring_t content_hash = {0, 0, NULL};
+    kstring_t authorisation = {0, 0, NULL};
+    kstring_t url = {0, 0, NULL};
+    kstring_t content = {0, 0, NULL};
+    kstring_t date = {0, 0, NULL};
+    kstring_t token = {0, 0, NULL};
+    int ret = -1;
+    struct curl_slist *headers = NULL;
+    char http_request[] = "POST";
+
+    if (fp->au->callback(fp->au->callback_data,  http_request, NULL, "uploads=",
+                         &content_hash, &authorisation, &date, &token) != 0) {
+        goto out;
+    }
+
+    if (ksprintf(&url, "%s?uploads", fp->url.s) < 0) {
+        goto out;
+    }
+
+    if (ksprintf(&content, "x-amz-content-sha256: %s", content_hash.s) < 0) {
+        goto out;
+    }
+
+    curl_easy_setopt(fp->curl, CURLOPT_URL, url.s);
+    curl_easy_setopt(fp->curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(fp->curl, CURLOPT_POSTFIELDS, "");  // send no data
+    curl_easy_setopt(fp->curl, CURLOPT_WRITEFUNCTION, response_callback);
+    curl_easy_setopt(fp->curl, CURLOPT_WRITEDATA, (void *)resp);
+    curl_easy_setopt(fp->curl, CURLOPT_HEADERFUNCTION, response_callback);
+    curl_easy_setopt(fp->curl, CURLOPT_HEADERDATA, (void *)head);
+    curl_easy_setopt(fp->curl, CURLOPT_USERAGENT, curl.useragent.s);
+
+    curl_easy_setopt(fp->curl, CURLOPT_VERBOSE, fp->verbose);
+
+    headers = set_html_headers(fp, &authorisation, &date, &content, &token);
+    fp->ret = curl_easy_perform(fp->curl);
+
+    if (fp->ret == CURLE_OK) {
+        ret = 0;
+    }
+
+ out:
+    ksfree(&authorisation);
+    ksfree(&content);
+    ksfree(&content_hash);
+    ksfree(&url);
+    ksfree(&date);
+    ksfree(&token);
+    curl_slist_free_all(headers);
+
+    return ret;
+}
+
+
+static int get_upload_id(hFILE_s3_write *fp, kstring_t *resp) {
+    int ret = 0;
+
+    ksinit(&fp->upload_id);
+
+    if (get_entry(resp->s, "<UploadId>", "</UploadId>", &fp->upload_id) == EOF) {
+        ret = -1;
+    }
+
+    return ret;
+}
+
+
+static const struct hFILE_backend s3_write_backend = {
+    NULL, s3_write, NULL, NULL, s3_close
+};
+
+
+static hFILE *s3_write_open(const char *url, s3_authorisation *auth) {
+    hFILE_s3_write *fp;
+    kstring_t response = {0, 0, NULL};
+    kstring_t header   = {0, 0, NULL};
+    int ret;
+
+    if (!auth || !auth->callback || !auth->callback_data) {
+        return NULL;
+    }
+
+    fp = (hFILE_s3_write *)hfile_init(sizeof(hFILE_s3_write), "w", 0);
+
+    if (fp == NULL) {
+        return NULL;
+    }
+
+    if ((fp->curl = curl_easy_init()) == NULL) {
+        errno = ENOMEM;
+        goto error;
+    }
+
+    if ((fp->au = calloc(1, sizeof(s3_authorisation))) == NULL) {
+        goto error;
+    }
+
+    memcpy(fp->au, auth, sizeof(s3_authorisation));
+
+    ksinit(&fp->buffer);
+    ksinit(&fp->url);
+    ksinit(&fp->completion_message);
+    fp->aborted = 0;
+
+    if (hts_verbose >= 8) {
+        fp->verbose = 1L;
+    } else {
+        fp->verbose = 0L;
+    }
+
+    kputs(url + 4, &fp->url);
+
+    ret = initialise_upload(fp, &header, &response);
+
+    if (ret == 0) {
+        long response_code;
+
+        curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
+
+        if (response_code == S3_MOVED_PERMANENTLY) {
+            if (redirect_endpoint(fp, &header) == 0) {
+                ksfree(&response);
+                ksfree(&header);
+
+                ret = initialise_upload(fp, &header, &response);
+            }
+        } else if (response_code == S3_BAD_REQUEST) {
+            if (handle_bad_request(fp, &response) == 0) {
+                ksfree(&response);
+                ksfree(&header);
+
+                ret = initialise_upload(fp, &header, &response);
+            }
+        }
+
+        ksfree(&header); // no longer needed
+    }
+
+    if (ret) goto error;
+
+    if (get_upload_id(fp, &response)) goto error;
+
+    // start the completion message (a formatted list of parts)
+    ksinit(&fp->completion_message);
+
+    if (kputs("<CompleteMultipartUpload>\n", &fp->completion_message) == EOF) {
+        goto error;
+    }
+
+    fp->part_no = 1;
+
+    fp->base.backend = &s3_write_backend;
+    ksfree(&response);
+
+    return &fp->base;
+
+error:
+    ksfree(&response);
+    cleanup_local(fp);
+    hfile_destroy((hFILE *)fp);
+    return NULL;
+}
+
+
+static hFILE *hopen_s3_write(const char *url, const char *mode) {
+    if (hts_verbose >= 1) {
+        fprintf(stderr, "[E::%s] s3w:// URLs should not be used directly; use s3:// instead.\n", __func__);
+    }
+    return NULL;
+}
+
+
+static int parse_va_list(s3_authorisation *auth, va_list args) {
+    const char *argtype;
+
+    while  ((argtype = va_arg(args, const char *)) != NULL) {
+        if (strcmp(argtype, "s3_auth_callback") == 0) {
+            auth->callback = va_arg(args, s3_auth_callback);
+        } else if (strcmp(argtype, "s3_auth_callback_data") == 0) {
+            auth->callback_data = va_arg(args, void *);
+        } else if (strcmp(argtype, "redirect_callback") == 0) {
+            auth->redirect_callback = va_arg(args, redirect_callback);
+        } else if (strcmp(argtype, "set_region_callback") == 0) {
+            auth->set_region_callback = va_arg(args, set_region_callback);
+        } else if (strcmp(argtype, "va_list") == 0) {
+            va_list *args2 = va_arg(args, va_list *);
+
+            if (args2) {
+                if (parse_va_list(auth, *args2) < 0) return -1;
+            }
+        } else {
+            errno = EINVAL;
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+
+static hFILE *vhopen_s3_write(const char *url, const char *mode, va_list args) {
+    hFILE *fp = NULL;
+    s3_authorisation auth = {NULL, NULL, NULL};
+
+    if (parse_va_list(&auth, args) == 0) {
+        fp =  s3_write_open(url, &auth);
+    }
+
+    return fp;
+}
+
+
+static void s3_write_exit() {
+    if (curl_share_cleanup(curl.share) == CURLSHE_OK)
+        curl.share = NULL;
+
+    free(curl.useragent.s);
+    curl.useragent.l = curl.useragent.m = 0; curl.useragent.s = NULL;
+    curl_global_cleanup();
+}
+
+
+int PLUGIN_GLOBAL(hfile_plugin_init,_s3_write)(struct hFILE_plugin *self) {
+
+    static const struct hFILE_scheme_handler handler =
+        { hopen_s3_write, hfile_always_remote, "S3 Multipart Upload",
+          2000 + 50, vhopen_s3_write
+        };
+
+#ifdef ENABLE_PLUGINS
+    // Embed version string for examination via strings(1) or what(1)
+    static const char id[] = "@(#)hfile_s3_write plugin (htslib)\t" HTS_VERSION;
+    const char *version = strchr(id, '\t') + 1;
+
+    if (hts_verbose >= 9)
+        fprintf(stderr, "[M::hfile_s3_write.init] version %s\n",
+                version);
+#else
+    const char *version = hts_version();
+#endif
+
+    const curl_version_info_data *info;
+    CURLcode err;
+    CURLSHcode errsh;
+
+    err = curl_global_init(CURL_GLOBAL_ALL);
+
+    if (err != CURLE_OK) {
+        // look at putting in an errno here
+        return -1;
+    }
+
+    curl.share = curl_share_init();
+
+    if (curl.share == NULL) {
+        curl_global_cleanup();
+        errno = EIO;
+        return -1;
+    }
+
+    errsh  = curl_share_setopt(curl.share, CURLSHOPT_LOCKFUNC, share_lock);
+    errsh |= curl_share_setopt(curl.share, CURLSHOPT_UNLOCKFUNC, share_unlock);
+    errsh |= curl_share_setopt(curl.share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
+
+    if (errsh != 0) {
+        curl_share_cleanup(curl.share);
+        curl_global_cleanup();
+        errno = EIO;
+        return -1;
+    }
+
+    info = curl_version_info(CURLVERSION_NOW);
+    ksprintf(&curl.useragent, "htslib/%s libcurl/%s", version, info->version);
+
+    self->name = "S3 Multipart Upload";
+    self->destroy = s3_write_exit;
+
+    hfile_add_scheme_handler("s3w",       &handler);
+    hfile_add_scheme_handler("s3w+http",  &handler);
+    hfile_add_scheme_handler("s3w+https", &handler);
+
+    return 0;
+}


### PR DESCRIPTION
This change will default to using version 4 signatures over the current version 2 ones.  It will also allow the writing of files to S3 repositories. Fixes #776, #764, #492, #477 and #454.

Documentation of new and old environmental variables and of general s3 htslib usage will be done in a separate pull request.