### PR TITLE
Allow removed vcf headers to be replaced.

### DIFF
--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -36,49 +36,56 @@ void error(const char *format, ...)
     va_start(ap, format);
     vfprintf(stderr, format, ap);
     va_end(ap);
+    if (strrchr(format, '\n') == NULL) fputc('\n', stderr);
     exit(-1);
 }
+
+#define STRINGIFY(x) #x
+#define check0(x) ((x) == 0 ? (void) 0 : error("Failed: %s", STRINGIFY(x)))
 
 void write_bcf(char *fname)
 {
     // Init
     htsFile *fp    = hts_open(fname,"wb");
+    if (!fp) error("Failed to open \"%s\" : %s", fname, strerror(errno));
     bcf_hdr_t *hdr = bcf_hdr_init("w");
+    if (!hdr) error("bcf_hdr_init : %s", strerror(errno));
     bcf1_t *rec    = bcf_init1();
+    if (!rec) error("bcf_init1 : %s", strerror(errno));
 
     // Create VCF header
     kstring_t str = {0,0,0};
-    bcf_hdr_append(hdr, "##fileDate=20090805");
-    bcf_hdr_append(hdr, "##FORMAT=<ID=UF,Number=1,Type=Integer,Description=\"Unused FORMAT\">");
-    bcf_hdr_append(hdr, "##INFO=<ID=UI,Number=1,Type=Integer,Description=\"Unused INFO\">");
-    bcf_hdr_append(hdr, "##FILTER=<ID=Flt,Description=\"Unused FILTER\">");
-    bcf_hdr_append(hdr, "##unused=<XX=AA,Description=\"Unused generic\">");
-    bcf_hdr_append(hdr, "##unused=unformatted text 1");
-    bcf_hdr_append(hdr, "##unused=unformatted text 2");
-    bcf_hdr_append(hdr, "##contig=<ID=Unused,length=62435964>");
-    bcf_hdr_append(hdr, "##source=myImputationProgramV3.1");
-    bcf_hdr_append(hdr, "##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta");
-    bcf_hdr_append(hdr, "##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species=\"Homo sapiens\",taxonomy=x>");
-    bcf_hdr_append(hdr, "##phasing=partial");
-    bcf_hdr_append(hdr, "##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of Samples With Data\">");
-    bcf_hdr_append(hdr, "##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">");
-    bcf_hdr_append(hdr, "##INFO=<ID=NEG,Number=.,Type=Integer,Description=\"Test Negative Numbers\">");
-    bcf_hdr_append(hdr, "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele Frequency\">");
-    bcf_hdr_append(hdr, "##INFO=<ID=AA,Number=1,Type=String,Description=\"Ancestral Allele\">");
-    bcf_hdr_append(hdr, "##INFO=<ID=DB,Number=0,Type=Flag,Description=\"dbSNP membership, build 129\">");
-    bcf_hdr_append(hdr, "##INFO=<ID=H2,Number=0,Type=Flag,Description=\"HapMap2 membership\">");
-    bcf_hdr_append(hdr, "##FILTER=<ID=q10,Description=\"Quality below 10\">");
-    bcf_hdr_append(hdr, "##FILTER=<ID=s50,Description=\"Less than 50% of samples have data\">");
-    bcf_hdr_append(hdr, "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
-    bcf_hdr_append(hdr, "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Genotype Quality\">");
-    bcf_hdr_append(hdr, "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Read Depth\">");
-    bcf_hdr_append(hdr, "##FORMAT=<ID=HQ,Number=2,Type=Integer,Description=\"Haplotype Quality\">");
-    bcf_hdr_append(hdr, "##FORMAT=<ID=TS,Number=1,Type=String,Description=\"Test String\">");
+    check0(bcf_hdr_append(hdr, "##fileDate=20090805"));
+    check0(bcf_hdr_append(hdr, "##FORMAT=<ID=UF,Number=1,Type=Integer,Description=\"Unused FORMAT\">"));
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=UI,Number=1,Type=Integer,Description=\"Unused INFO\">"));
+    check0(bcf_hdr_append(hdr, "##FILTER=<ID=Flt,Description=\"Unused FILTER\">"));
+    check0(bcf_hdr_append(hdr, "##unused=<XX=AA,Description=\"Unused generic\">"));
+    check0(bcf_hdr_append(hdr, "##unused=unformatted text 1"));
+    check0(bcf_hdr_append(hdr, "##unused=unformatted text 2"));
+    check0(bcf_hdr_append(hdr, "##contig=<ID=Unused,length=62435964>"));
+    check0(bcf_hdr_append(hdr, "##source=myImputationProgramV3.1"));
+    check0(bcf_hdr_append(hdr, "##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta"));
+    check0(bcf_hdr_append(hdr, "##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species=\"Homo sapiens\",taxonomy=x>"));
+    check0(bcf_hdr_append(hdr, "##phasing=partial"));
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of Samples With Data\">"));
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">"));
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=NEG,Number=.,Type=Integer,Description=\"Test Negative Numbers\">"));
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele Frequency\">"));
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=AA,Number=1,Type=String,Description=\"Ancestral Allele\">"));
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=DB,Number=0,Type=Flag,Description=\"dbSNP membership, build 129\">"));
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=H2,Number=0,Type=Flag,Description=\"HapMap2 membership\">"));
+    check0(bcf_hdr_append(hdr, "##FILTER=<ID=q10,Description=\"Quality below 10\">"));
+    check0(bcf_hdr_append(hdr, "##FILTER=<ID=s50,Description=\"Less than 50% of samples have data\">"));
+    check0(bcf_hdr_append(hdr, "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"));
+    check0(bcf_hdr_append(hdr, "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Genotype Quality\">"));
+    check0(bcf_hdr_append(hdr, "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Read Depth\">"));
+    check0(bcf_hdr_append(hdr, "##FORMAT=<ID=HQ,Number=2,Type=Integer,Description=\"Haplotype Quality\">"));
+    check0(bcf_hdr_append(hdr, "##FORMAT=<ID=TS,Number=1,Type=String,Description=\"Test String\">"));
 
