### PR TITLE
Fixes #842, Support vcf hrec deletion and re-add

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -887,6 +887,7 @@ void bcf_hdr_remove(bcf_hdr_t *hdr, int type, const char *key)
             vdict_t *d = type==BCF_HL_CTG ? (vdict_t*)hdr->dict[BCF_DT_CTG] : (vdict_t*)hdr->dict[BCF_DT_ID];
             khint_t k = kh_get(vdict, d, key);
             kh_val(d, k).hrec[type==BCF_HL_CTG?0:type] = NULL;
+            kh_del(vdict, d, k);
         }
         else
         {

--- a/vcf.c
+++ b/vcf.c
@@ -888,6 +888,7 @@ void bcf_hdr_remove(bcf_hdr_t *hdr, int type, const char *key)
             khint_t k = kh_get(vdict, d, key);
             kh_val(d, k).hrec[type==BCF_HL_CTG?0:type] = NULL;
             kh_del(vdict, d, k);
+            free((char*) kh_key(d,k));
         }
         else
         {


### PR DESCRIPTION
Simple fix -- delete the key representing the deleted hrec from the dictionary.