### PR TITLE
Make bgzf_useek more efficient if data is already available.

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -2275,6 +2275,13 @@ int bgzf_useek(BGZF *fp, off_t uoffset, int where)
         fp->errcode |= BGZF_ERR_MISUSE;
         return -1;
     }
+    if (uoffset >= fp->uncompressed_address - fp->block_offset &&
+        uoffset < fp->uncompressed_address + fp->block_length - fp->block_offset) {
+        // Can seek into existing data
+        fp->block_offset += uoffset - fp->uncompressed_address;
+        fp->uncompressed_address = uoffset;
+        return 0;
+    }
     if ( !fp->is_compressed )
     {
         if (hseek(fp->fp, uoffset, SEEK_SET) < 0)


### PR DESCRIPTION
Instead of always trying to seek, check to see if the desired location is within the data that has already been read.

Fixes repeated reads of the same data spotted when running tests for samtools/samtools#1066 where a test reference fasta file had lots of very small entries.  While most normal reference fastas are going to have much bigger entries in them, it's still likely that most of the seek calls that skip over the headers can actually be avoided.