-    bcf_hdr_add_sample(hdr, "NA00001");
-    bcf_hdr_add_sample(hdr, "NA00002");
-    bcf_hdr_add_sample(hdr, "NA00003");
-    bcf_hdr_add_sample(hdr, NULL);      // to update internal structures
+    check0(bcf_hdr_add_sample(hdr, "NA00001"));
+    check0(bcf_hdr_add_sample(hdr, "NA00002"));
+    check0(bcf_hdr_add_sample(hdr, "NA00003"));
+    check0(bcf_hdr_add_sample(hdr, NULL));      // to update internal structures
     if ( bcf_hdr_write(fp, hdr)!=0 ) error("Failed to write to %s\n", fname);
 
 
@@ -89,25 +96,25 @@ void write_bcf(char *fname)
     // .. POS
     rec->pos = 14369;
     // .. ID
-    bcf_update_id(hdr, rec, "rs6054257");
+    check0(bcf_update_id(hdr, rec, "rs6054257"));
     // .. REF and ALT
-    bcf_update_alleles_str(hdr, rec, "G,A");
+    check0(bcf_update_alleles_str(hdr, rec, "G,A"));
     // .. QUAL
     rec->qual = 29;
     // .. FILTER
     int32_t tmpi = bcf_hdr_id2int(hdr, BCF_DT_ID, "PASS");
-    bcf_update_filter(hdr, rec, &tmpi, 1);
+    check0(bcf_update_filter(hdr, rec, &tmpi, 1));
     // .. INFO
     tmpi = 3;
-    bcf_update_info_int32(hdr, rec, "NS", &tmpi, 1);
+    check0(bcf_update_info_int32(hdr, rec, "NS", &tmpi, 1));
     tmpi = 14;
-    bcf_update_info_int32(hdr, rec, "DP", &tmpi, 1);
+    check0(bcf_update_info_int32(hdr, rec, "DP", &tmpi, 1));
     tmpi = -127;
-    bcf_update_info_int32(hdr, rec, "NEG", &tmpi, 1);
+    check0(bcf_update_info_int32(hdr, rec, "NEG", &tmpi, 1));
     float tmpf = 0.5;
