### PR TITLE
Fix configure --disable-werror (trivial m4 fix)

### DIFF
--- a/m4/hts_prog_cc_warnings.m4
+++ b/m4/hts_prog_cc_warnings.m4
@@ -167,10 +167,10 @@ CFLAGS="$ac_arg_needed $CFLAGS"],[dnl
 AC_DEFUN([HTS_PROG_CC_WERROR], [
   AC_ARG_ENABLE([werror],
     [AS_HELP_STRING([--enable-werror], [change warnings into errors, where supported])],
-    [enable_werror=yes],
-    [])
+    [],
+    [enable_werror=no])
 
-  AS_IF([test "x$enable_werror" = xyes],[
+  AS_IF([test "x$enable_werror" != xno],[
     AC_MSG_CHECKING([for C compiler flags to error on warnings])
     AC_CACHE_VAL(hts_cv_prog_cc_werror, [dnl
       hts_cv_prog_cc_werror=""


### PR DESCRIPTION
AC_ARG_ENABLE's third argument, ACTION-IF-GIVEN, includes when the argument is given as --enable-werror=no / --disable-werror. The fourth argument continues the existing default of enable=no.