### PR TITLE
Put hts_ prefix in front of various klib functions

### DIFF
--- a/htslib/kfunc.h
+++ b/htslib/kfunc.h
@@ -35,13 +35,19 @@ extern "C" {
  * \log{\Gamma(z)}
  * AS245, 2nd algorithm, http://lib.stat.cmu.edu/apstat/245
  */
-double kf_lgamma(double z);
+static inline double kf_lgamma(double z) {
+    double hts_kf_lgamma(double z);
+    return hts_kf_lgamma(z);
+}
 
 /* complementary error function
  * \frac{2}{\sqrt{\pi}} \int_x^{\infty} e^{-t^2} dt
  * AS66, 2nd algorithm, http://lib.stat.cmu.edu/apstat/66
  */
-double kf_erfc(double x);
+static inline double kf_erfc(double x) {
+    double hts_kf_erfc(double x);
+    return hts_kf_erfc(x);
+}
 
 /* The following computes regularized incomplete gamma functions.
  * Formulas are taken from Wiki, with additional input from Numerical
@@ -56,8 +62,14 @@ double kf_erfc(double x);
  * kf_gammaq(s,z)*tgamma(s).
  */
 
-double kf_gammap(double s, double z);
-double kf_gammaq(double s, double z);
+static inline double kf_gammap(double s, double z) {
+    double hts_kf_gammap(double s, double z);
+    return hts_kf_gammap(s, z);
+}
+static inline double kf_gammaq(double s, double z) {
+    double hts_kf_gammaq(double s, double z);
+    return hts_kf_gammaq(s, z);
+}
 
 /* Regularized incomplete beta function. The method is taken from
  * Numerical Recipe in C, 2nd edition, section 6.4. The following web
@@ -66,7 +78,10 @@ double kf_gammaq(double s, double z);
  *
  *   http://www.danielsoper.com/statcalc/calc36.aspx
  */
-double kf_betai(double a, double b, double x);
+static inline double kf_betai(double a, double b, double x) {
+    double hts_kf_betai(double a, double b, double x);
+    return hts_kf_betai(a, b, x);
+}
 
 /*
  *    n11  n12  | n1_
@@ -74,7 +89,10 @@ double kf_betai(double a, double b, double x);
  *   -----------+----
  *    n_1  n_2  | n
  */
-double kt_fisher_exact(int n11, int n12, int n21, int n22, double *_left, double *_right, double *two);
+static inline double kt_fisher_exact(int n11, int n12, int n21, int n22, double *left_, double *right_, double *two) {
+    double hts_kt_fisher_exact(int n11, int n12, int n21, int n22, double *left_, double *right_, double *two);
+    return hts_kt_fisher_exact(n11, n12, n21, n22, left_, right_, two);
+}
 
 #ifdef __cplusplus
 }