-    bcf_update_info_float(hdr, rec, "AF", &tmpf, 1);
-    bcf_update_info_flag(hdr, rec, "DB", NULL, 1);
-    bcf_update_info_flag(hdr, rec, "H2", NULL, 1);
+    check0(bcf_update_info_float(hdr, rec, "AF", &tmpf, 1));
+    check0(bcf_update_info_flag(hdr, rec, "DB", NULL, 1));
+    check0(bcf_update_info_flag(hdr, rec, "H2", NULL, 1));
     // .. FORMAT
     int32_t *tmpia = (int*)malloc(bcf_hdr_nsamples(hdr)*2*sizeof(int));
     tmpia[0] = bcf_gt_phased(0);
@@ -116,51 +123,51 @@ void write_bcf(char *fname)
     tmpia[3] = bcf_gt_phased(0);
     tmpia[4] = bcf_gt_unphased(1);
     tmpia[5] = bcf_gt_unphased(1);
-    bcf_update_genotypes(hdr, rec, tmpia, bcf_hdr_nsamples(hdr)*2);
+    check0(bcf_update_genotypes(hdr, rec, tmpia, bcf_hdr_nsamples(hdr)*2));
     tmpia[0] = 48;
     tmpia[1] = 48;
     tmpia[2] = 43;
-    bcf_update_format_int32(hdr, rec, "GQ", tmpia, bcf_hdr_nsamples(hdr));
+    check0(bcf_update_format_int32(hdr, rec, "GQ", tmpia, bcf_hdr_nsamples(hdr)));
     tmpia[0] = 1;
     tmpia[1] = 8;
     tmpia[2] = 5;
-    bcf_update_format_int32(hdr, rec, "DP", tmpia, bcf_hdr_nsamples(hdr));
+    check0(bcf_update_format_int32(hdr, rec, "DP", tmpia, bcf_hdr_nsamples(hdr)));
     tmpia[0] = 51;
     tmpia[1] = 51;
     tmpia[2] = 51;
     tmpia[3] = 51;
     tmpia[4] = bcf_int32_missing;
     tmpia[5] = bcf_int32_missing;
-    bcf_update_format_int32(hdr, rec, "HQ", tmpia, bcf_hdr_nsamples(hdr)*2);
+    check0(bcf_update_format_int32(hdr, rec, "HQ", tmpia, bcf_hdr_nsamples(hdr)*2));
     char *tmp_str[] = {"String1","SomeOtherString2","YetAnotherString3"};
-    bcf_update_format_string(hdr, rec, "TS", (const char**)tmp_str, 3);
+    check0(bcf_update_format_string(hdr, rec, "TS", (const char**)tmp_str, 3));
     if ( bcf_write1(fp, hdr, rec)!=0 ) error("Failed to write to %s\n", fname);
 
     // 20     1110696 . A      G,T     67   .   NS=2;DP=10;NEG=-128;AF=0.333,.;AA=T;DB GT 2 1   ./.
     bcf_clear1(rec);
     rec->rid = bcf_hdr_name2id(hdr, "20");
     rec->pos = 1110695;
-    bcf_update_alleles_str(hdr, rec, "A,G,T");
+    check0(bcf_update_alleles_str(hdr, rec, "A,G,T"));
     rec->qual = 67;
     tmpi = 2;
-    bcf_update_info_int32(hdr, rec, "NS", &tmpi, 1);
+    check0(bcf_update_info_int32(hdr, rec, "NS", &tmpi, 1));
     tmpi = 10;
-    bcf_update_info_int32(hdr, rec, "DP", &tmpi, 1);
+    check0(bcf_update_info_int32(hdr, rec, "DP", &tmpi, 1));
     tmpi = -128;
-    bcf_update_info_int32(hdr, rec, "NEG", &tmpi, 1);
+    check0(bcf_update_info_int32(hdr, rec, "NEG", &tmpi, 1));
     float *tmpfa = (float*)malloc(2*sizeof(float));
     tmpfa[0] = 0.333;
     bcf_float_set_missing(tmpfa[1]);
-    bcf_update_info_float(hdr, rec, "AF", tmpfa, 2);
-    bcf_update_info_string(hdr, rec, "AA", "T");
-    bcf_update_info_flag(hdr, rec, "DB", NULL, 1);
+    check0(bcf_update_info_float(hdr, rec, "AF", tmpfa, 2));
+    check0(bcf_update_info_string(hdr, rec, "AA", "T"));
+    check0(bcf_update_info_flag(hdr, rec, "DB", NULL, 1));
     tmpia[0] = bcf_gt_phased(2);
     tmpia[1] = bcf_int32_vector_end;
     tmpia[2] = bcf_gt_phased(1);
     tmpia[3] = bcf_int32_vector_end;
     tmpia[4] = bcf_gt_missing;
     tmpia[5] = bcf_gt_missing;
