### PR TITLE
Fix compilation on Illumos / Sun C compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ test/hfile: test/hfile.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/hfile.o libhts.a $(LIBS) -lpthread
 
 test/pileup: test/pileup.o libhts.a
-	$(CC) -pthread $(LDFLAGS) -o $@ test/pileup.o libhts.a $(LIBS) -lpthread
+	$(CC) $(LDFLAGS) -o $@ test/pileup.o libhts.a $(LIBS) -lpthread
 
 test/sam: test/sam.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/sam.o libhts.a $(LIBS) -lpthread

--- a/faidx.c
+++ b/faidx.c
@@ -159,7 +159,6 @@ static faidx_t *fai_build_core(BGZF *bgzf) {
                         char s[4] = { '"', c, '"', '\0' };
                         hts_log_error("Format error, unexpected %s at line %d", isprint(c) ? s : "character", line_num);
                         goto fail;
-                    break;
                     }
                 }
             break;
@@ -252,10 +251,9 @@ static faidx_t *fai_build_core(BGZF *bgzf) {
             case SEQ_END:
                 if (c == '+') {
                     state = IN_QUAL;
-                    if (c != '\n') while ((c = bgzf_getc(bgzf)) >= 0 && c != '\n');
+                    while ((c = bgzf_getc(bgzf)) >= 0 && c != '\n');
                     qual_offset = bgzf_utell(bgzf);
                     line_num++;
-                    continue;
                 } else {
                     hts_log_error("Format error, expecting '+', got '%c' at line %d", c, line_num);
                     goto fail;


### PR DESCRIPTION
While I had the Illumos VM running, I noticed that the htslib build had regressed slightly.  This fixes a linking problem and a couple of warnings.  The last one didn't generate a warning, I just noticed it as it was nearby.

* Remove unnecessary -pthread option from test/pileup
* Fix unreachable code warnings in faidx.c
* Remove if statement where condition is always true. 