### PR TITLE
Change long to off_t for file offsets

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -2143,7 +2143,7 @@ int bgzf_index_load(BGZF *fp, const char *bname, const char *suffix)
     return -1;
 }
 
-int bgzf_useek(BGZF *fp, long uoffset, int where)
+int bgzf_useek(BGZF *fp, off_t uoffset, int where)
 {
     if (fp->is_write || where != SEEK_SET || fp->is_gzip) {
         fp->errcode |= BGZF_ERR_MISUSE;
@@ -2199,7 +2199,7 @@ int bgzf_useek(BGZF *fp, long uoffset, int where)
     return 0;
 }
 
-long bgzf_utell(BGZF *fp)
+off_t bgzf_utell(BGZF *fp)
 {
     return fp->uncompressed_address;    // currently maintained only when reading
 }

--- a/hts.c
+++ b/hts.c
@@ -1110,14 +1110,14 @@ BGZF *hts_get_bgzfp(htsFile *fp)
     else
         return NULL;
 }
-int hts_useek(htsFile *fp, long uoffset, int where)
+int hts_useek(htsFile *fp, off_t uoffset, int where)
 {
     if (fp->is_bgzf)
         return bgzf_useek(fp->fp.bgzf, uoffset, where);
     else
         return (hseek(fp->fp.hfile, uoffset, SEEK_SET) >= 0)? 0 : -1;
 }
-long hts_utell(htsFile *fp)
+off_t hts_utell(htsFile *fp)
 {
     if (fp->is_bgzf)
         return bgzf_utell(fp->fp.bgzf);

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -336,7 +336,7 @@ typedef struct BGZF BGZF;
      *  @note It is not permitted to seek on files open for writing,
      *  or files compressed with gzip (as opposed to bgzip).
      */
-    int bgzf_useek(BGZF *fp, long uoffset, int where) HTS_RESULT_USED;
+    int bgzf_useek(BGZF *fp, off_t uoffset, int where) HTS_RESULT_USED;
 
     /**
      *  Position in uncompressed BGZF
@@ -345,7 +345,7 @@ typedef struct BGZF BGZF;
      *
      *  Returns the current offset on success and -1 on error.
      */
-    long bgzf_utell(BGZF *fp);
+    off_t bgzf_utell(BGZF *fp);
 
     /**
      * Tell BGZF to build index while compressing.

--- a/vcf_sweep.c
+++ b/vcf_sweep.c
@@ -49,8 +49,8 @@ struct _bcf_sweep_t
 };
 
 BGZF *hts_get_bgzfp(htsFile *fp);
-int hts_useek(htsFile *file, long uoffset, int where);
-long hts_utell(htsFile *file);
+int hts_useek(htsFile *file, off_t uoffset, int where);
+off_t hts_utell(htsFile *file);
 
 static inline int sw_rec_equal(bcf_sweep_t *sw, bcf1_t *rec)
 {
@@ -146,7 +146,7 @@ bcf1_t *bcf_sweep_fwd(bcf_sweep_t *sw)
 {
     if ( sw->direction==SW_BWD ) sw_seek(sw, SW_FWD);
 
-    long pos = hts_utell(sw->file);
+    off_t pos = hts_utell(sw->file);
 
     bcf1_t *rec = &sw->rec[0];
     int ret = bcf_read1(sw->file, sw->hdr, rec);


### PR DESCRIPTION
On Windows, `long` is defined as a signed 32 bit type, even on a 64 bit OS, while it is a 64 bit type on a 64 bit Linux machine. This creates discrepancies, especially when working with values larger than 2<sup>31</sup>.
On the other hand, the length of `off_t` is determined by the platform configurable macro `_FILE_OFFSET_BITS`.
Fixes #866 
