### PR TITLE
Add extra target for shared library

### DIFF
--- a/htslib.mk
+++ b/htslib.mk
@@ -152,7 +152,7 @@ $(HTSDIR)/config.h:
 $(HTSDIR)/libhts.a: $(HTSLIB_ALL)
 	+cd $(HTSDIR) && $(MAKE) lib-static
 
-$(HTSDIR)/libhts.so $(HTSDIR)/libhts.dylib: $(HTSLIB_ALL)
+$(HTSDIR)/libhts.so $(HTSDIR)/libhts.dylib $(HTSDIR)/libhts.dll.a $(HTSDIR)/hts.dll.a: $(HTSLIB_ALL)
 	+cd $(HTSDIR) && $(MAKE) lib-shared
 
 $(HTSDIR)/bgzip: $(HTSDIR)/bgzip.c $(HTSLIB_PUBLIC_HEADERS)


### PR DESCRIPTION
Add extra target `hts.dll.a` for building htslib as a shared library. Needed for compiling bcftools plug-ins on Windows.