### PR TITLE
S3 multi region support

### DIFF
--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -378,7 +378,7 @@ static hFILE * s3_rewrite(const char *s3url, const char *mode, va_list *argsp)
     if (ad->id.l == 0)
         parse_ini("~/.s3cfg", profile.s, "access_key", &ad->id,
                   "secret_key", &ad->secret, "access_token", &ad->token,
-                  "region", &ad->bucket_location || &ad->region,
+                  "bucket_location", &ad->region,
                   "host_base", &host_base, NULL);
     if (ad->id.l == 0)
         parse_simple("~/.awssecret", &ad->id, &ad->secret);

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -41,6 +41,7 @@ typedef struct {
     kstring_t id;
     kstring_t token;
     kstring_t secret;
+    kstring_t region;
     char *bucket;
     kstring_t auth_hdr;
     time_t auth_time;
@@ -247,6 +248,7 @@ static void free_auth_data(s3_auth_data *ad) {
     free(ad->id.s);
     free(ad->token.s);
     free(ad->secret.s);
+    free(ad->region.s);
     free(ad->bucket);
     free(ad->auth_hdr.s);
     free(ad);
@@ -358,6 +360,7 @@ static hFILE * s3_rewrite(const char *s3url, const char *mode, va_list *argsp)
         if ((v = getenv("AWS_ACCESS_KEY_ID")) != NULL) kputs(v, &ad->id);
         if ((v = getenv("AWS_SECRET_ACCESS_KEY")) != NULL) kputs(v, &ad->secret);
         if ((v = getenv("AWS_SESSION_TOKEN")) != NULL) kputs(v, &ad->token);
+        if ((v = getenv("AWS_DEFAULT_REGION")) != NULL) kputs(v, &ad->region);
 
         if ((v = getenv("AWS_DEFAULT_PROFILE")) != NULL) kputs(v, &profile);
         else if ((v = getenv("AWS_PROFILE")) != NULL) kputs(v, &profile);
@@ -369,17 +372,26 @@ static hFILE * s3_rewrite(const char *s3url, const char *mode, va_list *argsp)
         parse_ini(v? v : "~/.aws/credentials", profile.s,
                   "aws_access_key_id", &ad->id,
                   "aws_secret_access_key", &ad->secret,
+                  "region", &ad->region,
                   "aws_session_token", &ad->token, NULL);
     }
     if (ad->id.l == 0)
         parse_ini("~/.s3cfg", profile.s, "access_key", &ad->id,
                   "secret_key", &ad->secret, "access_token", &ad->token,
+                  "region", &ad->bucket_location || &ad->region,
                   "host_base", &host_base, NULL);
     if (ad->id.l == 0)
         parse_simple("~/.awssecret", &ad->id, &ad->secret);
 
     if (host_base.l == 0)
         kputs("s3.amazonaws.com", &host_base);
+
+    if (host_base.l == 0){
+        ksprintf(&host_base, "%s%s.amazonaws.com",
+        ad->region.l > 0 ? "s3." : "s3",
+        ad->region.l > 0 ? ad->region.s : "");
+    }
+
     // Use virtual hosted-style access if possible, otherwise path-style.
     if (is_dns_compliant(bucket, path)) {
         kputsn(bucket, path - bucket, &url);


### PR DESCRIPTION
@daviesrob, this PR addresses your last comments from https://github.com/samtools/htslib/pull/680.  Direct S3 access is such an awesome feature, it's a shame not to be able to support multiple regions.

> As we're using s3cmd's configuration file, we should try to behave as much as possible like it does. In this case, it seems to use bucket_location so set the region that it tries to download from / upload to rather than region (which I don't think it understands).
> 
> I think this would be OK with a rebase to current develop and that one change.

Note that  [s3cmd usage](https://s3tools.org/usage) indicates either `bucket_location` or `region` are acceptable to specify the bucket region.  The only change I've made to @mwchristiansen's original PR is  to use the `bucket_location` key.  It's also rebased to match the current `develop` branch. 

Please let me know if there's anything else I can do to support getting this merged.  

Thanks!