### PR TITLE
bgzip '-F, --on-the-fly': writes an incremental index file as input is read.

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -1988,7 +1988,7 @@ static char * get_name_suffix(const char *bname, const char *suffix)
     return buff;
 }
 
-int bgzf_index_dump_hfile(BGZF *fp, struct hFILE *idx, const char *name)
+int bgzf_index_dump_hfile(BGZF *fp, struct hFILE *idx, const char *name, int last_index_pointer)
 {
     // Note that the index contains one extra record when indexing files opened
     // for reading. The terminating record is not present when opened for writing.
@@ -2002,30 +2002,58 @@ int bgzf_index_dump_hfile(BGZF *fp, struct hFILE *idx, const char *name)
         return -1;
     }
 
-    if (bgzf_flush(fp) != 0) return -1;
+    if ( fp->mt ) {
+        if (bgzf_flush(fp) != 0) return -1;
+    } else {
+        // bgzf_flush(fp) moved to bgzf_index_dump() on close of idx
+        ;
+    }
 
     // discard the entry marking the end of the file
     if (fp->mt && fp->idx)
         fp->idx->noffs--;
 
-    if (hwrite_uint64(fp->idx->noffs - 1, idx) < 0) goto fail;
-    for (i=1; i<fp->idx->noffs; i++)
-    {
-        if (hwrite_uint64(fp->idx->offs[i].caddr, idx) < 0) goto fail;
-        if (hwrite_uint64(fp->idx->offs[i].uaddr, idx) < 0) goto fail;
+    if ( fp->mt ) {
+        if (hwrite_uint64(fp->idx->noffs - 1, idx) < 0) goto fail;
+        for (i=1; i<fp->idx->noffs; i++)
+        {
+            if (hwrite_uint64(fp->idx->offs[i].caddr, idx) < 0) goto fail;
+            if (hwrite_uint64(fp->idx->offs[i].uaddr, idx) < 0) goto fail;
+        }
+
+        return 0;
+    } else {
+        // write header with idx->noffs
+        if ( hseek(idx, 0, SEEK_SET) == 0 ) {
+            if (hwrite_uint64(fp->idx->noffs - 1, idx) < 0) goto fail;
+        } else {
+            goto fail;
+        }
+
+        // Seek to end of file before writing to not overwrite/repeat previously written indexes
+        if ( hseek( idx, 8 + (last_index_pointer - 1)*( 8 + 8 ), SEEK_SET ) < 0 ) goto fail;
+
+        for (i=last_index_pointer; i<fp->idx->noffs; i++)
+        {
+            if (hwrite_uint64(fp->idx->offs[i].caddr, idx) < 0) goto fail;
+            if (hwrite_uint64(fp->idx->offs[i].uaddr, idx) < 0) goto fail;
+        }
+
+        // return last written index
+        return i;
     }
-    return 0;
 
  fail:
     hts_log_error("Error writing to %s : %s", name ? name : "index", strerror(errno));
     return -1;
 }
 
-int bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix)
+int bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix, int last_index_pointer)
 {
     const char *name = bname, *msg = NULL;
-    char *tmp = NULL;
-    hFILE *idx = NULL;
+    static char *tmp = NULL;
+    static hFILE *idx = NULL;
+    int close_file = 0;
 
     if (!fp->idx) {
         hts_log_error("Called for BGZF handle with no index");
@@ -2033,30 +2061,61 @@ int bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix)
         return -1;
     }
 