--- a/htslib/knetfile.h
+++ b/htslib/knetfile.h
@@ -71,29 +71,50 @@ extern "C" {
 #endif
 
 #ifdef _WIN32
-	int knet_win32_init();
-	void knet_win32_destroy();
+	static inline int knet_win32_init() {
+		int hts_knet_win32_init();
+		return hts_knet_win32_init();
+	}
+	static inline void knet_win32_destroy() {
+		void hts_knet_win32_destroy();
+		hts_knet_win32_destroy();
+	}
 #endif
 
-	knetFile *knet_open(const char *fn, const char *mode);
+	static inline knetFile *knet_open(const char *fn, const char *mode) {
+		knetFile *hts_knet_open(const char *fn, const char *mode);
+		return hts_knet_open(fn, mode);
+	}
 
 	/*
 	   This only works with local files.
 	 */
-	knetFile *knet_dopen(int fd, const char *mode);
+	static inline knetFile *knet_dopen(int fd, const char *mode) {
+		knetFile *hts_knet_dopen(int fd, const char *mode);
+		return hts_knet_dopen(fd, mode);
+	}
 
 	/*
 	  If ->is_ready==0, this routine updates ->fd; otherwise, it simply
 	  reads from ->fd.
 	 */
-	ssize_t knet_read(knetFile *fp, void *buf, size_t len);
+	static inline ssize_t knet_read(knetFile *fp, void *buf, size_t len) {
+		ssize_t hts_knet_read(knetFile *fp, void *buf, size_t len);
+		return hts_knet_read(fp, buf, len);
+	}
 
 	/*
 	  This routine only sets ->offset and ->is_ready=0. It does not
 	  communicate with the FTP server.
 	 */
-	off_t knet_seek(knetFile *fp, off_t off, int whence);
-	int knet_close(knetFile *fp);
+	static inline off_t knet_seek(knetFile *fp, off_t off, int whence) {
+		off_t hts_knet_seek(knetFile *fp, off_t off, int whence);
+		return hts_knet_seek(fp, off, whence);
+	}
+	static inline int knet_close(knetFile *fp) {
+		int hts_knet_close(knetFile *fp);
+		return hts_knet_close(fp);
+	}
 
 #ifdef __cplusplus
 }

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -127,20 +127,23 @@ static inline int ksplit_core(char *s, int delimiter, int *max_, int **offsets_)
 }
 
 /// Boyer-Moore pattern search
-static inline void *kmemmem(const void *str, int n, const void *pat, int m, int **prep_)
+/// @note @p m must be less than INT_MAX
+static inline void *kmemmem(const void *str, size_t n, const void *pat, size_t m, int **prep_)
 {
-    void *hts_kmemmem(const void *str, int n, const void *pat, int m, int **prep_);
+    void *hts_kmemmem(const void *str, size_t n, const void *pat, size_t m, int **prep_);
     return hts_kmemmem(str, n, pat, m, prep_);
 }
 
 /// Boyer-Moore pattern search
+/// @note @p pat must be less than INT_MAX bytes long
 static inline char *kstrstr(const char *str, const char *pat, int **prep_)
 {
     return (char*)kmemmem(str, strlen(str), pat, strlen(pat), prep_);
 }
 
 /// Boyer-Moore pattern search
