### PR TITLE
Fix undefined behavior

### DIFF
--- a/bcf_sr_sort.c
+++ b/bcf_sr_sort.c
@@ -147,7 +147,7 @@ static int multi_is_subset(var_t *avar, var_t *bvar)
     }
     return 0;
 }
-int32_t pairing_score(sr_sort_t *srt, int ivset, int jvset)
+uint32_t pairing_score(sr_sort_t *srt, int ivset, int jvset)
 {
     varset_t *iv = &srt->vset[ivset];
     varset_t *jv = &srt->vset[jvset];
@@ -185,7 +185,7 @@ int32_t pairing_score(sr_sort_t *srt, int ivset, int jvset)
     for (i=0; i<iv->nvar; i++) cnt += srt->var[iv->var[i]].nvcf;
     for (j=0; j<jv->nvar; j++) cnt += srt->var[jv->var[j]].nvcf;
 
-    return (1<<(28+min)) + cnt;
+    return (1u<<(28+min)) + cnt;
 }
 void remove_vset(sr_sort_t *srt, int jvset)
 {

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -2632,10 +2632,14 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 
         int l2 = cr->len / 2;
         unsigned char *from = (unsigned char *)bam_seq(b);
-        uint16_t *cpi = (uint16_t *)cp;
         cp[0] = 0;
         for (i = 0; i < l2; i++)
-            cpi[i] = le_int2(code2base[from[i]]);
+        {
+            // do not replace this memcpy by creating a misaligned
+            // pointer to cp using a uint16_t*, that is UB
+            const uint16_t cpi = le_int2(code2base[from[i]]);
+            memcpy(cp + i*sizeof(uint16_t), &cpi, sizeof(uint16_t));
+        }
         if ((i *= 2) < cr->len)
             cp[i] = seq_nt16_str[bam_seqi(bam_seq(b), i)];
     }


### PR DESCRIPTION
## Fix undefined behavior in left-shift

UBSAN complains in

    bcf_sr_sort.c:188:14: runtime error: left shift of 1 by 31
    places cannot be represented in type 'int'

which involves signed overflow, and is hence undefined behavior.
The function `pairing_score` is only ever used in an unsigned
context, hence perform calculations using unsigned types, which
will not overflow/wrap.

## Fix unaligned access

UBSAN complains about unaligned access in

    cram/cram_encode.c:2638:20: runtime error: store to misaligned address
    0x619000000f9d for type 'uint16_t', which requires 2 byte alignment

which is valid, as the current code contains undefined behavior.
Using `memcpy` avoids this undefined behavior and every modern
C compiler nowadays turns `memcpy` calls into the most optimal
fetch instruction for the target platform.

See also
* https://blog.regehr.org/archives/1520
* https://pzemtsov.github.io/2016/11/06/bug-story-alignment-on-x86.html
* https://blog.quarkslab.com/unaligned-accesses-in-cc-what-why-and-solutions-to-do-it-properly.html