-    if ( suffix )
-    {
-        tmp = get_name_suffix(bname, suffix);
-        if ( !tmp ) return -1;
-        name = tmp;
+    if ( last_index_pointer == 0 ) {
+
+        if (bgzf_flush(fp) != 0) return -1;
+
+        last_index_pointer = 1; // (incomplete)-index-file will be (over)written with complete index,
+        close_file = 1;         // and closed.
     }
 
-    idx = hopen(name, "wb");
-    if ( !idx ) {
-        msg = "Error opening";
-        goto fail;
+    if ( last_index_pointer > 0 ) {
+
+        if ( !idx )
+        {
+            if ( suffix ) {
+                tmp = get_name_suffix(bname, suffix);
+                if ( !tmp ) return -1;
+                name = tmp;
+            }
+            idx = hopen(name, "wb");
+        } else {
+            name = tmp;
+        }
+
+        if ( !idx )
+        {
+            msg = "Error opening";
+            goto fail;
+        }
+
+        last_index_pointer = bgzf_index_dump_hfile(fp, idx, name, last_index_pointer);
+
+        if (last_index_pointer == -1) goto fail;
+
+        if ( close_file == 0 )
+            return last_index_pointer;
+
     }
 
-    if (bgzf_index_dump_hfile(fp, idx, name) != 0) goto fail;
+    if ( close_file == 1 ) {
 
-    if (hclose(idx) < 0)
-    {
+        // close index file
+
+        if (hclose(idx) < 0)
+        {
+            idx = NULL;
+            msg = "Error on closing";
+            goto fail;
+        }
+
         idx = NULL;
-        msg = "Error on closing";
-        goto fail;
-    }
+        free(tmp);
+        tmp = NULL;
 
-    free(tmp);
-    return 0;
+        return 0;
+
+    }
 
  fail:
     if (msg != NULL) {
@@ -2064,6 +2123,7 @@ int bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix)
     }
     if (idx) hclose_abruptly(idx);
     free(tmp);
+    tmp = NULL;
     return -1;
 }
 

--- a/bgzip.c
+++ b/bgzip.c
@@ -240,7 +240,9 @@ int main(int argc, char **argv)
                 if (bgzf_block_write(fp, buffer, c) < 0) error("Could not write %d bytes: Error %d\n", c, fp->errcode);
         }
         else {
-            int last_index_pointer = 1;
+            BGZF_IDX_CONTEXT ctx;
+            empty_bgzf_idx_context(&ctx);
+            ctx.close_file = 0;
             // Compressing data:
             while ((c = read(f_src, buffer, WINDOW_SIZE)) > 0) {
                 if (bgzf_write(fp, buffer, c) < 0) error("Could not write %d bytes: Error %d\n", c, fp->errcode);
@@ -248,30 +250,28 @@ int main(int argc, char **argv)
                 if ( index && on_the_fly )
                 {
                     if (index_fname) {
-                        last_index_pointer = bgzf_index_dump(fp, index_fname, NULL, last_index_pointer);
-                        if (last_index_pointer < 0)
+                        if (bgzf_index_dump(fp, index_fname, NULL, &ctx) < 0)
                             error("Could not write index to '%s'\n", index_fname);
                     } else {
-                        last_index_pointer = bgzf_index_dump(fp, argv[optind], ".gz.gzi", last_index_pointer);
-                        if (last_index_pointer < 0)
+                        if (bgzf_index_dump(fp, argv[optind], ".gz.gzi", &ctx) < 0)
                             error("Could not write index to '%s.gz.gzi'", argv[optind]);
                     }
                 }
-
             }
             if ( index && on_the_fly ) {
                 // write complete index file and close it
-                if (bgzf_index_dump(fp, NULL, NULL, 0) < 0)
+                ctx.close_file = 1;
+                if (bgzf_index_dump(fp, NULL, NULL, &ctx) < 0)
                     error("Could not write index to '%s'\n", index_fname);
             }
         }
         if ( index && ! on_the_fly )
         {
             if (index_fname) {
-                if (bgzf_index_dump(fp, index_fname, NULL, 0) < 0)
+                if (bgzf_index_dump(fp, index_fname, NULL, NULL) < 0)
                     error("Could not write index to '%s'\n", index_fname);
             } else {
-                if (bgzf_index_dump(fp, argv[optind], ".gz.gzi", 0) < 0)
+                if (bgzf_index_dump(fp, argv[optind], ".gz.gzi", NULL) < 0)
                     error("Could not write index to '%s.gz.gzi'", argv[optind]);
             }
         }
