### PR TITLE
Allow making KSORT functions static

### DIFF
--- a/errmod.c
+++ b/errmod.c
@@ -30,7 +30,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/ksort.h"
 #include "htslib/hts_os.h" // for drand48
 
-KSORT_INIT_GENERIC(uint16_t)
+KSORT_INIT_STATIC_GENERIC(uint16_t)
 
 struct errmod_t {
     double depcorr;

--- a/hts.c
+++ b/hts.c
@@ -1282,8 +1282,8 @@ int hts_check_EOF(htsFile *fp)
 
 #define pair64_lt(a,b) ((a).u < (b).u)
 
-KSORT_INIT(_off, hts_pair64_t, pair64_lt)
-KSORT_INIT(_off_max, hts_pair64_max_t, pair64_lt)
+KSORT_INIT_STATIC(_off, hts_pair64_t, pair64_lt)
+KSORT_INIT_STATIC(_off_max, hts_pair64_max_t, pair64_lt)
 
 typedef struct {
     int32_t m, n;


### PR DESCRIPTION
Consider the following program:

```c
#include "htslib/ksort.h"
#include "htslib/hts.h"

/* Compile and link with
        gcc -o foo foo.c libhts.a -lbz2 -llzma -lz
*/

typedef struct {
    int x;
} foo;

#define bar(a,b) ((a).x < (b).x)

KSORT_INIT_GENERIC(uint16_t)
KSORT_INIT(_off, foo, bar)
KSORT_INIT(_off_max, foo, bar)

int main() {
    hts_version();  // pull in hts.o
    errmod_cal(NULL, 0, 0, NULL, NULL);  // pull in errmod.o
}
```

This fails to link due to 24 duplicate `ks_*` functions, as the ksort usage in _errmod.c_ and _hts.c_ uses non-`hts_`-prefixed public namespace functions. It would be possible to make those HTSlib source files use ksort functions with names like `…_htslib_internal_…` which would not collide with sensible third-party code, but it's about as easy to add `static` support to _htslib/ksort.h_.

See also PacificBiosciences/pbmm2#11 (via [this tweet](https://twitter.com/jomarnz/status/1095272592582328321)); if static ksort had been available, this would have been a good way to fix this rather than renaming away from the collision.