### PR TITLE
bgzip '-F, --on-the-fly': writes an incremental index file as input is read.

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -477,7 +477,7 @@ static int fai_build3_core(const char *fn, const char *fnfai, const char *fngzi)
     }
 
     if ( bgzf->is_compressed ) {
-        if (bgzf_index_dump(bgzf, fngzi, NULL) < 0) {
+        if (bgzf_index_dump(bgzf, fngzi, NULL, 0) < 0) {
             hts_log_error("Failed to make bgzf index %s", fngzi);
             goto fail;
         }

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -394,17 +394,19 @@ typedef struct BGZF BGZF;
      * @param fp          BGZF file handler
      * @param bname       base name
      * @param suffix      suffix to add to bname (can be NULL)
-     * @return 0 on success and -1 on error.
+     * @param last_index_pointer    last index written to index file
+     * @return 0 if fp->mt, or last index pointer written (>1) if !fp->mt, and -1 on error.
      */
     int bgzf_index_dump(BGZF *fp,
-                        const char *bname, const char *suffix) HTS_RESULT_USED;
+                        const char *bname, const char *suffix, int last_index_pointer) HTS_RESULT_USED;
 
     /// Write a BGZF index to an hFILE
     /**
      * @param fp     BGZF file handle
      * @param idx    hFILE to write to
      * @param name   file name (for error reporting only, can be NULL)
-     * @return 0 on success and -1 on error.
+     * @param last_index_pointer    last index written to index file
+     * @return 0 if fp->mt, or last index pointer written (>1) if !fp->mt, and -1 on error.
      *
      * Write index data from @p fp to the file @p idx.
      *
@@ -414,7 +416,7 @@ typedef struct BGZF BGZF;
      */
 
     int bgzf_index_dump_hfile(BGZF *fp, struct hFILE *idx,
-                              const char *name) HTS_RESULT_USED;
+                              const char *name, int last_index_pointer) HTS_RESULT_USED;
 
 #ifdef __cplusplus
 }

--- a/test/test_bgzf.c
+++ b/test/test_bgzf.c
@@ -234,7 +234,7 @@ static int try_bgzf_index_load(BGZF *fp, const char *bname, const char *suffix,
 
 static int try_bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix,
                                const char *func) {
-    if (bgzf_index_dump(fp, bname, suffix) != 0) {
+    if (bgzf_index_dump(fp, bname, suffix, 0) != 0) {
         fprintf(stderr, "%s : Couldn't bgzf_index_dump %s%s : %s\n",
                 func, bname, suffix ? suffix : "", strerror(errno));
         return -1;


### PR DESCRIPTION
Intended for possible long stdin inputs (e.g. logs), this allows
for quick random access reads of the still-growing compressed file.

I'm planning to use bgzip for compressed logging, so this feature is a must to exploit the advantages of gzipped blocks from bgzip.

I think I haven't break anything, as multithreading (*-@*) is excluded, and modifier (*-F, --on-the-fly*) must be explicitly set, but :
* **hseek()** is used (to overwrite the number of index entries so far, and later positioning at the end again)
* **bgzf_index_dump_hfile()** and **bgzf_index_dump()** are modified with an extra parameter (this could be omitted, but this way the index is only appended, not totally overwritten on each update).

Maybe an easier way is possible.