@@ -303,10 +303,10 @@ int main(int argc, char **argv)
         if ( ret<0 ) error("Is the file gzipped or bgzipped? The latter is required for indexing.\n");
 
         if ( index_fname ) {
-            if (bgzf_index_dump(fp, index_fname, NULL, 0) < 0)
+            if (bgzf_index_dump(fp, index_fname, NULL, NULL) < 0)
                 error("Could not write index to '%s'\n", index_fname);
         } else {
-            if (bgzf_index_dump(fp, argv[optind], ".gzi", 0) < 0)
+            if (bgzf_index_dump(fp, argv[optind], ".gzi", NULL) < 0)
                 error("Could not write index to '%s.gzi'\n", argv[optind]);
         }
 

--- a/faidx.c
+++ b/faidx.c
@@ -477,7 +477,7 @@ static int fai_build3_core(const char *fn, const char *fnfai, const char *fngzi)
     }
 
     if ( bgzf->is_compressed ) {
-        if (bgzf_index_dump(bgzf, fngzi, NULL) < 0) {
+        if (bgzf_index_dump(bgzf, fngzi, NULL, 0) < 0) {
             hts_log_error("Failed to make bgzf index %s", fngzi);
             goto fail;
         }

--- a/faidx.c
+++ b/faidx.c
@@ -477,7 +477,7 @@ static int fai_build3_core(const char *fn, const char *fnfai, const char *fngzi)
     }
 
     if ( bgzf->is_compressed ) {
-        if (bgzf_index_dump(bgzf, fngzi, NULL, 0) < 0) {
+        if (bgzf_index_dump(bgzf, fngzi, NULL, NULL) < 0) {
             hts_log_error("Failed to make bgzf index %s", fngzi);
             goto fail;
         }

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -79,6 +79,19 @@ typedef struct BGZF BGZF;
 #define HTS_BGZF_TYPEDEF
 #endif
 
+// struct BGZF_IDX_CONTEXT is used with `--on-the-fly` index writing
+struct BGZF_IDX_CONTEXT {
+    int last_index_pointer;
+    char *idxfilename;
+    struct hFILE *idx;
+    int close_file;
+};
+#ifndef HTS_BGZF_IDX_CONTEXT_TYPEDEF
+typedef struct BGZF_IDX_CONTEXT BGZF_IDX_CONTEXT;
+#define HTS_BGZF_IDX_CONTEXT_TYPEDEF
+#endif
+
+
     /******************
      * Basic routines *
      ******************/
@@ -394,19 +407,19 @@ typedef struct BGZF BGZF;
      * @param fp          BGZF file handler
      * @param bname       base name
      * @param suffix      suffix to add to bname (can be NULL)
-     * @param last_index_pointer    last index written to index file
-     * @return 0 if fp->mt, or last index pointer written (>1) if !fp->mt, and -1 on error.
+     * @param ctx         BGZF_IDX_CONTEXT struct for incremental `--on-the-fly` index, or NULL
+     * @return 0 on success and -1 on error.
      */
     int bgzf_index_dump(BGZF *fp,
-                        const char *bname, const char *suffix, int last_index_pointer) HTS_RESULT_USED;
+                        const char *bname, const char *suffix, BGZF_IDX_CONTEXT *ctx) HTS_RESULT_USED;
 
     /// Write a BGZF index to an hFILE
     /**
      * @param fp     BGZF file handle
      * @param idx    hFILE to write to
      * @param name   file name (for error reporting only, can be NULL)
-     * @param last_index_pointer    last index written to index file
-     * @return 0 if fp->mt, or last index pointer written (>1) if !fp->mt, and -1 on error.
+     * @param ctx    BGZF_IDX_CONTEXT struct for incremental `--on-the-fly` index, or NULL
+     * @return 0 on success and -1 on error.
      *
      * Write index data from @p fp to the file @p idx.
      *
@@ -416,7 +429,18 @@ typedef struct BGZF BGZF;
      */
 
     int bgzf_index_dump_hfile(BGZF *fp, struct hFILE *idx,
-                              const char *name, int last_index_pointer) HTS_RESULT_USED;
+                              const char *name, BGZF_IDX_CONTEXT *ctx) HTS_RESULT_USED;
+
+    /// Set values of BGZF_IDX_CONTEXT struct to an empty context
+    /**
+     * @param ctx    BGZF_IDX_CONTEXT
+     *
+     * Initialize values of BGZF_IDX_CONTEXT struct as if there was no context
+     * and so incremental index file writing (`--on-the-fly`) is not in use.
+     *
+     * Set both last_index_pointer and close_file to 1, and pointers to NULL.
+     */
+    void empty_bgzf_idx_context(BGZF_IDX_CONTEXT *ctx);
 
 #ifdef __cplusplus
 }

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -394,17 +394,19 @@ typedef struct BGZF BGZF;
      * @param fp          BGZF file handler
      * @param bname       base name
      * @param suffix      suffix to add to bname (can be NULL)
