### PR TITLE
Allow repeated invocations of bcf_update_info/format_*()

### DIFF
--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -117,6 +117,10 @@ void write_bcf(char *fname)
     // .. INFO
     tmpi = 3;
     check0(bcf_update_info_int32(hdr, rec, "NS", &tmpi, 1));
+    tmpi = 500;
+    check0(bcf_update_info_int32(hdr, rec, "DP", &tmpi, 1));
+    tmpi = 100000;
+    check0(bcf_update_info_int32(hdr, rec, "DP", &tmpi, 1));
     tmpi = 14;
     check0(bcf_update_info_int32(hdr, rec, "DP", &tmpi, 1));
     tmpi = -127;
@@ -138,6 +142,14 @@ void write_bcf(char *fname)
     tmpia[1] = 48;
     tmpia[2] = 43;
     check0(bcf_update_format_int32(hdr, rec, "GQ", tmpia, bcf_hdr_nsamples(hdr)));
+    tmpia[0] = 0;
+    tmpia[1] = 0;
+    tmpia[2] = 1;
+    check0(bcf_update_format_int32(hdr, rec, "DP", tmpia, bcf_hdr_nsamples(hdr)));
+    tmpia[0] = 1;
+    tmpia[1] = 100000;
+    tmpia[2] = 1;
+    check0(bcf_update_format_int32(hdr, rec, "DP", tmpia, bcf_hdr_nsamples(hdr)));
     tmpia[0] = 1;
     tmpia[1] = 8;
     tmpia[2] = 5;
@@ -150,6 +162,10 @@ void write_bcf(char *fname)
     tmpia[5] = bcf_int32_missing;
     check0(bcf_update_format_int32(hdr, rec, "HQ", tmpia, bcf_hdr_nsamples(hdr)*2));
     char *tmp_str[] = {"String1","SomeOtherString2","YetAnotherString3"};
+    check0(bcf_update_format_string(hdr, rec, "TS", (const char**)tmp_str, 3));
+    tmp_str[0] = "LongerStringRequiringBufferReallocation";
+    check0(bcf_update_format_string(hdr, rec, "TS", (const char**)tmp_str, 3));
+    tmp_str[0] = "String1";
     check0(bcf_update_format_string(hdr, rec, "TS", (const char**)tmp_str, 3));
     if ( bcf_write1(fp, hdr, rec)!=0 ) error("Failed to write to %s\n", fname);
 
@@ -169,6 +185,8 @@ void write_bcf(char *fname)
     tmpfa[0] = 0.333;
     bcf_float_set_missing(tmpfa[1]);
     check0(bcf_update_info_float(hdr, rec, "AF", tmpfa, 2));
+    check0(bcf_update_info_string(hdr, rec, "AA", "SHORT"));
+    check0(bcf_update_info_string(hdr, rec, "AA", "LONGSTRING"));
     check0(bcf_update_info_string(hdr, rec, "AA", "T"));
     check0(bcf_update_info_flag(hdr, rec, "DB", NULL, 1));
     tmpia[0] = bcf_gt_phased(2);

--- a/vcf.c
+++ b/vcf.c
@@ -3727,7 +3727,8 @@ int bcf_update_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key, const v
         }
         else
         {
-            assert( !inf->vptr_free );  // fix the caller or improve here: this has been modified before
+            if ( inf->vptr_free )
+                free(inf->vptr - inf->vptr_off);
             bcf_unpack_info_core1((uint8_t*)str.s, inf);
             inf->vptr_free = 1;
             line->d.shared_dirty |= BCF1_DIRTY_INF;
@@ -3867,7 +3868,8 @@ int bcf_update_format(const bcf_hdr_t *hdr, bcf1_t *line, const char *key, const
         }
         else
         {
-            assert( !fmt->p_free );  // fix the caller or improve here: this has been modified before
+            if ( fmt->p_free )
+                free(fmt->p - fmt->p_off);
             bcf_unpack_fmt_core1((uint8_t*)str.s, line->n_sample, fmt);
             fmt->p_free = 1;
             line->d.indiv_dirty = 1;


### PR DESCRIPTION
I needed this for something else, hence… Rather than asserting that no value has previously been set, free any previously set value array before unpacking the new one.  Fixes #813.

(This free() is all that's left after duplicating the "Mark the tag for removal, free existing memory if necessary" code from earlier in each function, and removing assignments that are unnecessary due to the immediately following bcf_unpack_info/fmt_core1() call.)