### PR TITLE
Make sam_open_mode() work with ##idx## index delimiter

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -2438,14 +2438,26 @@ double bam_auxB2f(const uint8_t *s, uint32_t idx)
     else return get_int_aux_val(s[1], s + 6, idx);
 }
 
+static int find_file_extension(const char *fn, char ext_out[5])
+{
+    const char *delim = fn ? strstr(fn, HTS_IDX_DELIM) : NULL, *ext;
+    if (!fn) return -1;
+    if (!delim) delim = fn + strlen(fn);
+    for (ext = delim; ext > fn && *ext != '.' && *ext != '/'; --ext) {}
+    if (*ext != '.' || delim - ext > 5 || delim - ext < 4) return -1;
+    memcpy(ext_out, ext + 1, delim - ext - 1);
+    ext_out[delim - ext - 1] = '\0';
+    return 0;
+}
+
 int sam_open_mode(char *mode, const char *fn, const char *format)
 {
     // TODO Parse "bam5" etc for compression level
     if (format == NULL) {
         // Try to pick a format based on the filename extension
-        const char *ext = fn? strrchr(fn, '.') : NULL;
-        if (ext == NULL || strchr(ext, '/')) return -1;
-        return sam_open_mode(mode, fn, ext+1);
+        char extension[5];
+        if (find_file_extension(fn, extension) < 0) return -1;
+        return sam_open_mode(mode, fn, extension);
     }
     else if (strcmp(format, "bam") == 0) strcpy(mode, "b");
     else if (strcmp(format, "cram") == 0) strcpy(mode, "c");
@@ -2475,12 +2487,12 @@ char *sam_open_mode_opts(const char *fn,
 
     if (format == NULL) {
         // Try to pick a format based on the filename extension
-        const char *ext = fn? strrchr(fn, '.') : NULL;
-        if (ext == NULL || strchr(ext, '/')) {
+        char extension[5];
+        if (find_file_extension(fn, extension) < 0) {
             free(mode_opts);
             return NULL;
         }
-        if (sam_open_mode(cp, fn, ext+1) == 0) {
+        if (sam_open_mode(cp, fn, extension) == 0) {
             return mode_opts;
         } else {
             free(mode_opts);


### PR DESCRIPTION
Also sam_open_mode_opts().

Makes explicitly naming an index compatible with choosing the output format by extension.