-     * @return 0 on success and -1 on error.
+     * @param last_index_pointer    last index written to index file
+     * @return 0 if fp->mt, or last index pointer written (>1) if !fp->mt, and -1 on error.
      */
     int bgzf_index_dump(BGZF *fp,
-                        const char *bname, const char *suffix) HTS_RESULT_USED;
+                        const char *bname, const char *suffix, int last_index_pointer) HTS_RESULT_USED;
 
     /// Write a BGZF index to an hFILE
     /**
      * @param fp     BGZF file handle
      * @param idx    hFILE to write to
      * @param name   file name (for error reporting only, can be NULL)
-     * @return 0 on success and -1 on error.
+     * @param last_index_pointer    last index written to index file
+     * @return 0 if fp->mt, or last index pointer written (>1) if !fp->mt, and -1 on error.
      *
      * Write index data from @p fp to the file @p idx.
      *
@@ -414,7 +416,7 @@ typedef struct BGZF BGZF;
      */
 
     int bgzf_index_dump_hfile(BGZF *fp, struct hFILE *idx,
-                              const char *name) HTS_RESULT_USED;
+                              const char *name, int last_index_pointer) HTS_RESULT_USED;
 
 #ifdef __cplusplus
 }

--- a/test/test_bgzf.c
+++ b/test/test_bgzf.c
@@ -234,7 +234,7 @@ static int try_bgzf_index_load(BGZF *fp, const char *bname, const char *suffix,
 
 static int try_bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix,
                                const char *func) {
-    if (bgzf_index_dump(fp, bname, suffix) != 0) {
+    if (bgzf_index_dump(fp, bname, suffix, 0) != 0) {
         fprintf(stderr, "%s : Couldn't bgzf_index_dump %s%s : %s\n",
                 func, bname, suffix ? suffix : "", strerror(errno));
         return -1;

--- a/test/test_bgzf.c
+++ b/test/test_bgzf.c
@@ -234,7 +234,7 @@ static int try_bgzf_index_load(BGZF *fp, const char *bname, const char *suffix,
 
 static int try_bgzf_index_dump(BGZF *fp, const char *bname, const char *suffix,
                                const char *func) {
-    if (bgzf_index_dump(fp, bname, suffix, 0) != 0) {
+    if (bgzf_index_dump(fp, bname, suffix, NULL) != 0) {
         fprintf(stderr, "%s : Couldn't bgzf_index_dump %s%s : %s\n",
                 func, bname, suffix ? suffix : "", strerror(errno));
         return -1;


### PR DESCRIPTION
Intended for possible long stdin inputs (e.g. logs), this allows
for quick random access reads of the still-growing bgzip-compressed file.

I'm planning to use bgzip for compressed logging, so this feature is a must to exploit the advantages of gzipped blocks from bgzip.

I think I haven't broken anything, as multithreading (*-@*) is excluded, and modifier (*-F, --on-the-fly*) must be explicitly set, but :
* **hseek()** is used (to overwrite the number of index entries so far, and later positioning at the end again)
* **bgzf_index_dump_hfile()** and **bgzf_index_dump()** are modified with an extra parameter (this could be omitted, but this way the index is only appended, not totally overwritten on each update).

Maybe an easier way is possible.