-static inline char *kstrnstr(const char *str, const char *pat, int n, int **prep_)
+/// @note @p pat must be less than INT_MAX bytes long
+static inline char *kstrnstr(const char *str, const char *pat, size_t n, int **prep_)
 {
     return (char*)kmemmem(str, n, pat, strlen(pat), prep_);
 }

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -91,28 +91,100 @@ typedef struct {
 extern "C" {
 #endif
 
-	int kvsprintf(kstring_t *s, const char *fmt, va_list ap) KS_ATTR_PRINTF(2,0);
-	int ksprintf(kstring_t *s, const char *fmt, ...) KS_ATTR_PRINTF(2,3);
-    int kputd(double d, kstring_t *s); // custom %g only handler
-	int ksplit_core(char *s, int delimiter, int *_max, int **_offsets);
-	char *kstrstr(const char *str, const char *pat, int **_prep);
-	char *kstrnstr(const char *str, const char *pat, int n, int **_prep);
-	void *kmemmem(const void *_str, int n, const void *_pat, int m, int **_prep);
+/// Append formatted data to a kstring
+KS_ATTR_PRINTF(2,0)
+static inline int kvsprintf(kstring_t *s, const char *fmt, va_list ap)
+{
+    int hts_kvsprintf(kstring_t *s, const char *fmt, va_list ap);
+    return hts_kvsprintf(s, fmt, ap);
+}
 
-	/* kstrtok() is similar to strtok_r() except that str is not
-	 * modified and both str and sep can be NULL. For efficiency, it is
-	 * actually recommended to set both to NULL in the subsequent calls
-	 * if sep is not changed. */
-	char *kstrtok(const char *str, const char *sep, ks_tokaux_t *aux);
+/// Append formatted data to a kstring
+KS_ATTR_PRINTF(2,3)
+static inline int ksprintf(kstring_t *s, const char *fmt, ...)
+{
+    int hts_kvsprintf(kstring_t *s, const char *fmt, va_list ap);
+    va_list ap;
+    int l;
+    va_start(ap, fmt);
+    l = kvsprintf(s, fmt, ap);
+    va_end(ap);
+    return l;
+}
 
-	/* kgetline() uses the supplied fgets()-like function to read a "\n"-
-	 * or "\r\n"-terminated line from fp.  The line read is appended to the
-	 * kstring without its terminator and 0 is returned; EOF is returned at
-	 * EOF or on error (determined by querying fp, as per fgets()). */
-	typedef char *kgets_func(char *, int, void *);
-	int kgetline(kstring_t *s, kgets_func *fgets, void *fp);
-	typedef ssize_t kgets_func2(char *, int, void *);
-	int kgetline2(kstring_t *s, kgets_func2 *fgets, void *fp);
+/// Append a double value to a kstring (%g format only)
+static inline int kputd(double d, kstring_t *s)
+{
+    int hts_kputd(double d, kstring_t *s);
+    return hts_kputd(d, s);
+}
+
+/// Split a string at a delimiter
+static inline int ksplit_core(char *s, int delimiter, int *max_, int **offsets_)
+{
+    int hts_ksplit_core(char *s, int delimiter, int *max_, int **offsets_);
+    return hts_ksplit_core(s, delimiter, max_, offsets_);
+}
+
+/// Boyer-Moore pattern search
+static inline void *kmemmem(const void *str, int n, const void *pat, int m, int **prep_)
+{
+    void *hts_kmemmem(const void *str, int n, const void *pat, int m, int **prep_);
+    return hts_kmemmem(str, n, pat, m, prep_);
+}
+
+/// Boyer-Moore pattern search
+static inline char *kstrstr(const char *str, const char *pat, int **prep_)
+{
+    return (char*)kmemmem(str, strlen(str), pat, strlen(pat), prep_);
+}
+
+/// Boyer-Moore pattern search
+static inline char *kstrnstr(const char *str, const char *pat, int n, int **prep_)
+{
+    return (char*)kmemmem(str, n, pat, strlen(pat), prep_);
+}
+
+/// Tokenise a string
+/**
+ * kstrtok() is similar to strtok_r() except that str is not
+ * modified and both str and sep can be NULL. For efficiency, it is
+ * actually recommended to set both to NULL in the subsequent calls
+ * if sep is not changed. */
+static inline char *kstrtok(const char *str, const char *sep, ks_tokaux_t *aux)
+{
+    char *hts_kstrtok(const char *str, const char *sep, ks_tokaux_t *aux);
+    return hts_kstrtok(str, sep, aux);
+}
+
+/// Callback function for kgetline
+typedef char *kgets_func(char *, int, void *);
+
+/// Read a line into a kstring
+/**
+ * kgetline() uses the supplied fgets()-like function to read a "\n"-
+ * or "\r\n"-terminated line from fp.  The line read is appended to the
+ * kstring without its terminator and 0 is returned; EOF is returned at
+ * EOF or on error (determined by querying fp, as per fgets()). */
+static inline int kgetline(kstring_t *s, kgets_func *fgets, void *fp)
+{
+    int hts_kgetline(kstring_t *s, kgets_func *fgets, void *fp);
+    return hts_kgetline(s, fgets, fp);
+}
+
+/// Callback function for kgetline2()
+typedef ssize_t kgets_func2(char *, int, void *);
+
+/// Read a line into a kstring
+/**
+ * Similar to kgetline(), but the callback function returns the number of
+ * bytes added.
+ */
+static inline int kgetline2(kstring_t *s, kgets_func2 *fgets, void *fp)
+{
+    int hts_kgetline2(kstring_t *s, kgets_func2 *fgets, void *fp);
+    return hts_kgetline2(s, fgets, fp);
+}
 
 #ifdef __cplusplus
 }

--- a/kfunc.c
+++ b/kfunc.c
@@ -34,7 +34,7 @@
  * \log{\Gamma(z)}
  * AS245, 2nd algorithm, http://lib.stat.cmu.edu/apstat/245
  */
-double kf_lgamma(double z)
+double hts_kf_lgamma(double z)
 {
 	double x = 0;
 	x += 0.1659470187408462e-06 / (z+7);
@@ -53,7 +53,7 @@ double kf_lgamma(double z)
  * \frac{2}{\sqrt{\pi}} \int_x^{\infty} e^{-t^2} dt
  * AS66, 2nd algorithm, http://lib.stat.cmu.edu/apstat/66
  */
-double kf_erfc(double x)
+double hts_kf_erfc(double x)
 {
 	const double p0 = 220.2068679123761;
 	const double p1 = 221.2135961699311;
@@ -98,7 +98,7 @@ double kf_erfc(double x)
 #define KF_TINY 1e-290
 
 // regularized lower incomplete gamma function, by series expansion
-static double _kf_gammap(double s, double z)
+static double kf_gammap_(double s, double z)
 {
 	double sum, x;
 	int k;
@@ -109,7 +109,7 @@ static double _kf_gammap(double s, double z)
 	return exp(s * log(z) - z - kf_lgamma(s + 1.) + log(sum));
 }
 // regularized upper incomplete gamma function, by continued fraction
-static double _kf_gammaq(double s, double z)
+static double kf_gammaq_(double s, double z)
 {
 	int j;
 	double C, D, f;
@@ -130,14 +130,14 @@ static double _kf_gammaq(double s, double z)
 	return exp(s * log(z) - z - kf_lgamma(s) - log(f));
 }
 
-double kf_gammap(double s, double z)
+double hts_kf_gammap(double s, double z)
 {
-	return z <= 1. || z < s? _kf_gammap(s, z) : 1. - _kf_gammaq(s, z);
+	return z <= 1. || z < s? kf_gammap_(s, z) : 1. - kf_gammaq_(s, z);
 }
 
-double kf_gammaq(double s, double z)
+double hts_kf_gammaq(double s, double z)
 {
-	return z <= 1. || z < s? 1. - _kf_gammap(s, z) : _kf_gammaq(s, z);
+	return z <= 1. || z < s? 1. - kf_gammap_(s, z) : kf_gammaq_(s, z);
 }
 
 /* Regularized incomplete beta function. The method is taken from
@@ -171,7 +171,7 @@ static double kf_betai_aux(double a, double b, double x)
 	}
 	return exp(kf_lgamma(a+b) - kf_lgamma(a) - kf_lgamma(b) + a * log(x) + b * log(1.-x)) / a / f;
 }
-double kf_betai(double a, double b, double x)
+double hts_kf_betai(double a, double b, double x)
 {
 	return x < (a + 1.) / (a + b + 2.)? kf_betai_aux(a, b, x) : 1. - kf_betai_aux(b, a, 1. - x);
 }
@@ -240,7 +240,7 @@ static double hypergeo_acc(int n11, int n1_, int n_1, int n, hgacc_t *aux)
     return aux->p;
 }
 
-double kt_fisher_exact(int n11, int n12, int n21, int n22, double *_left, double *_right, double *two)
+double hts_kt_fisher_exact(int n11, int n12, int n21, int n22, double *left_, double *right_, double *two)
 {
     int i, j, max, min;
     double p, q, left, right;
@@ -251,7 +251,7 @@ double kt_fisher_exact(int n11, int n12, int n21, int n22, double *_left, double
     max = (n_1 < n1_) ? n_1 : n1_; // max n11, for right tail
     min = n1_ + n_1 - n;    // not sure why n11-n22 is used instead of min(n_1,n1_)
     if (min < 0) min = 0; // min n11, for left tail
-    *two = *_left = *_right = 1.;
+    *two = *left_ = *right_ = 1.;
     if (min == max) return 1.; // no need to do test
     q = hypergeo_acc(n11, n1_, n_1, n, &aux); // the probability of the current table
     // left tail
@@ -274,7 +274,7 @@ double kt_fisher_exact(int n11, int n12, int n21, int n22, double *_left, double
     // adjust left and right
     if (abs(i - n11) < abs(j - n11)) right = 1. - left + q;
     else left = 1.0 - right + q;
-    *_left = left; *_right = right;
+    *left_ = left; *right_ = right;
     return q;
 }
 

--- a/knetfile.c
+++ b/knetfile.c
@@ -118,7 +118,7 @@ static int socket_connect(const char *host, const char *port)
 #  endif
 #else
 /* MinGW's printf has problem with "%lld" */
-char *int64tostr(char *buf, int64_t x)
+static char *int64tostr(char *buf, int64_t x)
 {
 	int cnt;
 	int i = 0;
@@ -133,7 +133,7 @@ char *int64tostr(char *buf, int64_t x)
 	return buf;
 }
 
-int64_t strtoint64(const char *buf)
+static int64_t strtoint64(const char *buf)
 {
 	int64_t x;
 	for (x = 0; *buf != '\0'; ++buf)
@@ -141,12 +141,12 @@ int64_t strtoint64(const char *buf)
 	return x;
 }
 /* In windows, the first thing is to establish the TCP connection. */
-int knet_win32_init()
+int hts_knet_win32_init()
 {
 	WSADATA wsaData;
 	return WSAStartup(MAKEWORD(2, 2), &wsaData);
 }
-void knet_win32_destroy()
+void hts_knet_win32_destroy()
 {
 	WSACleanup();
 }
@@ -277,7 +277,7 @@ static int kftp_pasv_connect(knetFile *ftp)
 	return 0;
 }
 
-int kftp_connect(knetFile *ftp)
+static int kftp_connect(knetFile *ftp)
 {
 	ftp->ctrl_fd = socket_connect(ftp->host, ftp->port);
 	if (ftp->ctrl_fd == -1) return -1;
@@ -288,7 +288,7 @@ int kftp_connect(knetFile *ftp)
 	return 0;
 }
 
-int kftp_reconnect(knetFile *ftp)
+static int kftp_reconnect(knetFile *ftp)
 {
 	if (ftp->ctrl_fd != -1) {
 		netclose(ftp->ctrl_fd);
@@ -300,7 +300,7 @@ int kftp_reconnect(knetFile *ftp)
 }
 
 // initialize ->type, ->host, ->retr and ->size
-knetFile *kftp_parse_url(const char *fn, const char *mode)
+static knetFile *kftp_parse_url(const char *fn, const char *mode)
 {
 	knetFile *fp;
 	char *p;
@@ -326,7 +326,7 @@ knetFile *kftp_parse_url(const char *fn, const char *mode)
 	return fp;
 }
 // place ->fd at offset off
-int kftp_connect_file(knetFile *fp)
+static int kftp_connect_file(knetFile *fp)
 {
 	int ret;
 	long long file_size;
@@ -376,7 +376,7 @@ int kftp_connect_file(knetFile *fp)
  * HTTP specific routines *
  **************************/
 
-knetFile *khttp_parse_url(const char *fn, const char *mode)
+static knetFile *khttp_parse_url(const char *fn, const char *mode)
 {
 	knetFile *fp;
 	char *p, *proxy, *q;
@@ -411,7 +411,7 @@ knetFile *khttp_parse_url(const char *fn, const char *mode)
 	return fp;
 }
 
-int khttp_connect_file(knetFile *fp)
+static int khttp_connect_file(knetFile *fp)
 {
 	int ret, l = 0;
 	char *buf, *p;
@@ -469,7 +469,7 @@ int khttp_connect_file(knetFile *fp)
  * Generic routines *
  ********************/
 
-knetFile *knet_open(const char *fn, const char *mode)
+knetFile *hts_knet_open(const char *fn, const char *mode)
 {
 	knetFile *fp = 0;
 	if (mode[0] != 'r') {
@@ -514,7 +514,7 @@ knetFile *knet_open(const char *fn, const char *mode)
 	return fp;
 }
 
-knetFile *knet_dopen(int fd, const char *mode)
+knetFile *hts_knet_dopen(int fd, const char *mode)
 {
 	knetFile *fp = (knetFile*)calloc(1, sizeof(knetFile));
 	fp->type = KNF_TYPE_LOCAL;
@@ -522,7 +522,7 @@ knetFile *knet_dopen(int fd, const char *mode)
 	return fp;
 }
 
-ssize_t knet_read(knetFile *fp, void *buf, size_t len)
+ssize_t hts_knet_read(knetFile *fp, void *buf, size_t len)
 {
 	off_t l = 0;
 	if (fp->fd == -1) return 0;
@@ -551,7 +551,7 @@ ssize_t knet_read(knetFile *fp, void *buf, size_t len)
 	return l;
 }
 
-off_t knet_seek(knetFile *fp, off_t off, int whence)
+off_t hts_knet_seek(knetFile *fp, off_t off, int whence)
 {
 	if (whence == SEEK_SET && off == fp->offset) return 0;
 	if (fp->type == KNF_TYPE_LOCAL) {
@@ -584,7 +584,7 @@ off_t knet_seek(knetFile *fp, off_t off, int whence)
 	return -1;
 }
 
-int knet_close(knetFile *fp)
+int hts_knet_close(knetFile *fp)
 {
 	if (fp == 0) return 0;
 	if (fp->ctrl_fd != -1) netclose(fp->ctrl_fd); // FTP specific

--- a/kstring.c
+++ b/kstring.c
@@ -33,7 +33,7 @@
 #include <math.h>
 #include "htslib/kstring.h"
 
-int kputd(double d, kstring_t *s) {
+int hts_kputd(double d, kstring_t *s) {
 	int len = 0;
 	char buf[21], *cp = buf+20, *ep;
 	if (d == 0) {
@@ -138,7 +138,7 @@ int kputd(double d, kstring_t *s) {
 	return len;
 }
 
-int kvsprintf(kstring_t *s, const char *fmt, va_list ap)
+int hts_kvsprintf(kstring_t *s, const char *fmt, va_list ap)
 {
 	va_list args;
 	int l;
@@ -164,17 +164,7 @@ int kvsprintf(kstring_t *s, const char *fmt, va_list ap)
 	return l;
 }
 
-int ksprintf(kstring_t *s, const char *fmt, ...)
-{
-	va_list ap;
-	int l;
-	va_start(ap, fmt);
-	l = kvsprintf(s, fmt, ap);
-	va_end(ap);
-	return l;
-}
-
-char *kstrtok(const char *str, const char *sep_in, ks_tokaux_t *aux)
+char *hts_kstrtok(const char *str, const char *sep_in, ks_tokaux_t *aux)
 {
 	const unsigned char *p, *start, *sep = (unsigned char *) sep_in;
 	if (sep) { // set up the table
@@ -202,7 +192,7 @@ char *kstrtok(const char *str, const char *sep_in, ks_tokaux_t *aux)
 }
 
 // s MUST BE a null terminated string; l = strlen(s)
-int ksplit_core(char *s, int delimiter, int *_max, int **_offsets)
+int hts_ksplit_core(char *s, int delimiter, int *_max, int **_offsets)
 {
 	int i, n, max, last_char, last_start, *offsets, l;
 	n = 0; max = *_max; offsets = *_offsets;
@@ -248,7 +238,7 @@ int ksplit_core(char *s, int delimiter, int *_max, int **_offsets)
 	return n;
 }
 
-int kgetline(kstring_t *s, kgets_func *fgets_fn, void *fp)
+int hts_kgetline(kstring_t *s, kgets_func *fgets_fn, void *fp)
 {
 	size_t l0 = s->l;
 
@@ -271,7 +261,7 @@ int kgetline(kstring_t *s, kgets_func *fgets_fn, void *fp)
 	return 0;
 }
 
-int kgetline2(kstring_t *s, kgets_func2 *fgets_fn, void *fp)
+int hts_kgetline2(kstring_t *s, kgets_func2 *fgets_fn, void *fp)
 {
 	size_t l0 = s->l;
 
@@ -344,7 +334,7 @@ static int *ksBM_prep(const ubyte_t *pat, int m)
 	return prep;
 }
 
-void *kmemmem(const void *_str, int n, const void *_pat, int m, int **_prep)
+void *hts_kmemmem(const void *_str, int n, const void *_pat, int m, int **_prep)
 {
 	int i, j, *prep = 0, *bmGs, *bmBc;
 	const ubyte_t *str, *pat;
@@ -364,16 +354,6 @@ void *kmemmem(const void *_str, int n, const void *_pat, int m, int **_prep)
 	}
 	if (_prep == 0) free(prep);
 	return 0;
-}
-
-char *kstrstr(const char *str, const char *pat, int **_prep)
-{
-	return (char*)kmemmem(str, strlen(str), pat, strlen(pat), _prep);
-}
-
-char *kstrnstr(const char *str, const char *pat, int n, int **_prep)
-{
-	return (char*)kmemmem(str, n, pat, strlen(pat), _prep);
 }
 
 /***********************

--- a/test/test_kstring.c
+++ b/test/test_kstring.c
@@ -179,6 +179,41 @@ static int test_kputw(int64_t start, int64_t end) {
     return 0;
 }
 
+static int test_kstrstr(void) {
+    const char *hs = "haystackhaystack", *found;
+    char haystack[1025];
+    size_t i;
+    for (i = 0; i < sizeof(haystack) - 1; i += 16)
+        memcpy(&haystack[i], hs, 16);
+    haystack[i] = '\0';
+
+    found = kstrstr(haystack, "needle", NULL);
+    if (found) {
+        fprintf(stderr,
+                "Wrong result from kstrstr, expected NULL, got str + %zu\n",
+                found - haystack);
+    }
+
+    for (i = 0; i < sizeof(haystack) - 7; i++) {
+        memcpy(&haystack[i], "needle", 6);
+        found = kstrstr(haystack, "needle", NULL);
+        if (!found) {
+            fprintf(stderr,
+                    "Wrong result from kstrstr, expected str + %zd got NULL\n",
+                    i);
+            return -1;
+        }
+        if ((found - haystack) != i) {
+            fprintf(stderr,
+                    "Wrong result from kstrstr, expected str + %zd got %zd\n",
+                    i, (size_t)(found - haystack));
+            return -1;
+        }
+        memcpy(&haystack[i], hs + (i % 8), 6);
+    }
+    return 0;
+}
+
 int main(int argc, char **argv) {
     int opt, res = EXIT_SUCCESS;
     int64_t start = 0;
@@ -208,6 +243,9 @@ int main(int argc, char **argv) {
 
     if (!test || strcmp(test, "kputw") == 0)
         if (test_kputw(start, end) != 0) res = EXIT_FAILURE;
+
+    if (!test || strcmp(test, "kstrstr") == 0)
+        if (test_kstrstr() != 0) res = EXIT_FAILURE;
 
     return res;
 }


### PR DESCRIPTION
Put hts_ prefix in front of various klib functions and add wrappers to preserve the existing API.  This is so we don't get clashes with the Attarctive Chaos versions of these functions, in case anyone links against both.

Fixes #693 (Duplicate symbols with libbwa)

N.B. Breaks ABI, so `TWO_TO_THREE_TRANSITION_COUNT` needs to be incremented on merge (which should not be done as a fast-forward).