-    bcf_update_genotypes(hdr, rec, tmpia, bcf_hdr_nsamples(hdr)*2);
+    check0(bcf_update_genotypes(hdr, rec, tmpia, bcf_hdr_nsamples(hdr)*2));
     if ( bcf_write1(fp, hdr, rec)!=0 ) error("Failed to write to %s\n", fname);
 
     free(tmpia);
@@ -181,12 +188,17 @@ void write_bcf(char *fname)
 void bcf_to_vcf(char *fname)
 {
     htsFile *fp    = hts_open(fname,"rb");
+    if (!fp) error("Failed to open \"%s\" : %s", fname, strerror(errno));
     bcf_hdr_t *hdr = bcf_hdr_read(fp);
+    if (!hdr) error("bcf_hdr_read : %s", strerror(errno));
     bcf1_t *rec    = bcf_init1();
+    if (!rec) error("bcf_init1 : %s", strerror(errno));
 
     char *gz_fname = (char*) malloc(strlen(fname)+4);
+    if (!gz_fname) error("malloc : %s", strerror(errno));
     snprintf(gz_fname,strlen(fname)+4,"%s.gz",fname);
     htsFile *out   = hts_open(gz_fname,"wg");
+    if (!out) error("Couldn't open \"%s\" : %s\n", gz_fname, strerror(errno));
 
     bcf_hdr_t *hdr_out = bcf_hdr_dup(hdr);
     bcf_hdr_remove(hdr_out,BCF_HL_STR,"unused");
@@ -196,30 +208,31 @@ void bcf_to_vcf(char *fname)
     bcf_hdr_remove(hdr_out,BCF_HL_FMT,"UF");
     bcf_hdr_remove(hdr_out,BCF_HL_CTG,"Unused");
     if ( bcf_hdr_write(out, hdr_out)!=0 ) error("Failed to write to %s\n", fname);
-
-    while ( bcf_read1(fp, hdr, rec)>=0 )
+    int r;
+    while ((r = bcf_read1(fp, hdr, rec)) >= 0)
     {
         if ( bcf_write1(out, hdr_out, rec)!=0 ) error("Failed to write to %s\n", fname);
 
         // Test problems caused by bcf1_sync: the data block
         // may be realloced, also the unpacked structures must
         // get updated.
-        bcf_unpack(rec, BCF_UN_STR);
-        bcf_update_id(hdr, rec, 0);
-        bcf_update_format_int32(hdr, rec, "GQ", NULL, 0);
+        check0(bcf_unpack(rec, BCF_UN_STR));
+        check0(bcf_update_id(hdr, rec, 0));
+        check0(bcf_update_format_int32(hdr, rec, "GQ", NULL, 0));
 
         bcf1_t *dup = bcf_dup(rec);     // force bcf1_sync call
         if ( bcf_write1(out, hdr_out, dup)!=0 ) error("Failed to write to %s\n", fname);
         bcf_destroy1(dup);
 
-        bcf_update_alleles_str(hdr_out, rec, "G,A");
+        check0(bcf_update_alleles_str(hdr_out, rec, "G,A"));
         int32_t tmpi = 99;
-        bcf_update_info_int32(hdr_out, rec, "DP", &tmpi, 1);
+        check0(bcf_update_info_int32(hdr_out, rec, "DP", &tmpi, 1));
         int32_t tmpia[] = {9,9,9};
-        bcf_update_format_int32(hdr_out, rec, "DP", tmpia, 3);
+        check0(bcf_update_format_int32(hdr_out, rec, "DP", tmpia, 3));
 
         if ( bcf_write1(out, hdr_out, rec)!=0 ) error("Failed to write to %s\n", fname);
     }
+    if (r < -1) error("bcf_read1");
 
     bcf_destroy1(rec);
     bcf_hdr_destroy(hdr);
@@ -264,7 +277,9 @@ void bcf_to_vcf(char *fname)
 void iterator(const char *fname)
 {
     htsFile *fp = hts_open(fname, "r");
+    if (!fp) error("Failed to open \"%s\" : %s", fname, strerror(errno));
     bcf_hdr_t *hdr = bcf_hdr_read(fp);
+    if (!hdr) error("bcf_hdr_read : %s", strerror(errno));
     hts_idx_t *idx;
     hts_itr_t *iter;
 
@@ -290,10 +305,13 @@ void iterator(const char *fname)
 void test_get_info_values(const char *fname)
 {
     htsFile *fp = hts_open(fname, "r");
+    if (!fp) error("Failed to open \"%s\" : %s", fname, strerror(errno));
     bcf_hdr_t *hdr = bcf_hdr_read(fp);
+    if (!hdr) error("bcf_hdr_read : %s", strerror(errno));
     bcf1_t *line = bcf_init();
-
-    while (bcf_read(fp, hdr, line) == 0)
+    if (!line) error("bcf_init : %s", strerror(errno));
+    int r;
+    while ((r = bcf_read(fp, hdr, line)) == 0)
     {
         float *afs = 0;
         int32_t *negs = NULL;
@@ -334,6 +352,7 @@ void test_get_info_values(const char *fname)
         }
         free(negs);
     }
+    if (r < -1) error("bcf_read");
 
     bcf_destroy(line);
     bcf_hdr_destroy(hdr);
@@ -344,14 +363,17 @@ void write_format_values(const char *fname)
 {
     // Init
     htsFile *fp = hts_open(fname, "wb");
+    if (!fp) error("Failed to open \"%s\" : %s", fname, strerror(errno));
     bcf_hdr_t *hdr = bcf_hdr_init("w");
+    if (!hdr) error("bcf_hdr_init : %s", strerror(errno));
     bcf1_t *rec = bcf_init1();
+    if (!rec) error("bcf_init1 : %s", strerror(errno));
 
     // Create VCF header
-    bcf_hdr_append(hdr, "##contig=<ID=1>");
-    bcf_hdr_append(hdr, "##FORMAT=<ID=TF,Number=1,Type=Float,Description=\"Test Float\">");
-    bcf_hdr_add_sample(hdr, "S");
-    bcf_hdr_add_sample(hdr, NULL); // to update internal structures
+    check0(bcf_hdr_append(hdr, "##contig=<ID=1>"));
+    check0(bcf_hdr_append(hdr, "##FORMAT=<ID=TF,Number=1,Type=Float,Description=\"Test Float\">"));
+    check0(bcf_hdr_add_sample(hdr, "S"));
+    check0(bcf_hdr_add_sample(hdr, NULL)); // to update internal structures
     if ( bcf_hdr_write(fp, hdr)!=0 ) error("Failed to write to %s\n", fname);
 
     // Add a record
@@ -361,7 +383,7 @@ void write_format_values(const char *fname)
     test[1] = 47.11f;
     bcf_float_set_vector_end(test[2]);
     test[3] = -1.2e-13;
-    bcf_update_format_float(hdr, rec, "TF", test, 4);
+    check0(bcf_update_format_float(hdr, rec, "TF", test, 4));
     if ( bcf_write1(fp, hdr, rec)!=0 ) error("Failed to write to %s\n", fname);
 
     bcf_destroy1(rec);

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -62,25 +62,35 @@ void write_bcf(char *fname)
     check0(bcf_hdr_append(hdr, "##unused=<XX=AA,Description=\"Unused generic\">"));
     check0(bcf_hdr_append(hdr, "##unused=unformatted text 1"));
     check0(bcf_hdr_append(hdr, "##unused=unformatted text 2"));
-    check0(bcf_hdr_append(hdr, "##contig=<ID=Unused,length=62435964>"));
+    check0(bcf_hdr_append(hdr, "##contig=<ID=Unused,length=1>"));
     check0(bcf_hdr_append(hdr, "##source=myImputationProgramV3.1"));
     check0(bcf_hdr_append(hdr, "##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta"));
     check0(bcf_hdr_append(hdr, "##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species=\"Homo sapiens\",taxonomy=x>"));
     check0(bcf_hdr_append(hdr, "##phasing=partial"));
     check0(bcf_hdr_append(hdr, "##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of Samples With Data\">"));
     check0(bcf_hdr_append(hdr, "##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Total Depth\">"));
-    check0(bcf_hdr_append(hdr, "##INFO=<ID=NEG,Number=.,Type=Integer,Description=\"Test Negative Numbers\">"));
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=NEG,Number=.,Type=Integer,Description=\"Test -ve Numbers\">"));
     check0(bcf_hdr_append(hdr, "##INFO=<ID=AF,Number=A,Type=Float,Description=\"Allele Frequency\">"));
     check0(bcf_hdr_append(hdr, "##INFO=<ID=AA,Number=1,Type=String,Description=\"Ancestral Allele\">"));
     check0(bcf_hdr_append(hdr, "##INFO=<ID=DB,Number=0,Type=Flag,Description=\"dbSNP membership, build 129\">"));
     check0(bcf_hdr_append(hdr, "##INFO=<ID=H2,Number=0,Type=Flag,Description=\"HapMap2 membership\">"));
     check0(bcf_hdr_append(hdr, "##FILTER=<ID=q10,Description=\"Quality below 10\">"));
-    check0(bcf_hdr_append(hdr, "##FILTER=<ID=s50,Description=\"Less than 50% of samples have data\">"));
+    check0(bcf_hdr_append(hdr, "##FILTER=<ID=s50,Description=\"Less than half of samples have data\">"));
     check0(bcf_hdr_append(hdr, "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">"));
     check0(bcf_hdr_append(hdr, "##FORMAT=<ID=GQ,Number=1,Type=Integer,Description=\"Genotype Quality\">"));
     check0(bcf_hdr_append(hdr, "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Read Depth\">"));
     check0(bcf_hdr_append(hdr, "##FORMAT=<ID=HQ,Number=2,Type=Integer,Description=\"Haplotype Quality\">"));
+    check0(bcf_hdr_append(hdr, "##FORMAT=<ID=TS,Number=1,Type=String,Description=\"Test String 1\">"));
+
+    // Try a few header modifications
+    bcf_hdr_remove(hdr, BCF_HL_CTG, "Unused");
+    check0(bcf_hdr_append(hdr, "##contig=<ID=Unused,length=62435964>"));
+    bcf_hdr_remove(hdr, BCF_HL_FMT, "TS");
     check0(bcf_hdr_append(hdr, "##FORMAT=<ID=TS,Number=1,Type=String,Description=\"Test String\">"));
+    bcf_hdr_remove(hdr, BCF_HL_INFO, "NEG");
+    check0(bcf_hdr_append(hdr, "##INFO=<ID=NEG,Number=.,Type=Integer,Description=\"Test Negative Numbers\">"));
+    bcf_hdr_remove(hdr, BCF_HL_FLT, "s50");
+    check0(bcf_hdr_append(hdr, "##FILTER=<ID=s50,Description=\"Less than 50% of samples have data\">"));
 
     check0(bcf_hdr_add_sample(hdr, "NA00001"));
     check0(bcf_hdr_add_sample(hdr, "NA00002"));

--- a/test/test-vcf-api.out
+++ b/test/test-vcf-api.out
@@ -8,18 +8,18 @@
 ##phasing=partial
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
 ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
-##INFO=<ID=NEG,Number=.,Type=Integer,Description="Test Negative Numbers">
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
 ##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
 ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
 ##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
 ##FILTER=<ID=q10,Description="Quality below 10">
-##FILTER=<ID=s50,Description="Less than 50% of samples have data">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
 ##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
 ##FORMAT=<ID=TS,Number=1,Type=String,Description="Test String">
+##INFO=<ID=NEG,Number=.,Type=Integer,Description="Test Negative Numbers">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
 20	14370	rs6054257	G	A	29	PASS	NS=3;DP=14;NEG=-127;AF=0.5;DB;H2	GT:GQ:DP:HQ:TS	0|0:48:1:51,51:String1	1|0:48:8:51,51:SomeOtherString2	1/1:43:5:.,.:YetAnotherString3
 20	14370	.	G	A	29	PASS	NS=3;DP=14;NEG=-127;AF=0.5;DB;H2	GT:DP:HQ:TS	0|0:1:51,51:String1	1|0:8:51,51:SomeOtherString2	1/1:5:.,.:YetAnotherString3


### PR DESCRIPTION
Fixes #842 and an alternative to #843.