### PR TITLE
Proposal: Use sam_hdr_ prefix for new header API functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -48,8 +48,8 @@ Noteworthy changes in release a.b
     to size_t, to allow for very large headers in SAM files.  The text
     and l_text fields have been left for backwards compatibility, but
     should not be accessed directly in code that uses the new header API.
-    To access the header text, the new functions bam_hdr_length() and
-    bam_hdr_str() should be used instead.
+    To access the header text, the new functions sam_hdr_length() and
+    sam_hdr_str() should be used instead.
 
   - bcf_index_load() no longer tries the '.tbi' suffix when looking for
     BCF index files (.tbi indexes are for text files, not binary BCF).

--- a/NEWS
+++ b/NEWS
@@ -54,9 +54,14 @@ Noteworthy changes in release a.b
   - bcf_index_load() no longer tries the '.tbi' suffix when looking for
     BCF index files (.tbi indexes are for text files, not binary BCF).
 
-* A new header API has been added to HTSlib, allowing header data to
-  be updated without having to parse or rewrite large parts of the header
-  text.  See htslib/sam.h for function definitions and documentation.
+* A new SAM/BAM/CRAM header API has been added to HTSlib, allowing header
+  data to be updated without having to parse or rewrite large parts of the
+  header text.  See htslib/sam.h for function definitions and documentation.
+
+  The header typedef and several pre-existing functions have been renamed
+  to have a sam_hdr_ prefix: sam_hdr_t, sam_hdr_init(), sam_hdr_destroy(),
+  and sam_hdr_dup().  (The existing bam_hdr_-prefixed names are still
+  provided for compatibility with existing code.)
 
 * SAM format reading and writing is now much faster.  Compared to revision 1.9,
   reading uncompressed SAM may be up to 100% faster; writing up to 80%.  The

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1221,7 +1221,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
     int decode_md = s->decode_md && s->ref && !has_MD && cr->ref_id >= 0;
     int decode_nm = s->decode_md && s->ref && !has_NM && cr->ref_id >= 0;
     uint32_t ds = s->data_series;
-    bam_hrecs_t *bfd = sh->hrecs;
+    sam_hrecs_t *bfd = sh->hrecs;
 
     if ((ds & CRAM_QS) && !(cf & CRAM_FLAG_PRESERVE_QUAL_SCORES)) {
         memset(qual, 255, cr->len);
@@ -2243,7 +2243,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
     int embed_ref;
     char **refs = NULL;
     uint32_t ds;
-    bam_hrecs_t *bfd = sh->hrecs;
+    sam_hrecs_t *bfd = sh->hrecs;
 
     if (cram_dependent_data_series(fd, c->comp_hdr, s) != 0)
         return -1;
@@ -2880,7 +2880,7 @@ static int cram_to_bam(sam_hdr_t *sh, cram_fd *fd, cram_slice *s,
     int name_len;
     char *aux, *aux_orig;
     char *seq, *qual;
-    bam_hrecs_t *bfd = sh->hrecs;
+    sam_hrecs_t *bfd = sh->hrecs;
 
     /* Assign names if not explicitly set */
     if (fd->required_fields & SAM_QNAME) {
@@ -3027,7 +3027,7 @@ static cram_container *cram_first_slice(cram_fd *fd) {
     if (!c->comp_hdr)
         return NULL;
     if (!c->comp_hdr->AP_delta &&
-        bam_hrecs_sort_order(fd->header->hrecs) != ORDER_COORD) {
+        sam_hrecs_sort_order(fd->header->hrecs) != ORDER_COORD) {
         pthread_mutex_lock(&fd->ref_lock);
         fd->unsorted = 1;
         pthread_mutex_unlock(&fd->ref_lock);
@@ -3155,7 +3155,7 @@ static cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
                     return NULL;
 
                 if (!c_next->comp_hdr->AP_delta &&
-                    bam_hrecs_sort_order(fd->header->hrecs) != ORDER_COORD) {
+                    sam_hrecs_sort_order(fd->header->hrecs) != ORDER_COORD) {
                     pthread_mutex_lock(&fd->ref_lock);
                     fd->unsorted = 1;
                     pthread_mutex_unlock(&fd->ref_lock);

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1204,7 +1204,7 @@ static inline void add_md_char(cram_slice *s, int decode_md, char c, int32_t *md
  * Generates the sequence, quality and cigar components.
  */
 static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
-                           cram_block *blk, cram_record *cr, bam_hdr_t *bh,
+                           cram_block *blk, cram_record *cr, sam_hdr_t *sh,
                            int cf, char *seq, char *qual,
                            int has_MD, int has_NM) {
     int prev_pos = 0, f, r = 0, out_sz = 1;
@@ -1221,7 +1221,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
     int decode_md = s->decode_md && s->ref && !has_MD && cr->ref_id >= 0;
     int decode_nm = s->decode_md && s->ref && !has_NM && cr->ref_id >= 0;
     uint32_t ds = s->data_series;
-    bam_hrecs_t *bfd = bh->hrecs;
+    bam_hrecs_t *bfd = sh->hrecs;
 
     if ((ds & CRAM_QS) && !(cf & CRAM_FLAG_PRESERVE_QUAL_SCORES)) {
         memset(qual, 255, cr->len);
@@ -2232,7 +2232,7 @@ static char *md5_print(unsigned char *md5, char *out) {
  *        -1 on failure
  */
 int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
-                      bam_hdr_t *bh) {
+                      sam_hdr_t *sh) {
     cram_block *blk = s->block[0];
     int32_t bf, ref_id;
     unsigned char cf;
@@ -2243,7 +2243,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
     int embed_ref;
     char **refs = NULL;
     uint32_t ds;
-    bam_hrecs_t *bfd = bh->hrecs;
+    bam_hrecs_t *bfd = sh->hrecs;
 
     if (cram_dependent_data_series(fd, c->comp_hdr, s) != 0)
         return -1;
@@ -2721,7 +2721,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
             }
             /* Decode sequence and generate CIGAR */
             if (ds & (CRAM_SEQ | CRAM_MQ)) {
-                r |= cram_decode_seq(fd, c, s, blk, cr, bh, cf, seq, qual,
+                r |= cram_decode_seq(fd, c, s, blk, cr, sh, cf, seq, qual,
                                      has_MD, has_NM);
                 if (r) return r;
             } else {
@@ -2810,7 +2810,7 @@ typedef struct {
     cram_fd *fd;
     cram_container *c;
     cram_slice *s;
-    bam_hdr_t *h;
+    sam_hdr_t *h;
     int exit_code;
 } cram_decode_job;
 
@@ -2826,7 +2826,7 @@ void *cram_decode_slice_thread(void *arg) {
  * Spawn a multi-threaded version of cram_decode_slice().
  */
 int cram_decode_slice_mt(cram_fd *fd, cram_container *c, cram_slice *s,
-                         bam_hdr_t *bfd) {
+                         sam_hdr_t *bfd) {
     cram_decode_job *j;
     int nonblock;
 
@@ -2873,14 +2873,14 @@ int cram_decode_slice_mt(cram_fd *fd, cram_container *c, cram_slice *s,
  * Returns the used size of the bam record on success
  *         -1 on failure.
  */
-static int cram_to_bam(bam_hdr_t *bh, cram_fd *fd, cram_slice *s,
+static int cram_to_bam(sam_hdr_t *sh, cram_fd *fd, cram_slice *s,
                        cram_record *cr, int rec, bam_seq_t **bam) {
     int bam_idx, rg_len;
     char name_a[1024], *name;
     int name_len;
     char *aux, *aux_orig;
     char *seq, *qual;
-    bam_hrecs_t *bfd = bh->hrecs;
+    bam_hrecs_t *bfd = sh->hrecs;
 
     /* Assign names if not explicitly set */
     if (fd->required_fields & SAM_QNAME) {

--- a/cram/cram_decode.h
+++ b/cram/cram_decode.h
@@ -102,7 +102,7 @@ cram_block_slice_hdr *cram_decode_slice_header(cram_fd *fd, cram_block *b);
  *        -1 on failure
  */
 int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
-                      bam_hdr_t *hdr);
+                      sam_hdr_t *hdr);
 
 
 /*

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -2864,10 +2864,10 @@ static int process_one_read(cram_fd *fd, cram_container *c,
 
     /* Read group, identified earlier */
     if (rg) {
-        bam_hrec_rg_t *brg = bam_hrecs_find_rg(fd->header->hrecs, rg);
+        sam_hrec_rg_t *brg = sam_hrecs_find_rg(fd->header->hrecs, rg);
         cr->rg = brg ? brg->id : -1;
     } else if (CRAM_MAJOR_VERS(fd->version) == 1) {
-        bam_hrec_rg_t *brg = bam_hrecs_find_rg(fd->header->hrecs, "UNKNOWN");
+        sam_hrec_rg_t *brg = sam_hrecs_find_rg(fd->header->hrecs, "UNKNOWN");
         assert(brg);
     } else {
         cr->rg = -1;

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -47,8 +47,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *-----------------------------------------------------------------------------
  * cram_fd
  */
-bam_hdr_t *cram_fd_get_header(cram_fd *fd) { return fd->header; }
-void cram_fd_set_header(cram_fd *fd, bam_hdr_t *hdr) { fd->header = hdr; }
+sam_hdr_t *cram_fd_get_header(cram_fd *fd) { return fd->header; }
+void cram_fd_set_header(cram_fd *fd, sam_hdr_t *hdr) { fd->header = hdr; }
 
 int cram_fd_get_version(cram_fd *fd) { return fd->version; }
 void cram_fd_set_version(cram_fd *fd, int vers) { fd->version = vers; }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1940,8 +1940,8 @@ int cram_set_header2(cram_fd *fd, const sam_hdr_t *hdr) {
 
     if (fd->header != hdr) {
         if (fd->header)
-            bam_hdr_destroy(fd->header);
-        fd->header = bam_hdr_dup(hdr);
+            sam_hdr_destroy(fd->header);
+        fd->header = sam_hdr_dup(hdr);
         if (!fd->header)
             return -1;
     }
@@ -3799,7 +3799,7 @@ sam_hdr_t *cram_read_SAM_hdr(cram_fd *fd) {
     }
 
     /* Parse */
-    hdr = bam_hdr_init();
+    hdr = sam_hdr_init();
     if (!hdr) {
         free(header);
         return NULL;
@@ -3807,7 +3807,7 @@ sam_hdr_t *cram_read_SAM_hdr(cram_fd *fd) {
 
     if (-1 == sam_hdr_add_lines(hdr, header, header_len)) {
         free(header);
-        bam_hdr_destroy(hdr);
+        sam_hdr_destroy(hdr);
         return NULL;
     }
 
@@ -4425,7 +4425,7 @@ int cram_close(cram_fd *fd) {
         cram_free_file_def(fd->file_def);
 
     if (fd->header)
-        bam_hdr_destroy(fd->header);
+        sam_hdr_destroy(fd->header);
 
     free(fd->prefix);
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3805,7 +3805,7 @@ bam_hdr_t *cram_read_SAM_hdr(cram_fd *fd) {
         return NULL;
     }
 
-    if (-1 == bam_hdr_add_lines(hdr, header, header_len)) {
+    if (-1 == sam_hdr_add_lines(hdr, header, header_len)) {
         free(header);
         bam_hdr_destroy(hdr);
         return NULL;
@@ -3867,7 +3867,7 @@ int cram_write_SAM_hdr(cram_fd *fd, bam_hdr_t *hdr) {
     /* 1.0 requires an UNKNOWN read-group */
     if (CRAM_MAJOR_VERS(fd->version) == 1) {
         if (!bam_hrecs_find_rg(hdr->hrecs, "UNKNOWN"))
-            if (bam_hdr_add_line(hdr, "RG",
+            if (sam_hdr_add_line(hdr, "RG",
                             "ID", "UNKNOWN", "SM", "UNKNOWN", NULL))
                 return -1;
     }
@@ -3905,21 +3905,21 @@ int cram_write_SAM_hdr(cram_fd *fd, bam_hdr_t *hdr) {
                 cram_ref_decr(fd->refs, i);
 
                 hts_md5_hex(buf2, buf);
-                if (bam_hdr_update_line(hdr, "SQ", "SN", hdr->hrecs->ref[i].name, "M5", buf2, NULL))
+                if (sam_hdr_update_line(hdr, "SQ", "SN", hdr->hrecs->ref[i].name, "M5", buf2, NULL))
                     return -1;
             }
 
             if (fd->ref_fn) {
                 char ref_fn[PATH_MAX];
                 full_path(ref_fn, fd->ref_fn);
-                if (bam_hdr_update_line(hdr, "SQ", "SN", hdr->hrecs->ref[i].name, "UR", ref_fn, NULL))
+                if (sam_hdr_update_line(hdr, "SQ", "SN", hdr->hrecs->ref[i].name, "UR", ref_fn, NULL))
                     return -1;
             }
         }
     }
 
     /* Length */
-    header_len = bam_hdr_length(hdr);
+    header_len = sam_hdr_length(hdr);
     if (header_len > INT32_MAX) {
         hts_log_error("Header is too long for CRAM format");
         return -1;
@@ -3929,7 +3929,7 @@ int cram_write_SAM_hdr(cram_fd *fd, bam_hdr_t *hdr) {
             return -1;
 
         /* Text data */
-        if (header_len != hwrite(fd->fp, bam_hdr_str(hdr), header_len))
+        if (header_len != hwrite(fd->fp, sam_hdr_str(hdr), header_len))
             return -1;
     } else {
         /* Create block(s) inside a container */
@@ -3947,7 +3947,7 @@ int cram_write_SAM_hdr(cram_fd *fd, bam_hdr_t *hdr) {
 
         int32_put_blk(b, header_len);
         if (header_len)
-            BLOCK_APPEND(b, bam_hdr_str(hdr), header_len);
+            BLOCK_APPEND(b, sam_hdr_str(hdr), header_len);
         BLOCK_UPLEN(b);
 
         // Compress header block if V3.0 and above

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1830,7 +1830,7 @@ static void sanitise_SQ_lines(cram_fd *fd) {
  */
 int refs2id(refs_t *r, sam_hdr_t *hdr) {
     int i;
-    bam_hrecs_t *h = hdr->hrecs;
+    sam_hrecs_t *h = hdr->hrecs;
 
     if (r->ref_id)
         free(r->ref_id);
@@ -1888,8 +1888,8 @@ static int refs_from_header(cram_fd *fd) {
     int i, j;
     /* Copy info from h->ref[i] over to r */
     for (i = 0, j = r->nref; i < h->hrecs->nref; i++) {
-        bam_hrec_type_t *ty;
-        bam_hrec_tag_t *tag;
+        sam_hrec_type_t *ty;
+        sam_hrec_tag_t *tag;
         khint_t k;
         int n;
 
@@ -1908,8 +1908,8 @@ static int refs_from_header(cram_fd *fd) {
         r->ref_id[j]->length = 0; // marker for not yet loaded
 
         /* Initialise likely filename if known */
-        if ((ty = bam_hrecs_find_type_id(h->hrecs, "SQ", "SN", h->hrecs->ref[i].name))) {
-            if ((tag = bam_hrecs_find_key(ty, "M5", NULL))) {
+        if ((ty = sam_hrecs_find_type_id(h->hrecs, "SQ", "SN", h->hrecs->ref[i].name))) {
+            if ((tag = sam_hrecs_find_key(ty, "M5", NULL))) {
                 r->ref_id[j]->fn = string_dup(r->pool, tag->str+3);
                 //fprintf(stderr, "Tagging @SQ %s / %s\n", r->ref_id[h]->name, r->ref_id[h]->fn);
             }
@@ -2098,8 +2098,8 @@ static unsigned get_int_threadid() {
  */
 static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
     char *ref_path = getenv("REF_PATH");
-    bam_hrec_type_t *ty;
-    bam_hrec_tag_t *tag;
+    sam_hrec_type_t *ty;
+    sam_hrec_tag_t *tag;
     char path[PATH_MAX], path_tmp[PATH_MAX + 64];
     char cache[PATH_MAX], cache_root[PATH_MAX];
     char *local_cache = getenv("REF_CACHE");
@@ -2129,10 +2129,10 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
     if (!r->name)
         return -1;
 
-    if (!(ty = bam_hrecs_find_type_id(fd->header->hrecs, "SQ", "SN", r->name)))
+    if (!(ty = sam_hrecs_find_type_id(fd->header->hrecs, "SQ", "SN", r->name)))
         return -1;
 
-    if (!(tag = bam_hrecs_find_key(ty, "M5", NULL)))
+    if (!(tag = sam_hrecs_find_key(ty, "M5", NULL)))
         goto no_M5;
 
     hts_log_info("Querying ref %s", tag->str+3);
@@ -2200,7 +2200,7 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
 
     no_M5:
         /* Failed to find in search path or M5 cache, see if @SQ UR: tag? */
-        if (!(tag = bam_hrecs_find_key(ty, "UR", NULL)))
+        if (!(tag = sam_hrecs_find_key(ty, "UR", NULL)))
             return -1;
 
         fn = (strncmp(tag->str+3, "file:", 5) == 0)
@@ -3866,7 +3866,7 @@ int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr) {
 
     /* 1.0 requires an UNKNOWN read-group */
     if (CRAM_MAJOR_VERS(fd->version) == 1) {
-        if (!bam_hrecs_find_rg(hdr->hrecs, "UNKNOWN"))
+        if (!sam_hrecs_find_rg(hdr->hrecs, "UNKNOWN"))
             if (sam_hdr_add_line(hdr, "RG",
                             "ID", "UNKNOWN", "SM", "UNKNOWN", NULL))
                 return -1;
@@ -3876,13 +3876,13 @@ int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr) {
     if (fd->refs && !fd->no_ref) {
         int i;
         for (i = 0; i < hdr->hrecs->nref; i++) {
-            bam_hrec_type_t *ty;
+            sam_hrec_type_t *ty;
             char *ref;
 
-            if (!(ty = bam_hrecs_find_type_id(hdr->hrecs, "SQ", "SN", hdr->hrecs->ref[i].name)))
+            if (!(ty = sam_hrecs_find_type_id(hdr->hrecs, "SQ", "SN", hdr->hrecs->ref[i].name)))
                 return -1;
 
-            if (!bam_hrecs_find_key(ty, "M5", NULL)) {
+            if (!sam_hrecs_find_key(ty, "M5", NULL)) {
                 char unsigned buf[16];
                 char buf2[33];
                 int rlen;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1872,7 +1872,7 @@ static int refs_from_header(cram_fd *fd) {
         return 0;
 
     if (!h->hrecs) {
-        if (-1 == bam_hdr_parse(h))
+        if (-1 == sam_hdr_fill_hrecs(h))
             return -1;
     }
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1828,9 +1828,9 @@ static void sanitise_SQ_lines(cram_fd *fd) {
  * Returns 0 on success
  *        -1 on failure
  */
-int refs2id(refs_t *r, bam_hdr_t *bh) {
+int refs2id(refs_t *r, sam_hdr_t *hdr) {
     int i;
-    bam_hrecs_t *h = bh->hrecs;
+    bam_hrecs_t *h = hdr->hrecs;
 
     if (r->ref_id)
         free(r->ref_id);
@@ -1867,7 +1867,7 @@ static int refs_from_header(cram_fd *fd) {
     if (!r)
         return -1;
 
-    bam_hdr_t *h = fd->header;
+    sam_hdr_t *h = fd->header;
     if (!h)
         return 0;
 
@@ -1934,7 +1934,7 @@ static int refs_from_header(cram_fd *fd) {
  * we have a header already constructed (eg from a file we've read
  * in).
  */
-int cram_set_header2(cram_fd *fd, const bam_hdr_t *hdr) {
+int cram_set_header2(cram_fd *fd, const sam_hdr_t *hdr) {
     if (!fd || !hdr )
         return -1;
 
@@ -1948,7 +1948,7 @@ int cram_set_header2(cram_fd *fd, const bam_hdr_t *hdr) {
     return refs_from_header(fd);
 }
 
-int cram_set_header(cram_fd *fd, bam_hdr_t *hdr) {
+int cram_set_header(cram_fd *fd, sam_hdr_t *hdr) {
     return cram_set_header2(fd, hdr);
 }
 
@@ -3692,10 +3692,10 @@ void cram_free_file_def(cram_file_def *def) {
  * Returns SAM hdr ptr on success
  *         NULL on failure
  */
-bam_hdr_t *cram_read_SAM_hdr(cram_fd *fd) {
+sam_hdr_t *cram_read_SAM_hdr(cram_fd *fd) {
     int32_t header_len;
     char *header;
-    bam_hdr_t *hdr;
+    sam_hdr_t *hdr;
 
     /* 1.1 onwards stores the header in the first block of a container */
     if (CRAM_MAJOR_VERS(fd->version) == 1) {
@@ -3852,7 +3852,7 @@ static void full_path(char *out, char *in) {
  * Returns 0 on success
  *        -1 on failure
  */
-int cram_write_SAM_hdr(cram_fd *fd, bam_hdr_t *hdr) {
+int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr) {
     size_t header_len;
     int blank_block = (CRAM_MAJOR_VERS(fd->version) >= 3);
 

--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -634,7 +634,7 @@ static inline unsigned char *append_uint64(unsigned char *cp, uint64_t i) {
  */
 int cram_load_reference(cram_fd *fd, char *fn);
 
-/*! Generates a lookup table in refs based on the SQ headers in SAM_hdr.
+/*! Generates a lookup table in refs based on the SQ headers in sam_hdr_t.
  *
  * Indexes references by the order they appear in a BAM file. This may not
  * necessarily be the same order they appear in the fasta reference file.
@@ -643,7 +643,7 @@ int cram_load_reference(cram_fd *fd, char *fn);
  * Returns 0 on success;
  *        -1 on failure
  */
-int refs2id(refs_t *r, bam_hdr_t *bfd);
+int refs2id(refs_t *r, sam_hdr_t *hdr);
 
 void refs_free(refs_t *r);
 
@@ -800,7 +800,7 @@ void cram_free_file_def(cram_file_def *def);
  * Returns SAM hdr ptr on success;
  *         NULL on failure
  */
-bam_hdr_t *cram_read_SAM_hdr(cram_fd *fd);
+sam_hdr_t *cram_read_SAM_hdr(cram_fd *fd);
 
 /*! Writes a CRAM SAM header.
  *
@@ -808,7 +808,7 @@ bam_hdr_t *cram_read_SAM_hdr(cram_fd *fd);
  * Returns 0 on success;
  *        -1 on failure
  */
-int cram_write_SAM_hdr(cram_fd *fd, bam_hdr_t *hdr);
+int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr);
 
 
 /**@}*/
@@ -896,14 +896,14 @@ int cram_set_voption(cram_fd *fd, enum hts_fmt_option opt, va_list args);
  * Attaches a header to a cram_fd.
  *
  * This should be used when creating a new cram_fd for writing where
- * we have an SAM_hdr already constructed (eg from a file we've read
+ * we have an sam_hdr_t already constructed (eg from a file we've read
  * in).
  *
  * @return
  * Returns 0 on success;
  *        -1 on failure
  */
-int cram_set_header2(cram_fd *fd, const bam_hdr_t *hdr);
+int cram_set_header2(cram_fd *fd, const sam_hdr_t *hdr);
 
 /*!
  * Returns the hFILE connected to a cram_fd.

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -679,7 +679,7 @@ typedef struct cram_fd {
     int            mode;     // 'r' or 'w'
     int            version;
     cram_file_def *file_def;
-    bam_hdr_t     *header;
+    sam_hdr_t     *header;
 
     char          *prefix;
     int64_t        record_counter;

--- a/header.c
+++ b/header.c
@@ -1688,7 +1688,7 @@ int sam_hdr_add_pg(sam_hdr_t *bh, const char *name, ...) {
 /*! Increments a reference count on bh.
  *
  * This permits multiple files to share the same header, all calling
- * bam_hdr_destroy when done, without causing errors for other open files.
+ * sam_hdr_destroy when done, without causing errors for other open files.
  */
 void sam_hdr_incr_ref(sam_hdr_t *bh) {
     if (!bh)
@@ -2120,11 +2120,11 @@ enum sam_group_order bam_hrecs_group_order(bam_hrecs_t *hrecs) {
 typedef sam_hdr_t SAM_hdr;
 
 SAM_hdr *sam_hdr_parse_(const char *hdr, size_t len) {
-    sam_hdr_t *bh = bam_hdr_init();
+    sam_hdr_t *bh = sam_hdr_init();
     if (!bh) return NULL;
 
     if (sam_hdr_add_lines(bh, hdr, len) != 0) {
-        bam_hdr_destroy(bh);
+        sam_hdr_destroy(bh);
         return NULL;
     }
 
@@ -2132,5 +2132,5 @@ SAM_hdr *sam_hdr_parse_(const char *hdr, size_t len) {
 }
 
 void sam_hdr_free(SAM_hdr *hdr) {
-    bam_hdr_destroy(hdr);
+    sam_hdr_destroy(hdr);
 }

--- a/header.c
+++ b/header.c
@@ -982,7 +982,7 @@ int sam_hdr_add_lines(sam_hdr_t *bh, const char *lines, size_t len) {
 /*
  * Adds a single line to a SAM header.
  * Specify type and one or more key,value pairs, ending with the NULL key.
- * Eg. bam_hdr_add(h, "SQ", "ID", "foo", "LN", "100", NULL).
+ * Eg. sam_hdr_add_line(h, "SQ", "ID", "foo", "LN", "100", NULL).
  *
  * Returns 0 on success
  *        -1 on failure

--- a/header.c
+++ b/header.c
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 KHASH_SET_INIT_STR(rm)
 typedef khash_t(rm) rmhash_t;
 
-static int bam_hdr_link_pg(bam_hdr_t *bh);
+static int bam_hdr_link_pg(sam_hdr_t *bh);
 
 #define MAX_ERROR_QUOTE 320 // Prevent over-long error messages
 static void bam_hrecs_error(const char *msg, const char *line, size_t len, size_t lno) {
@@ -735,11 +735,11 @@ static int bam_hrecs_parse_lines(bam_hrecs_t *hrecs, const char *hdr, size_t len
     return 0;
 }
 
-/*! Update bam_hdr_t target_name and target_len arrays
+/*! Update sam_hdr_t target_name and target_len arrays
  *
  *  @return 0 on success; -1 on failure
  */
-int update_target_arrays(bam_hdr_t *bh, const bam_hrecs_t *hrecs,
+int update_target_arrays(sam_hdr_t *bh, const bam_hrecs_t *hrecs,
                          int refs_changed) {
     if (!bh || !hrecs)
         return -1;
@@ -786,7 +786,7 @@ int update_target_arrays(bam_hdr_t *bh, const bam_hrecs_t *hrecs,
     return 0;
 }
 
-static int rebuild_target_arrays(bam_hdr_t *bh) {
+static int rebuild_target_arrays(sam_hdr_t *bh) {
     if (!bh || !bh->hrecs)
         return -1;
 
@@ -801,7 +801,7 @@ static int rebuild_target_arrays(bam_hdr_t *bh) {
     return 0;
 }
 
-int bam_hdr_parse(bam_hdr_t *bh) {
+int bam_hdr_parse(sam_hdr_t *bh) {
     bam_hrecs_t *hrecs = bam_hrecs_new();
 
     if (!hrecs)
@@ -830,7 +830,7 @@ int bam_hdr_parse(bam_hdr_t *bh) {
     This is called when API functions have changed the header so that the
     text version is no longer valid.
  */
-static void redact_header_text(bam_hdr_t *bh) {
+static void redact_header_text(sam_hdr_t *bh) {
     assert(bh->hrecs && bh->hrecs->dirty);
     bh->l_text = 0;
     free(bh->text);
@@ -878,21 +878,21 @@ static bam_hrec_type_t *bam_hrecs_find_type_pos(bam_hrecs_t *hrecs,
 
 /* ==== Public methods ==== */
 
-size_t sam_hdr_length(bam_hdr_t *bh) {
+size_t sam_hdr_length(sam_hdr_t *bh) {
     if (!bh || -1 == bam_hdr_rebuild(bh))
         return -1;
 
     return bh->l_text;
 }
 
-const char *sam_hdr_str(bam_hdr_t *bh) {
+const char *sam_hdr_str(sam_hdr_t *bh) {
     if (!bh || -1 == bam_hdr_rebuild(bh))
         return NULL;
 
     return bh->text;
 }
 
-int sam_hdr_nref(const bam_hdr_t *bh) {
+int sam_hdr_nref(const sam_hdr_t *bh) {
     if (!bh)
         return -1;
 
@@ -904,7 +904,7 @@ int sam_hdr_nref(const bam_hdr_t *bh) {
  * Returns 0 on success
  *        -1 on failure
  */
-int bam_hdr_rebuild(bam_hdr_t *bh) {
+int bam_hdr_rebuild(sam_hdr_t *bh) {
     bam_hrecs_t *hrecs;
     if (!bh)
         return -1;
@@ -952,7 +952,7 @@ int bam_hdr_rebuild(bam_hdr_t *bh) {
  * Returns 0 on success
  *        -1 on failure
  */
-int sam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len) {
+int sam_hdr_add_lines(sam_hdr_t *bh, const char *lines, size_t len) {
     bam_hrecs_t *hrecs;
 
     if (!bh || !lines)
@@ -987,7 +987,7 @@ int sam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len) {
  * Returns 0 on success
  *        -1 on failure
  */
-int sam_hdr_add_line(bam_hdr_t *bh, const char *type, ...) {
+int sam_hdr_add_line(sam_hdr_t *bh, const char *type, ...) {
     va_list args;
     bam_hrecs_t *hrecs;
 
@@ -1020,7 +1020,7 @@ int sam_hdr_add_line(bam_hdr_t *bh, const char *type, ...) {
  * combination. If ID_key is NULL then it returns the first line of the specified
  * type.
  */
-int sam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
+int sam_hdr_find_line_id(sam_hdr_t *bh, const char *type,
                       const char *ID_key, const char *ID_val, kstring_t *ks) {
     bam_hrecs_t *hrecs;
     if (!bh || !type)
@@ -1044,7 +1044,7 @@ int sam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
     return 0;
 }
 
-int sam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
+int sam_hdr_find_line_pos(sam_hdr_t *bh, const char *type,
                           int pos, kstring_t *ks) {
     bam_hrecs_t *hrecs;
     if (!bh || !type)
@@ -1078,7 +1078,7 @@ int sam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
  * Returns 0 on success and -1 on error
  */
 
-int sam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value) {
+int sam_hdr_remove_line_id(sam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value) {
     bam_hrecs_t *hrecs;
     if (!bh || !type)
         return -1;
@@ -1117,7 +1117,7 @@ int sam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, 
  * Returns 0 on success and -1 on error
  */
 
-int sam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position) {
+int sam_hdr_remove_line_pos(sam_hdr_t *bh, const char *type, int position) {
     bam_hrecs_t *hrecs;
     if (!bh || !type || position <= 0)
         return -1;
@@ -1150,7 +1150,7 @@ int sam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position) {
     return ret;
 }
 
-int sam_hdr_update_line(bam_hdr_t *bh, const char *type,
+int sam_hdr_update_line(sam_hdr_t *bh, const char *type,
         const char *ID_key, const char *ID_value, ...) {
     bam_hrecs_t *hrecs;
     if (!bh)
@@ -1178,7 +1178,7 @@ int sam_hdr_update_line(bam_hdr_t *bh, const char *type,
     return ret;
 }
 
-int sam_hdr_keep_line(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value) {
+int sam_hdr_keep_line(sam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value) {
     bam_hrecs_t *hrecs;
     if (!bh || !type)
         return -1;
@@ -1225,7 +1225,7 @@ int sam_hdr_keep_line(bam_hdr_t *bh, const char *type, const char *ID_key, const
     return 0;
 }
 
-int sam_hdr_remove_lines(bam_hdr_t *bh, const char *type, const char *id, void *h) {
+int sam_hdr_remove_lines(sam_hdr_t *bh, const char *type, const char *id, void *h) {
     bam_hrecs_t *hrecs;
     rmhash_t *rh;
     if (!bh || !type || !id || !(rh = (rmhash_t *)h))
@@ -1283,7 +1283,7 @@ int sam_hdr_remove_lines(bam_hdr_t *bh, const char *type, const char *id, void *
     return ret;
 }
 
-int sam_hdr_count_lines(bam_hdr_t *bh, const char *type) {
+int sam_hdr_count_lines(sam_hdr_t *bh, const char *type) {
     int count;
     bam_hrec_type_t *first_ty, *itr_ty;
 
@@ -1325,7 +1325,7 @@ int sam_hdr_count_lines(bam_hdr_t *bh, const char *type) {
 
 /* ==== Key:val level methods ==== */
 
-int sam_hdr_find_tag_id(bam_hdr_t *bh,
+int sam_hdr_find_tag_id(sam_hdr_t *bh,
                      const char *type,
                      const char *ID_key,
                      const char *ID_value,
@@ -1357,7 +1357,7 @@ int sam_hdr_find_tag_id(bam_hdr_t *bh,
     return 0;
 }
 
-int sam_hdr_find_tag_pos(bam_hdr_t *bh,
+int sam_hdr_find_tag_pos(sam_hdr_t *bh,
                      const char *type,
                      int pos,
                      const char *key,
@@ -1388,7 +1388,7 @@ int sam_hdr_find_tag_pos(bam_hdr_t *bh,
     return 0;
 }
 
-int sam_hdr_remove_tag_id(bam_hdr_t *bh,
+int sam_hdr_remove_tag_id(sam_hdr_t *bh,
         const char *type,
         const char *ID_key,
         const char *ID_value,
@@ -1435,7 +1435,7 @@ int bam_hrecs_rebuild_text(const bam_hrecs_t *hrecs, kstring_t *ks) {
  * Looks up a reference sequence by name and returns the numerical ID.
  * Returns -1 if unknown reference; -2 if header could not be parsed.
  */
-int sam_hdr_name2ref(bam_hdr_t *bh, const char *ref) {
+int sam_hdr_name2ref(sam_hdr_t *bh, const char *ref) {
     bam_hrecs_t *hrecs;
     khint_t k;
 
@@ -1468,7 +1468,7 @@ int sam_hdr_name2ref(bam_hdr_t *bh, const char *ref) {
  * Returns 0 on success
  *        -1 on failure (indicating broken PG/PP records)
  */
-static int bam_hdr_link_pg(bam_hdr_t *bh) {
+static int bam_hdr_link_pg(sam_hdr_t *bh) {
     bam_hrecs_t *hrecs;
     int i, j, ret = 0, *new_pg_end;
 
@@ -1541,7 +1541,7 @@ static int bam_hdr_link_pg(bam_hdr_t *bh) {
  * The value returned is valid until the next call to
  * this function.
  */
-const char *sam_hdr_pg_id(bam_hdr_t *bh, const char *name) {
+const char *sam_hdr_pg_id(sam_hdr_t *bh, const char *name) {
     bam_hrecs_t *hrecs;
     size_t name_len;
     const size_t name_extra = 17;
@@ -1592,7 +1592,7 @@ const char *sam_hdr_pg_id(bam_hdr_t *bh, const char *name) {
  * Returns 0 on success
  *        -1 on failure
  */
-int sam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...) {
+int sam_hdr_add_pg(sam_hdr_t *bh, const char *name, ...) {
     bam_hrecs_t *hrecs;
     const char *specified_id = NULL, *specified_pn = NULL, *specified_pp = NULL;
     const char *key, *val;
@@ -1690,7 +1690,7 @@ int sam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...) {
  * This permits multiple files to share the same header, all calling
  * bam_hdr_destroy when done, without causing errors for other open files.
  */
-void sam_hdr_incr_ref(bam_hdr_t *bh) {
+void sam_hdr_incr_ref(sam_hdr_t *bh) {
     if (!bh)
         return;
     bh->ref_count++;
@@ -2117,10 +2117,10 @@ enum sam_group_order bam_hrecs_group_order(bam_hrecs_t *hrecs) {
 }
 
 // Legacy functions from htslb/cram.h, included here for API compatibility.
-typedef bam_hdr_t SAM_hdr;
+typedef sam_hdr_t SAM_hdr;
 
 SAM_hdr *sam_hdr_parse_(const char *hdr, size_t len) {
-    bam_hdr_t *bh = bam_hdr_init();
+    sam_hdr_t *bh = bam_hdr_init();
     if (!bh) return NULL;
 
     if (sam_hdr_add_lines(bh, hdr, len) != 0) {

--- a/header.c
+++ b/header.c
@@ -375,7 +375,7 @@ static void bam_hrecs_global_list_add(bam_hrecs_t *hrecs,
  *
  * The purpose of the additional va_list parameter is to permit other
  * varargs functions to call this while including their own additional
- * parameters; an example is in bam_hdr_add_pg().
+ * parameters; an example is in sam_hdr_add_pg().
  *
  * Note: this function invokes va_arg at least once, making the value
  * of ap indeterminate after the return. The caller should call
@@ -878,21 +878,21 @@ static bam_hrec_type_t *bam_hrecs_find_type_pos(bam_hrecs_t *hrecs,
 
 /* ==== Public methods ==== */
 
-size_t bam_hdr_length(bam_hdr_t *bh) {
+size_t sam_hdr_length(bam_hdr_t *bh) {
     if (!bh || -1 == bam_hdr_rebuild(bh))
         return -1;
 
     return bh->l_text;
 }
 
-const char *bam_hdr_str(bam_hdr_t *bh) {
+const char *sam_hdr_str(bam_hdr_t *bh) {
     if (!bh || -1 == bam_hdr_rebuild(bh))
         return NULL;
 
     return bh->text;
 }
 
-int bam_hdr_nref(const bam_hdr_t *bh) {
+int sam_hdr_nref(const bam_hdr_t *bh) {
     if (!bh)
         return -1;
 
@@ -952,7 +952,7 @@ int bam_hdr_rebuild(bam_hdr_t *bh) {
  * Returns 0 on success
  *        -1 on failure
  */
-int bam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len) {
+int sam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len) {
     bam_hrecs_t *hrecs;
 
     if (!bh || !lines)
@@ -987,7 +987,7 @@ int bam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len) {
  * Returns 0 on success
  *        -1 on failure
  */
-int bam_hdr_add_line(bam_hdr_t *bh, const char *type, ...) {
+int sam_hdr_add_line(bam_hdr_t *bh, const char *type, ...) {
     va_list args;
     bam_hrecs_t *hrecs;
 
@@ -1020,7 +1020,7 @@ int bam_hdr_add_line(bam_hdr_t *bh, const char *type, ...) {
  * combination. If ID_key is NULL then it returns the first line of the specified
  * type.
  */
-int bam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
+int sam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
                       const char *ID_key, const char *ID_val, kstring_t *ks) {
     bam_hrecs_t *hrecs;
     if (!bh || !type)
@@ -1044,7 +1044,7 @@ int bam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
     return 0;
 }
 
-int bam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
+int sam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
                           int pos, kstring_t *ks) {
     bam_hrecs_t *hrecs;
     if (!bh || !type)
@@ -1078,7 +1078,7 @@ int bam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
  * Returns 0 on success and -1 on error
  */
 
-int bam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value) {
+int sam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value) {
     bam_hrecs_t *hrecs;
     if (!bh || !type)
         return -1;
@@ -1117,7 +1117,7 @@ int bam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, 
  * Returns 0 on success and -1 on error
  */
 
-int bam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position) {
+int sam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position) {
     bam_hrecs_t *hrecs;
     if (!bh || !type || position <= 0)
         return -1;
@@ -1150,7 +1150,7 @@ int bam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position) {
     return ret;
 }
 
-int bam_hdr_update_line(bam_hdr_t *bh, const char *type,
+int sam_hdr_update_line(bam_hdr_t *bh, const char *type,
         const char *ID_key, const char *ID_value, ...) {
     bam_hrecs_t *hrecs;
     if (!bh)
@@ -1178,7 +1178,7 @@ int bam_hdr_update_line(bam_hdr_t *bh, const char *type,
     return ret;
 }
 
-int bam_hdr_keep_line(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value) {
+int sam_hdr_keep_line(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value) {
     bam_hrecs_t *hrecs;
     if (!bh || !type)
         return -1;
@@ -1225,7 +1225,7 @@ int bam_hdr_keep_line(bam_hdr_t *bh, const char *type, const char *ID_key, const
     return 0;
 }
 
-int bam_hdr_remove_lines(bam_hdr_t *bh, const char *type, const char *id, void *h) {
+int sam_hdr_remove_lines(bam_hdr_t *bh, const char *type, const char *id, void *h) {
     bam_hrecs_t *hrecs;
     rmhash_t *rh;
     if (!bh || !type || !id || !(rh = (rmhash_t *)h))
@@ -1283,7 +1283,7 @@ int bam_hdr_remove_lines(bam_hdr_t *bh, const char *type, const char *id, void *
     return ret;
 }
 
-int bam_hdr_count_lines(bam_hdr_t *bh, const char *type) {
+int sam_hdr_count_lines(bam_hdr_t *bh, const char *type) {
     int count;
     bam_hrec_type_t *first_ty, *itr_ty;
 
@@ -1325,7 +1325,7 @@ int bam_hdr_count_lines(bam_hdr_t *bh, const char *type) {
 
 /* ==== Key:val level methods ==== */
 
-int bam_hdr_find_tag_id(bam_hdr_t *bh,
+int sam_hdr_find_tag_id(bam_hdr_t *bh,
                      const char *type,
                      const char *ID_key,
                      const char *ID_value,
@@ -1357,7 +1357,7 @@ int bam_hdr_find_tag_id(bam_hdr_t *bh,
     return 0;
 }
 
-int bam_hdr_find_tag_pos(bam_hdr_t *bh,
+int sam_hdr_find_tag_pos(bam_hdr_t *bh,
                      const char *type,
                      int pos,
                      const char *key,
@@ -1388,7 +1388,7 @@ int bam_hdr_find_tag_pos(bam_hdr_t *bh,
     return 0;
 }
 
-int bam_hdr_remove_tag_id(bam_hdr_t *bh,
+int sam_hdr_remove_tag_id(bam_hdr_t *bh,
         const char *type,
         const char *ID_key,
         const char *ID_value,
@@ -1435,7 +1435,7 @@ int bam_hrecs_rebuild_text(const bam_hrecs_t *hrecs, kstring_t *ks) {
  * Looks up a reference sequence by name and returns the numerical ID.
  * Returns -1 if unknown reference; -2 if header could not be parsed.
  */
-int bam_hdr_name2ref(bam_hdr_t *bh, const char *ref) {
+int sam_hdr_name2ref(bam_hdr_t *bh, const char *ref) {
     bam_hrecs_t *hrecs;
     khint_t k;
 
@@ -1541,7 +1541,7 @@ static int bam_hdr_link_pg(bam_hdr_t *bh) {
  * The value returned is valid until the next call to
  * this function.
  */
-const char *bam_hdr_pg_id(bam_hdr_t *bh, const char *name) {
+const char *sam_hdr_pg_id(bam_hdr_t *bh, const char *name) {
     bam_hrecs_t *hrecs;
     size_t name_len;
     const size_t name_extra = 17;
@@ -1579,20 +1579,20 @@ const char *bam_hdr_pg_id(bam_hdr_t *bh, const char *name) {
 /*
  * Add an @PG line.
  *
- * If we wish complete control over this use bam_hdr_add_line() directly. This
+ * If we wish complete control over this use sam_hdr_add_line() directly. This
  * function uses that, but attempts to do a lot of tedious house work for
  * you too.
  *
  * - It will generate a suitable ID if the supplied one clashes.
  * - It will generate multiple @PG records if we have multiple PG chains.
  *
- * Call it as per bam_hdr_add_line() with a series of key,value pairs ending
+ * Call it as per sam_hdr_add_line() with a series of key,value pairs ending
  * in NULL.
  *
  * Returns 0 on success
  *        -1 on failure
  */
-int bam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...) {
+int sam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...) {
     bam_hrecs_t *hrecs;
     const char *specified_id = NULL, *specified_pn = NULL, *specified_pp = NULL;
     const char *key, *val;
@@ -1648,7 +1648,7 @@ int bam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...) {
         memcpy(end, hrecs->pg_end, nends * sizeof(*end));
 
         for (i = 0; i < nends; i++) {
-            const char *id = !specified_id ? bam_hdr_pg_id(bh, name) : "";
+            const char *id = !specified_id ? sam_hdr_pg_id(bh, name) : "";
             if (!id) {
                 free(end);
                 return -1;
@@ -1667,7 +1667,7 @@ int bam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...) {
 
         free(end);
     } else {
-        const char *id = !specified_id ? bam_hdr_pg_id(bh, name) : "";
+        const char *id = !specified_id ? sam_hdr_pg_id(bh, name) : "";
         if (!id)
             return -1;
         va_start(args, name);
@@ -1690,7 +1690,7 @@ int bam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...) {
  * This permits multiple files to share the same header, all calling
  * bam_hdr_destroy when done, without causing errors for other open files.
  */
-void bam_hdr_incr_ref(bam_hdr_t *bh) {
+void sam_hdr_incr_ref(bam_hdr_t *bh) {
     if (!bh)
         return;
     bh->ref_count++;
@@ -2123,7 +2123,7 @@ SAM_hdr *sam_hdr_parse_(const char *hdr, size_t len) {
     bam_hdr_t *bh = bam_hdr_init();
     if (!bh) return NULL;
 
-    if (bam_hdr_add_lines(bh, hdr, len) != 0) {
+    if (sam_hdr_add_lines(bh, hdr, len) != 0) {
         bam_hdr_destroy(bh);
         return NULL;
     }
@@ -2133,12 +2133,4 @@ SAM_hdr *sam_hdr_parse_(const char *hdr, size_t len) {
 
 void sam_hdr_free(SAM_hdr *hdr) {
     bam_hdr_destroy(hdr);
-}
-
-size_t sam_hdr_length(SAM_hdr *hdr) {
-    return bam_hdr_length(hdr);
-}
-
-char *sam_hdr_str(SAM_hdr *hdr) {
-    return (char *) bam_hdr_str(hdr);
 }

--- a/header.c
+++ b/header.c
@@ -2115,22 +2115,3 @@ enum sam_group_order bam_hrecs_group_order(bam_hrecs_t *hrecs) {
 
     return go;
 }
-
-// Legacy functions from htslb/cram.h, included here for API compatibility.
-typedef sam_hdr_t SAM_hdr;
-
-SAM_hdr *sam_hdr_parse_(const char *hdr, size_t len) {
-    sam_hdr_t *bh = sam_hdr_init();
-    if (!bh) return NULL;
-
-    if (sam_hdr_add_lines(bh, hdr, len) != 0) {
-        sam_hdr_destroy(bh);
-        return NULL;
-    }
-
-    return bh;
-}
-
-void sam_hdr_free(SAM_hdr *hdr) {
-    sam_hdr_destroy(hdr);
-}

--- a/header.h
+++ b/header.h
@@ -232,7 +232,7 @@ struct bam_hrecs_t {
  * parsed representation becomes the single source of truth.
  *
  * @param bh    Header structure, previously initialised by a
- *              bam_hdr_init call
+ *              sam_hdr_init call
  * @return      0 on success, -1 on failure
  */
 int bam_hdr_parse(sam_hdr_t *bh);
@@ -262,7 +262,7 @@ bam_hrecs_t *bam_hrecs_dup(bam_hrecs_t *hrecs);
 
 /*! Update sam_hdr_t target_name and target_len arrays
  *
- *  sam_hdr_t and bam_hrecs_t are specified separately so that bam_hdr_dup
+ *  sam_hdr_t and bam_hrecs_t are specified separately so that sam_hdr_dup
  *  can use it to construct target arrays from the source header.
  *
  *  @return 0 on success; -1 on failure

--- a/header.h
+++ b/header.h
@@ -214,7 +214,7 @@ struct sam_hdr {
     int *pg_end;               //!< \@PG chain termination IDs
 
     // @cond internal
-    char *ID_buf;             // temporary buffer for bam_hdr_pg_id
+    char *ID_buf;             // temporary buffer for sam_hdr_pg_id
     uint32_t ID_buf_sz;
     int ID_cnt;
     // @endcond

--- a/header.h
+++ b/header.h
@@ -283,8 +283,6 @@ int bam_hrecs_rebuild_text(const bam_hrecs_t *hrecs, kstring_t *ks);
  * This also decrements the header reference count. If after decrementing
  * it is still non-zero then the header is assumed to be in use by another
  * caller and the free is not done.
- *
- * This is a synonym for sam_hdr_dec_ref().
  */
 void bam_hrecs_free(bam_hrecs_t *hrecs);
 

--- a/header.h
+++ b/header.h
@@ -185,7 +185,7 @@ KHASH_MAP_INIT_STR(m_s2i, int)
  * call sam_hdr_rebuild() any time the textual form needs to be
  * updated again.
  */
-struct sam_hdr {
+struct bam_hrecs_t {
     khash_t(bam_hrecs_t) *h;
     bam_hrec_type_t *first_line; //!< First line (usually @HD)
     string_alloc_t *str_pool; //!< Pool of sam_hdr_tag->str strings

--- a/header.h
+++ b/header.h
@@ -235,7 +235,7 @@ struct bam_hrecs_t {
  *              sam_hdr_init call
  * @return      0 on success, -1 on failure
  */
-int bam_hdr_parse(sam_hdr_t *bh);
+int sam_hdr_fill_hrecs(sam_hdr_t *bh);
 
 /*!
  * Reconstructs the text representation of the header from
@@ -244,7 +244,7 @@ int bam_hdr_parse(sam_hdr_t *bh);
  *
  * @return  0 on success, -1 on failure
  */
-int bam_hdr_rebuild(sam_hdr_t *bh);
+int sam_hdr_rebuild(sam_hdr_t *bh);
 
 /*! Creates an empty SAM header, ready to be populated.
  *
@@ -267,8 +267,8 @@ bam_hrecs_t *bam_hrecs_dup(bam_hrecs_t *hrecs);
  *
  *  @return 0 on success; -1 on failure
  */
-int update_target_arrays(sam_hdr_t *bh, const bam_hrecs_t *hrecs,
-                         int refs_changed);
+int sam_hdr_update_target_arrays(sam_hdr_t *bh, const bam_hrecs_t *hrecs,
+                                 int refs_changed);
 
 /*! Reconstructs a kstring from the header hash table.
  *

--- a/header.h
+++ b/header.h
@@ -235,7 +235,7 @@ struct bam_hrecs_t {
  *              bam_hdr_init call
  * @return      0 on success, -1 on failure
  */
-int bam_hdr_parse(bam_hdr_t *bh);
+int bam_hdr_parse(sam_hdr_t *bh);
 
 /*!
  * Reconstructs the text representation of the header from
@@ -244,7 +244,7 @@ int bam_hdr_parse(bam_hdr_t *bh);
  *
  * @return  0 on success, -1 on failure
  */
-int bam_hdr_rebuild(bam_hdr_t *bh);
+int bam_hdr_rebuild(sam_hdr_t *bh);
 
 /*! Creates an empty SAM header, ready to be populated.
  *
@@ -260,14 +260,14 @@ bam_hrecs_t *bam_hrecs_new(void);
  */
 bam_hrecs_t *bam_hrecs_dup(bam_hrecs_t *hrecs);
 
-/*! Update bam_hdr_t target_name and target_len arrays
+/*! Update sam_hdr_t target_name and target_len arrays
  *
- *  bam_hdr_t and bam_hrecs_t are specified separately so that bam_hdr_dup
+ *  sam_hdr_t and bam_hrecs_t are specified separately so that bam_hdr_dup
  *  can use it to construct target arrays from the source header.
  *
  *  @return 0 on success; -1 on failure
  */
-int update_target_arrays(bam_hdr_t *bh, const bam_hrecs_t *hrecs,
+int update_target_arrays(sam_hdr_t *bh, const bam_hrecs_t *hrecs,
                          int refs_changed);
 
 /*! Reconstructs a kstring from the header hash table.

--- a/header.h
+++ b/header.h
@@ -97,19 +97,19 @@ Ie SQ->ID(foo)->LN(100)
  *
  * These form a linked list and hold strings. The strings are
  * allocated from a string_alloc_t pool referenced in the master
- * bam_hrecs_t structure. Do not attempt to free, malloc or manipulate
+ * sam_hrecs_t structure. Do not attempt to free, malloc or manipulate
  * these strings directly.
  */
-typedef struct bam_hrec_tag_s {
-    struct bam_hrec_tag_s *next;
+typedef struct sam_hrec_tag_s {
+    struct sam_hrec_tag_s *next;
     char *str;
     int   len;
-} bam_hrec_tag_t;
+} sam_hrec_tag_t;
 
 /*! The parsed version of the SAM header string.
  *
  * Each header type (SQ, RG, HD, etc) points to its own sam_hdr_type
- * struct via the main hash table h in the bam_hrecs_t struct.
+ * struct via the main hash table h in the sam_hrecs_t struct.
  *
  * These in turn consist of circular bi-directional linked lists (ie
  * rings) to hold the multiple instances of the same header type
@@ -121,38 +121,38 @@ typedef struct bam_hrec_tag_s {
  * structure which holds the tokenised attributes; the tab separated
  * key:value pairs per line.
  */
-typedef struct bam_hrec_type_s {
-    struct bam_hrec_type_s *next; // circular list of this type
-    struct bam_hrec_type_s *prev; // circular list of this type
-    struct bam_hrec_type_s *global_next; // circular list of all lines
-    struct bam_hrec_type_s *global_prev; // circular list of all lines
-    bam_hrec_tag_t *tag;          // first tag
+typedef struct sam_hrec_type_s {
+    struct sam_hrec_type_s *next; // circular list of this type
+    struct sam_hrec_type_s *prev; // circular list of this type
+    struct sam_hrec_type_s *global_next; // circular list of all lines
+    struct sam_hrec_type_s *global_prev; // circular list of all lines
+    sam_hrec_tag_t *tag;          // first tag
     khint32_t type;               // Two-letter type code as an int
-} bam_hrec_type_t;
+} sam_hrec_type_t;
 
 /*! Parsed \@SQ lines */
 typedef struct {
     char *name;
     uint32_t len;
-    bam_hrec_type_t *ty;
-} bam_hrec_sq_t;
+    sam_hrec_type_t *ty;
+} sam_hrec_sq_t;
 
 /*! Parsed \@RG lines */
 typedef struct {
     char *name;
-    bam_hrec_type_t *ty;
+    sam_hrec_type_t *ty;
     int name_len;
     int id;           // numerical ID
-} bam_hrec_rg_t;
+} sam_hrec_rg_t;
 
 /*! Parsed \@PG lines */
 typedef struct {
     char *name;
-    bam_hrec_type_t *ty;
+    sam_hrec_type_t *ty;
     int name_len;
     int id;           // numerical ID
     int prev_id;      // -1 if none
-} bam_hrec_pg_t;
+} sam_hrec_pg_t;
 
 
 /*! Sort order parsed from @HD line */
@@ -170,7 +170,7 @@ enum sam_group_order {
     ORDER_REFERENCE = 1
 };
 
-KHASH_MAP_INIT_INT(bam_hrecs_t, bam_hrec_type_t*)
+KHASH_MAP_INIT_INT(sam_hrecs_t, sam_hrec_type_t*)
 KHASH_MAP_INIT_STR(m_s2i, int)
 
 /*! Primary structure for header manipulation
@@ -185,9 +185,9 @@ KHASH_MAP_INIT_STR(m_s2i, int)
  * call sam_hdr_rebuild() any time the textual form needs to be
  * updated again.
  */
-struct bam_hrecs_t {
-    khash_t(bam_hrecs_t) *h;
-    bam_hrec_type_t *first_line; //!< First line (usually @HD)
+struct sam_hrecs_t {
+    khash_t(sam_hrecs_t) *h;
+    sam_hrec_type_t *first_line; //!< First line (usually @HD)
     string_alloc_t *str_pool; //!< Pool of sam_hdr_tag->str strings
     pool_alloc_t   *type_pool;//!< Pool of sam_hdr_type structs
     pool_alloc_t   *tag_pool; //!< Pool of sam_hdr_tag structs
@@ -195,13 +195,13 @@ struct bam_hrecs_t {
     // @SQ lines / references
     int nref;                  //!< Number of \@SQ lines
     int ref_sz;                //!< Number of entries available in ref[]
-    bam_hrec_sq_t *ref;        //!< Array of parsed \@SQ lines
+    sam_hrec_sq_t *ref;        //!< Array of parsed \@SQ lines
     khash_t(m_s2i) *ref_hash;  //!< Maps SQ SN field to ref[] index
 
     // @RG lines / read-groups
     int nrg;                   //!< Number of \@RG lines
     int rg_sz;                 //!< number of entries available in rg[]
-    bam_hrec_rg_t *rg;         //!< Array of parsed \@RG lines
+    sam_hrec_rg_t *rg;         //!< Array of parsed \@RG lines
     khash_t(m_s2i) *rg_hash;   //!< Maps RG ID field to rg[] index
 
     // @PG lines / programs
@@ -209,7 +209,7 @@ struct bam_hrecs_t {
     int pg_sz;                //!< Number of entries available in pg[]
     int npg_end;               //!< Number of terminating \@PG lines
     int npg_end_alloc;         //!< Size of pg_end field
-    bam_hrec_pg_t *pg;         //!< Array of parsed \@PG lines
+    sam_hrec_pg_t *pg;         //!< Array of parsed \@PG lines
     khash_t(m_s2i) *pg_hash;   //!< Maps PG ID field to pg[] index
     int *pg_end;               //!< \@PG chain termination IDs
 
@@ -249,25 +249,25 @@ int sam_hdr_rebuild(sam_hdr_t *bh);
 /*! Creates an empty SAM header, ready to be populated.
  *
  * @return
- * Returns a bam_hrecs_t struct on success (free with bam_hrecs_free())
+ * Returns a sam_hrecs_t struct on success (free with sam_hrecs_free())
  *         NULL on failure
  */
-bam_hrecs_t *bam_hrecs_new(void);
+sam_hrecs_t *sam_hrecs_new(void);
 
 /*! Produces a duplicate copy of hrecs and returns it.
  * @return
  * Returns NULL on failure
  */
-bam_hrecs_t *bam_hrecs_dup(bam_hrecs_t *hrecs);
+sam_hrecs_t *sam_hrecs_dup(sam_hrecs_t *hrecs);
 
 /*! Update sam_hdr_t target_name and target_len arrays
  *
- *  sam_hdr_t and bam_hrecs_t are specified separately so that sam_hdr_dup
+ *  sam_hdr_t and sam_hrecs_t are specified separately so that sam_hdr_dup
  *  can use it to construct target arrays from the source header.
  *
  *  @return 0 on success; -1 on failure
  */
-int sam_hdr_update_target_arrays(sam_hdr_t *bh, const bam_hrecs_t *hrecs,
+int sam_hdr_update_target_arrays(sam_hdr_t *bh, const sam_hrecs_t *hrecs,
                                  int refs_changed);
 
 /*! Reconstructs a kstring from the header hash table.
@@ -276,15 +276,15 @@ int sam_hdr_update_target_arrays(sam_hdr_t *bh, const bam_hrecs_t *hrecs,
  * Returns 0 on success
  *        -1 on failure
  */
-int bam_hrecs_rebuild_text(const bam_hrecs_t *hrecs, kstring_t *ks);
+int sam_hrecs_rebuild_text(const sam_hrecs_t *hrecs, kstring_t *ks);
 
-/*! Deallocates all storage used by a bam_hrecs_t struct.
+/*! Deallocates all storage used by a sam_hrecs_t struct.
  *
  * This also decrements the header reference count. If after decrementing
  * it is still non-zero then the header is assumed to be in use by another
  * caller and the free is not done.
  */
-void bam_hrecs_free(bam_hrecs_t *hrecs);
+void sam_hrecs_free(sam_hrecs_t *hrecs);
 
 /*!
  * @return
@@ -293,7 +293,7 @@ void bam_hrecs_free(bam_hrecs_t *hrecs);
  *
  * Returns NULL if no type/ID is found
  */
-bam_hrec_type_t *bam_hrecs_find_type_id(bam_hrecs_t *hrecs, const char *type,
+sam_hrec_type_t *sam_hrecs_find_type_id(sam_hrecs_t *hrecs, const char *type,
                                      const char *ID_key, const char *ID_value);
 
 /*
@@ -306,14 +306,14 @@ bam_hrec_type_t *bam_hrecs_find_type_id(bam_hrecs_t *hrecs, const char *type,
  * Returns 0 on success
  *        -1 on failure
  */
-int bam_hrecs_update(bam_hrecs_t *hrecs, bam_hrec_type_t *type, va_list ap);
+int sam_hrecs_update(sam_hrecs_t *hrecs, sam_hrec_type_t *type, va_list ap);
 
-bam_hrec_tag_t *bam_hrecs_find_key(bam_hrec_type_t *type,
+sam_hrec_tag_t *sam_hrecs_find_key(sam_hrec_type_t *type,
                                    const char *key,
-                                   bam_hrec_tag_t **prev);
+                                   sam_hrec_tag_t **prev);
 
-int bam_hrecs_remove_key(bam_hrecs_t *hrecs,
-                         bam_hrec_type_t *type,
+int sam_hrecs_remove_key(sam_hrecs_t *hrecs,
+                         sam_hrec_type_t *type,
                          const char *key);
 
 /*! Looks up a read-group by name and returns a pointer to the start of the
@@ -322,13 +322,13 @@ int bam_hrecs_remove_key(bam_hrecs_t *hrecs,
  * @return
  * Returns NULL on failure
  */
-bam_hrec_rg_t *bam_hrecs_find_rg(bam_hrecs_t *hrecs, const char *rg);
+sam_hrec_rg_t *sam_hrecs_find_rg(sam_hrecs_t *hrecs, const char *rg);
 
 /*! Returns the sort order from the @HD SO: field */
-enum sam_sort_order bam_hrecs_sort_order(bam_hrecs_t *hrecs);
+enum sam_sort_order sam_hrecs_sort_order(sam_hrecs_t *hrecs);
 
 /*! Returns the group order from the @HD SO: field */
-enum sam_group_order bam_hrecs_group_order(bam_hrecs_t *hrecs);
+enum sam_group_order sam_hrecs_group_order(sam_hrecs_t *hrecs);
 
 #ifdef __cplusplus
 }

--- a/hts.c
+++ b/hts.c
@@ -975,7 +975,7 @@ int hts_close(htsFile *fp)
     }
 
     save = errno;
-    bam_hdr_destroy(fp->bam_header);
+    sam_hdr_destroy(fp->bam_header);
     hts_idx_destroy(fp->idx);
     free(fp->fn);
     free(fp->fn_aux);

--- a/htsfile.c
+++ b/htsfile.c
@@ -104,7 +104,7 @@ static void view_sam(samFile *in, const char *filename)
     }
 
  clean:
-    bam_hdr_destroy(hdr);
+    sam_hdr_destroy(hdr);
     bam_destroy1(b);
     if (out) hts_close(out);
 }

--- a/htsfile.c
+++ b/htsfile.c
@@ -68,7 +68,7 @@ static htsFile *dup_stdout(const char *mode)
 static void view_sam(samFile *in, const char *filename)
 {
     bam1_t *b = NULL;
-    bam_hdr_t *hdr = NULL;
+    sam_hdr_t *hdr = NULL;
     samFile *out = NULL;
 
     hdr = sam_hdr_read(in);

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -48,7 +48,7 @@ extern "C" {
 
 #ifndef _CRAM_STRUCTS_H_
 enum cram_block_method {
-    ERROR    = -1,
+    BM_ERROR = -1,
     RAW      = 0,
     GZIP     = 1,
     BZIP2    = 2,
@@ -439,30 +439,16 @@ static inline void sam_hdr_free(SAM_hdr *hdr) { sam_hdr_destroy(hdr); }
 
 /* sam_hdr_length() and sam_hdr_str() are now provided by sam.h. */
 
-/*! Appends a formatted line to an existing SAM header.
- *
- * Line is a full SAM header record, eg "@SQ\tSN:foo\tLN:100", with
- * optional new-line. If it contains more than 1 line then multiple lines
- * will be added in order.
- *
- * Len is the length of the text data, or 0 if unknown (in which case
- * it should be null terminated).
- *
- * @return
- * Returns 0 on success;
- *        -1 on failure
- */
-
 /*! Add an @PG line.
  *
- * If we wish complete control over this use sam_hdr_add() directly. This
+ * If we wish complete control over this use sam_hdr_add_line() directly. This
  * function uses that, but attempts to do a lot of tedious house work for
  * you too.
  *
  * - It will generate a suitable ID if the supplied one clashes.
  * - It will generate multiple @PG records if we have multiple PG chains.
  *
- * Call it as per sam_hdr_add() with a series of key,value pairs ending
+ * Call it as per sam_hdr_add_line() with a series of key,value pairs ending
  * in NULL.
  *
  * @return

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -412,9 +412,12 @@ int cram_check_EOF(cram_fd *fd);
 int int32_put_blk(cram_block *b, int32_t val);
 
 /**@}*/
-/**@{ -------------------------------------------------------------------*/
+/**@{ -------------------------------------------------------------------
+ * Old typedef and function names for compatibility with existing code.
+ * Header functionality is now provided by sam.h's sam_hdr_t functions.
+ */
 
-typedef struct bam_hdr_t SAM_hdr;
+typedef sam_hdr_t SAM_hdr;
 
 /*! Tokenises a SAM header into a hash table.
  *
@@ -424,17 +427,15 @@ typedef struct bam_hdr_t SAM_hdr;
  * Returns a SAM_hdr struct on success (free with sam_hdr_free());
  *         NULL on failure
  */
-SAM_hdr *sam_hdr_parse_(const char *hdr, size_t len);
+static inline SAM_hdr *sam_hdr_parse_(const char *hdr, size_t len) { return sam_hdr_parse(len, hdr); }
 
 /*! Deallocates all storage used by a SAM_hdr struct.
  *
  * This also decrements the header reference count. If after decrementing
  * it is still non-zero then the header is assumed to be in use by another
  * caller and the free is not done.
- *
- * This is a synonym for sam_hdr_dec_ref().
  */
-void sam_hdr_free(SAM_hdr *hdr);
+static inline void sam_hdr_free(SAM_hdr *hdr) { sam_hdr_destroy(hdr); }
 
 /* sam_hdr_length() and sam_hdr_str() are now provided by sam.h. */
 

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -40,6 +40,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <sys/types.h>
 
 #include "hts.h"
+#include "sam.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -435,19 +436,7 @@ SAM_hdr *sam_hdr_parse_(const char *hdr, size_t len);
  */
 void sam_hdr_free(SAM_hdr *hdr);
 
-/*! Returns the current length of the SAM_hdr in text form.
- *
- * Call sam_hdr_rebuild() first if editing has taken place.
- */
-#define sam_hdr_length bam_hdr_length
-//int sam_hdr_length(SAM_hdr *hdr);
-
-/*! Returns the string form of the SAM_hdr.
- *
- * Call sam_hdr_rebuild() first if editing has taken place.
- */
-#define sam_hdr_str bam_hdr_str
-//char *sam_hdr_str(SAM_hdr *hdr);
+/* sam_hdr_length() and sam_hdr_str() are now provided by sam.h. */
 
 /*! Appends a formatted line to an existing SAM header.
  *
@@ -479,7 +468,7 @@ void sam_hdr_free(SAM_hdr *hdr);
  * Returns 0 on success;
  *        -1 on failure
  */
-#define sam_hdr_add_PG bam_hdr_add_pg
+#define sam_hdr_add_PG sam_hdr_add_pg
 
 /*!
  * A function to help with construction of CL tags in @PG records.

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -89,8 +89,8 @@ struct hFILE;
  *-----------------------------------------------------------------------------
  * cram_fd
  */
-bam_hdr_t *cram_fd_get_header(cram_fd *fd);
-void cram_fd_set_header(cram_fd *fd, bam_hdr_t *hdr);
+sam_hdr_t *cram_fd_get_header(cram_fd *fd);
+void cram_fd_set_header(cram_fd *fd, sam_hdr_t *hdr);
 
 int cram_fd_get_version(cram_fd *fd);
 void cram_fd_set_version(cram_fd *fd, int vers);
@@ -394,7 +394,7 @@ int cram_set_voption(cram_fd *fd, enum hts_fmt_option opt, va_list args);
  * Returns 0 on success;
  *        -1 on failure
  */
-int cram_set_header(cram_fd *fd, bam_hdr_t *hdr);
+int cram_set_header(cram_fd *fd, sam_hdr_t *hdr);
 
 /*! Check if this file has a proper EOF block
  *

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -42,10 +42,10 @@ extern "C" {
 typedef struct BGZF BGZF;
 #define HTS_BGZF_TYPEDEF
 #endif
-struct bam_hdr_t;
 struct cram_fd;
 struct hFILE;
 struct hts_tpool;
+struct sam_hdr_t;
 
 #ifndef KSTRING_T
 #define KSTRING_T kstring_t
@@ -227,7 +227,7 @@ typedef struct {
     htsFormat format;
     hts_idx_t *idx;
     const char *fnidx;
-    struct bam_hdr_t *bam_header;
+    struct sam_hdr_t *bam_header;
 } htsFile;
 
 // A combined thread pool and queue allocation size.

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -305,7 +305,7 @@ typedef struct {
  *
  * @return  A valid pointer to new header on success, NULL on failure
  */
-sam_hdr_t *bam_hdr_init(void);
+sam_hdr_t *sam_hdr_init(void);
 
 /// Read the header from a BAM compressed file.
 /*!
@@ -331,13 +331,20 @@ int bam_hdr_write(BGZF *fp, const sam_hdr_t *h) HTS_RESULT_USED;
 /*!
  * Frees the resources associated with a header.
  */
-void bam_hdr_destroy(sam_hdr_t *h);
+void sam_hdr_destroy(sam_hdr_t *h);
 
 /// Duplicate a header structure.
 /*!
  * @return  A valid pointer to new header on success, NULL on failure
  */
-sam_hdr_t* bam_hdr_dup(const sam_hdr_t *h0);
+sam_hdr_t *sam_hdr_dup(const sam_hdr_t *h0);
+
+/*!
+ * @abstract Old names for compatibility with existing code.
+ */
+static inline sam_hdr_t *bam_hdr_init(void) { return sam_hdr_init(); }
+static inline void bam_hdr_destroy(sam_hdr_t *h) { sam_hdr_destroy(h); }
+static inline sam_hdr_t *bam_hdr_dup(const sam_hdr_t *h0) { return sam_hdr_dup(h0); }
 
 typedef htsFile samFile;
 
@@ -640,7 +647,7 @@ int sam_hdr_add_pg(sam_hdr_t *h, const char *name, ...);
 /// Increments the reference count on a header
 /*!
  * This permits multiple files to share the same header, all calling
- * bam_hdr_destroy when done, without causing errors for other open files.
+ * sam_hdr_destroy when done, without causing errors for other open files.
  */
 void sam_hdr_incr_ref(sam_hdr_t *h);
 

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -63,7 +63,7 @@ typedef struct sam_hdr bam_hrecs_t;
  @note The text and l_text fields are included for backwards compatibility.
  These fields may be set to NULL and zero respectively as a side-effect
  of calling some header API functions.  New code that needs to access the
- header text should use the bam_hdr_str() and bam_hdr_length() functions
+ header text should use the sam_hdr_str() and sam_hdr_length() functions
  instead of these fields.
  */
 
@@ -365,7 +365,7 @@ int sam_hdr_write(samFile *fp, const bam_hdr_t *h) HTS_RESULT_USED;
 /*!
  * @return  >= 0 on success, -1 on failure
  */
-size_t bam_hdr_length(bam_hdr_t *bh);
+size_t sam_hdr_length(bam_hdr_t *bh);
 
 /// Returns the text representation of the header.
 /*!
@@ -377,13 +377,13 @@ size_t bam_hdr_length(bam_hdr_t *bh);
  *
  * The caller should not attempt to free or realloc this pointer.
  */
-const char *bam_hdr_str(bam_hdr_t *bh);
+const char *sam_hdr_str(bam_hdr_t *bh);
 
 /// Returns the number of references in the header.
 /*!
  * @return  >= 0 on success, -1 on failure
  */
-int bam_hdr_nref(const bam_hdr_t *bh);
+int sam_hdr_nref(const bam_hdr_t *bh);
 
 /* ==== Line level methods ==== */
 
@@ -400,12 +400,12 @@ int bam_hdr_nref(const bam_hdr_t *bh);
  * The lines will be appended to the end of the existing header
  * (apart from HD, which always comes first).
  */
-int bam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len);
+int sam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len);
 
 /// Adds a single line to an existing header.
 /*!
  * Specify type and one or more key,value pairs, ending with the NULL key.
- * Eg. bam_hdr_add_line(h, "SQ", "ID", "foo", "LN", "100", NULL).
+ * Eg. sam_hdr_add_line(h, "SQ", "ID", "foo", "LN", "100", NULL).
  *
  * @param type  Type of the added line. Eg. "SQ"
  * @return      0 on success, -1 on failure
@@ -415,7 +415,7 @@ int bam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len);
  * given type currently exist.  The exception is HD lines, which always
  * come first.  If an HD line already exists, it will be replaced.
  */
-int bam_hdr_add_line(bam_hdr_t *bh, const char *type, ...);
+int sam_hdr_add_line(bam_hdr_t *bh, const char *type, ...);
 
 /// Returns a complete line of formatted text for a given type and ID.
 /*!
@@ -433,7 +433,7 @@ int bam_hdr_add_line(bam_hdr_t *bh, const char *type, ...);
  *
  * Any existing content in @p ks will be overwritten.
  */
-int bam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
+int sam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
                       const char *ID_key, const char *ID_val, kstring_t *ks);
 
 /// Returns a complete line of formatted text for a given type and index.
@@ -450,7 +450,7 @@ int bam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
  *
  * Any existing content in @p ks will be overwritten.
  */
-int bam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
+int sam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
                           int pos, kstring_t *ks);
 
 /// Remove a line with given type / id from a header
@@ -466,15 +466,15 @@ int bam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
  * \@SQ line is uniquely identified by the SN tag.
  * \@RG line is uniquely identified by the ID tag.
  * \@PG line is uniquely identified by the ID tag.
- * Eg. bam_hdr_remove_line_key(bh, "SQ", "SN", "ref1")
+ * Eg. sam_hdr_remove_line_key(bh, "SQ", "SN", "ref1")
  *
  * If no key:value pair is specified, the type MUST be followed by a NULL argument and
  * the first line of the type will be removed, if any.
- * Eg. bam_hdr_remove_line_key(bh, "SQ", NULL, NULL)
+ * Eg. sam_hdr_remove_line_key(bh, "SQ", NULL, NULL)
  *
  * @note Removing \@PG lines is currently unsupported.
  */
-int bam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value);
+int sam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value);
 
 /// Remove nth line of a given type from a header
 /*!
@@ -485,7 +485,7 @@ int bam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, 
  * Remove a line from the header by specifying the position in the type
  * group, i.e. 3rd @SQ line.
  */
-int bam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position);
+int sam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position);
 
 /// Add or update tag key,value pairs in a header line.
 /*!
@@ -499,9 +499,9 @@ int bam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position);
  * @HD line.
  *
  * Specify multiple key,value pairs ending in NULL. Eg.
- * bam_hdr_update_line(bh, "RG", "ID", "rg1", "DS", "description", "PG", "samtools", NULL)
+ * sam_hdr_update_line(bh, "RG", "ID", "rg1", "DS", "description", "PG", "samtools", NULL)
  */
-int bam_hdr_update_line(bam_hdr_t *bh, const char *type,
+int sam_hdr_update_line(bam_hdr_t *bh, const char *type,
         const char *ID_key, const char *ID_value, ...);
 
 /// Remove all lines of a given type from a header, except one matching an ID
@@ -514,7 +514,7 @@ int bam_hdr_update_line(bam_hdr_t *bh, const char *type,
  * Remove all lines of type <type> from the header, except the one
  * specified by tag:value, i.e. the @SQ line containing "SN:ref1".
  */
-int bam_hdr_keep_line(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value);
+int sam_hdr_keep_line(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value);
 
 /// Remove header lines of a given type, except those in a given ID set
 /*!
@@ -526,7 +526,7 @@ int bam_hdr_keep_line(bam_hdr_t *bh, const char *type, const char *ID_key, const
  * Remove all lines of type <type> from the header, except the one
  * specified in the hash set rh.
  */
-int bam_hdr_remove_lines(bam_hdr_t *bh, const char *type, const char *id, void *h);
+int sam_hdr_remove_lines(bam_hdr_t *bh, const char *type, const char *id, void *h);
 
 /// Count the number of lines for a given header type
 /*!
@@ -534,7 +534,7 @@ int bam_hdr_remove_lines(bam_hdr_t *bh, const char *type, const char *id, void *
  * @param type  Header type to count. Eg. "RG"
  * @return  Number of lines of this type on success; -1 on failure
  */
-int bam_hdr_count_lines(bam_hdr_t *bh, const char *type);
+int sam_hdr_count_lines(bam_hdr_t *bh, const char *type);
 
 /* ==== Key:val level methods ==== */
 
@@ -554,7 +554,7 @@ int bam_hdr_count_lines(bam_hdr_t *bh, const char *type);
  * and ID_value parameters.  Any pre-existing content in @p ks will be
  * overwritten.
  */
-int bam_hdr_find_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value, const char *key, kstring_t *ks);
+int sam_hdr_find_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value, const char *key, kstring_t *ks);
 
 /// Return the value associated with a key for a header line identified by position
 /*!
@@ -571,7 +571,7 @@ int bam_hdr_find_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, con
  * and @p position parameters.  Any pre-existing content in @p ks will be
  * overwritten.
  */
-int bam_hdr_find_tag_pos(bam_hdr_t *bh, const char *type, int pos, const char *key, kstring_t *ks);
+int sam_hdr_find_tag_pos(bam_hdr_t *bh, const char *type, int pos, const char *key, kstring_t *ks);
 
 /// Remove the key from the line identified by type, ID_key and ID_value.
 /*!
@@ -581,7 +581,7 @@ int bam_hdr_find_tag_pos(bam_hdr_t *bh, const char *type, int pos, const char *k
  * @param key       Key of the targeted tag. Eg. "M5"
  * @return          1 if the key was removed; 0 if it was not present; -1 on error
  */
-int bam_hdr_remove_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value, const char *key);
+int sam_hdr_remove_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value, const char *key);
 
 /// Get the target id for a given reference sequence name
 /*!
@@ -593,16 +593,16 @@ int bam_hdr_remove_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, c
  * Looks up a reference sequence by name in the reference hash table
  * and returns the numerical target id.
  */
-int bam_hdr_name2ref(bam_hdr_t *bh, const char *ref);
+int sam_hdr_name2ref(bam_hdr_t *bh, const char *ref);
 
-/// Alias of bam_hdr_name2ref(), for backwards compatibility.
+/// Alias of sam_hdr_name2ref(), for backwards compatibility.
 /*!
  * @param ref  Reference name
  * @return     Positive value on success,
  *             -1 if unknown reference,
  *             -2 if the header could not be parsed
  */
-static inline int bam_name2id(bam_hdr_t *h, const char *ref) { return bam_hdr_name2ref(h, ref); }
+static inline int bam_name2id(bam_hdr_t *h, const char *ref) { return sam_hdr_name2ref(h, ref); }
 
 /// Generate a unique \@PG ID: value
 /*!
@@ -613,44 +613,44 @@ static inline int bam_name2id(bam_hdr_t *h, const char *ref) { return bam_hdr_na
  * valid until the next call to this function, or the header is destroyed.
  * The caller should not attempt to free() or realloc() it.
  */
-const char *bam_hdr_pg_id(bam_hdr_t *bh, const char *name);
+const char *sam_hdr_pg_id(bam_hdr_t *bh, const char *name);
 
 /// Add an \@PG line.
 /*!
  * @param name  Name of the program. Eg. samtools
  * @return      0 on success, -1 on failure
  *
- * If we wish complete control over this use bam_hdr_add_line() directly. This
+ * If we wish complete control over this use sam_hdr_add_line() directly. This
  * function uses that, but attempts to do a lot of tedious house work for
  * you too.
  *
  * - It will generate a suitable ID if the supplied one clashes.
  * - It will generate multiple \@PG records if we have multiple PG chains.
  *
- * Call it as per bam_hdr_add_line() with a series of key,value pairs ending
+ * Call it as per sam_hdr_add_line() with a series of key,value pairs ending
  * in NULL.
  */
-int bam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...);
+int sam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...);
 
 /// Increments the reference count on a header
 /*!
  * This permits multiple files to share the same header, all calling
  * bam_hdr_destroy when done, without causing errors for other open files.
  */
-void bam_hdr_incr_ref(bam_hdr_t *bh);
+void sam_hdr_incr_ref(bam_hdr_t *bh);
 
 /*
  * Macros for changing the \@HD line. They eliminate the need to use NULL method arguments.
  */
 
 /// Returns the SAM formatted text of the \@HD header line
-#define bam_hdr_find_hd(h, ks) bam_hdr_find_line_id((h), "HD", NULL, NULL, (ks))
+#define sam_hdr_find_hd(h, ks) sam_hdr_find_line_id((h), "HD", NULL, NULL, (ks))
 /// Returns the value associated with a given \@HD line tag
-#define bam_hdr_find_tag_hd(h, key, ks) bam_hdr_find_tag_id((h), "HD", NULL, NULL, (key), (ks))
+#define sam_hdr_find_tag_hd(h, key, ks) sam_hdr_find_tag_id((h), "HD", NULL, NULL, (key), (ks))
 /// Adds or updates tags on the header \@HD line
-#define bam_hdr_update_hd(h, ...) bam_hdr_update_line((h), "HD", NULL, NULL, __VA_ARGS__, NULL)
+#define sam_hdr_update_hd(h, ...) sam_hdr_update_line((h), "HD", NULL, NULL, __VA_ARGS__, NULL)
 /// Removes the \@HD line tag with the given key
-#define bam_hdr_remove_tag_hd(h, key) bam_hdr_remove_tag_id((h), "HD", NULL, NULL, (key))
+#define sam_hdr_remove_tag_hd(h, key) sam_hdr_remove_tag_id((h), "HD", NULL, NULL, (key))
 
 /* Alignment */
 

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -466,11 +466,11 @@ int sam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
  * \@SQ line is uniquely identified by the SN tag.
  * \@RG line is uniquely identified by the ID tag.
  * \@PG line is uniquely identified by the ID tag.
- * Eg. sam_hdr_remove_line_key(bh, "SQ", "SN", "ref1")
+ * Eg. sam_hdr_remove_line_id(bh, "SQ", "SN", "ref1")
  *
  * If no key:value pair is specified, the type MUST be followed by a NULL argument and
  * the first line of the type will be removed, if any.
- * Eg. sam_hdr_remove_line_key(bh, "SQ", NULL, NULL)
+ * Eg. sam_hdr_remove_line_id(bh, "SQ", NULL, NULL)
  *
  * @note Removing \@PG lines is currently unsupported.
  */

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -46,7 +46,7 @@ extern "C" {
  *  of hash tables that contain the parsed header data.
  */
 
-typedef struct sam_hdr bam_hrecs_t;
+typedef struct bam_hrecs_t bam_hrecs_t;
 
 /*! @typedef
  @abstract Structure for the alignment header.

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -46,7 +46,7 @@ extern "C" {
  *  of hash tables that contain the parsed header data.
  */
 
-typedef struct bam_hrecs_t bam_hrecs_t;
+typedef struct sam_hrecs_t sam_hrecs_t;
 
 /*! @typedef
  @abstract Structure for the alignment header.
@@ -75,7 +75,7 @@ typedef struct sam_hdr_t {
     char **target_name;
     char *text;
     void *sdict HTS_DEPRECATED("Unused since 1.10");
-    bam_hrecs_t *hrecs;
+    sam_hrecs_t *hrecs;
     uint32_t ref_count;
 } sam_hdr_t;
 

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -37,9 +37,9 @@ extern "C" {
 /// Highest SAM format version supported by this library
 #define SAM_FORMAT_VERSION "1.6"
 
-/**********************
+/***************************
  *** SAM/BAM/CRAM header ***
- **********************/
+ ***************************/
 
 /*! @typedef
  * @abstract Header extension structure, grouping a collection
@@ -67,7 +67,7 @@ typedef struct bam_hrecs_t bam_hrecs_t;
  instead of these fields.
  */
 
-typedef struct bam_hdr_t {
+typedef struct sam_hdr_t {
     int32_t n_targets, ignore_sam_err;
     size_t l_text;
     uint32_t *target_len;
@@ -77,7 +77,12 @@ typedef struct bam_hdr_t {
     void *sdict HTS_DEPRECATED("Unused since 1.10");
     bam_hrecs_t *hrecs;
     uint32_t ref_count;
-} bam_hdr_t;
+} sam_hdr_t;
+
+/*! @typedef
+ * @abstract Old name for compatibility with existing code.
+ */
+typedef sam_hdr_t bam_hdr_t;
 
 /****************************
  *** CIGAR related macros ***
@@ -160,7 +165,7 @@ typedef struct bam_hdr_t {
 
 /*! @typedef
  @abstract Structure for core alignment information.
- @field  tid     chromosome ID, defined by bam_hdr_t
+ @field  tid     chromosome ID, defined by sam_hdr_t
  @field  pos     0-based leftmost coordinate
  @field  bin     bin calculated by bam_reg2bin()
  @field  qual    mapping quality
@@ -169,7 +174,7 @@ typedef struct bam_hdr_t {
  @field  l_extranul length of extra NULs between qname & cigar (for alignment)
  @field  n_cigar number of CIGAR operations
  @field  l_qseq  length of the query sequence (read)
- @field  mtid    chromosome ID of next read in template, defined by bam_hdr_t
+ @field  mtid    chromosome ID of next read in template, defined by sam_hdr_t
  @field  mpos    0-based leftmost coordinate of next read in template
  */
 typedef struct {
@@ -300,7 +305,7 @@ typedef struct {
  *
  * @return  A valid pointer to new header on success, NULL on failure
  */
-bam_hdr_t *bam_hdr_init(void);
+sam_hdr_t *bam_hdr_init(void);
 
 /// Read the header from a BAM compressed file.
 /*!
@@ -310,7 +315,7 @@ bam_hdr_t *bam_hdr_init(void);
  * This function only works with BAM files.  It is usually better to use
  * sam_hdr_read(), which works on SAM, BAM and CRAM files.
  */
-bam_hdr_t *bam_hdr_read(BGZF *fp);
+sam_hdr_t *bam_hdr_read(BGZF *fp);
 
 /// Writes the header to a BAM file.
 /*!
@@ -321,18 +326,18 @@ bam_hdr_t *bam_hdr_read(BGZF *fp);
  * This function only works with BAM files.  Use sam_hdr_write() to
  * write in any of the SAM, BAM or CRAM formats.
  */
-int bam_hdr_write(BGZF *fp, const bam_hdr_t *h) HTS_RESULT_USED;
+int bam_hdr_write(BGZF *fp, const sam_hdr_t *h) HTS_RESULT_USED;
 
 /*!
  * Frees the resources associated with a header.
  */
-void bam_hdr_destroy(bam_hdr_t *h);
+void bam_hdr_destroy(sam_hdr_t *h);
 
 /// Duplicate a header structure.
 /*!
  * @return  A valid pointer to new header on success, NULL on failure
  */
-bam_hdr_t* bam_hdr_dup(const bam_hdr_t *h0);
+sam_hdr_t* bam_hdr_dup(const sam_hdr_t *h0);
 
 typedef htsFile samFile;
 
@@ -340,18 +345,18 @@ typedef htsFile samFile;
 /*!
  * @param l_text    Length of text
  * @param text      Header text
- * @return A populated bam_hdr_t structure on success; NULL on failure.
+ * @return A populated sam_hdr_t structure on success; NULL on failure.
  * @note The text field of the returned header will be NULL, and the l_text
  * field will be zero.
  */
-bam_hdr_t *sam_hdr_parse(size_t l_text, const char *text);
+sam_hdr_t *sam_hdr_parse(size_t l_text, const char *text);
 
 /// Read a header from a SAM, BAM or CRAM file.
 /*!
  * @param fp    Pointer to a SAM, BAM or CRAM file handle
- * @return  A populated bam_hdr_t struct on success; NULL on failure.
+ * @return  A populated sam_hdr_t struct on success; NULL on failure.
  */
-bam_hdr_t *sam_hdr_read(samFile *fp);
+sam_hdr_t *sam_hdr_read(samFile *fp);
 
 /// Write a header to a SAM, BAM or CRAM file.
 /*!
@@ -359,13 +364,13 @@ bam_hdr_t *sam_hdr_read(samFile *fp);
  * @param h     Header structure to write
  * @return  0 on success; -1 on failure
  */
-int sam_hdr_write(samFile *fp, const bam_hdr_t *h) HTS_RESULT_USED;
+int sam_hdr_write(samFile *fp, const sam_hdr_t *h) HTS_RESULT_USED;
 
 /// Returns the current length of the header text.
 /*!
  * @return  >= 0 on success, -1 on failure
  */
-size_t sam_hdr_length(bam_hdr_t *bh);
+size_t sam_hdr_length(sam_hdr_t *h);
 
 /// Returns the text representation of the header.
 /*!
@@ -377,13 +382,13 @@ size_t sam_hdr_length(bam_hdr_t *bh);
  *
  * The caller should not attempt to free or realloc this pointer.
  */
-const char *sam_hdr_str(bam_hdr_t *bh);
+const char *sam_hdr_str(sam_hdr_t *h);
 
 /// Returns the number of references in the header.
 /*!
  * @return  >= 0 on success, -1 on failure
  */
-int sam_hdr_nref(const bam_hdr_t *bh);
+int sam_hdr_nref(const sam_hdr_t *h);
 
 /* ==== Line level methods ==== */
 
@@ -400,7 +405,7 @@ int sam_hdr_nref(const bam_hdr_t *bh);
  * The lines will be appended to the end of the existing header
  * (apart from HD, which always comes first).
  */
-int sam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len);
+int sam_hdr_add_lines(sam_hdr_t *h, const char *lines, size_t len);
 
 /// Adds a single line to an existing header.
 /*!
@@ -415,7 +420,7 @@ int sam_hdr_add_lines(bam_hdr_t *bh, const char *lines, size_t len);
  * given type currently exist.  The exception is HD lines, which always
  * come first.  If an HD line already exists, it will be replaced.
  */
-int sam_hdr_add_line(bam_hdr_t *bh, const char *type, ...);
+int sam_hdr_add_line(sam_hdr_t *h, const char *type, ...);
 
 /// Returns a complete line of formatted text for a given type and ID.
 /*!
@@ -433,7 +438,7 @@ int sam_hdr_add_line(bam_hdr_t *bh, const char *type, ...);
  *
  * Any existing content in @p ks will be overwritten.
  */
-int sam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
+int sam_hdr_find_line_id(sam_hdr_t *h, const char *type,
                       const char *ID_key, const char *ID_val, kstring_t *ks);
 
 /// Returns a complete line of formatted text for a given type and index.
@@ -450,7 +455,7 @@ int sam_hdr_find_line_id(bam_hdr_t *bh, const char *type,
  *
  * Any existing content in @p ks will be overwritten.
  */
-int sam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
+int sam_hdr_find_line_pos(sam_hdr_t *h, const char *type,
                           int pos, kstring_t *ks);
 
 /// Remove a line with given type / id from a header
@@ -466,15 +471,15 @@ int sam_hdr_find_line_pos(bam_hdr_t *bh, const char *type,
  * \@SQ line is uniquely identified by the SN tag.
  * \@RG line is uniquely identified by the ID tag.
  * \@PG line is uniquely identified by the ID tag.
- * Eg. sam_hdr_remove_line_id(bh, "SQ", "SN", "ref1")
+ * Eg. sam_hdr_remove_line_id(h, "SQ", "SN", "ref1")
  *
  * If no key:value pair is specified, the type MUST be followed by a NULL argument and
  * the first line of the type will be removed, if any.
- * Eg. sam_hdr_remove_line_id(bh, "SQ", NULL, NULL)
+ * Eg. sam_hdr_remove_line_id(h, "SQ", NULL, NULL)
  *
  * @note Removing \@PG lines is currently unsupported.
  */
-int sam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value);
+int sam_hdr_remove_line_id(sam_hdr_t *h, const char *type, const char *ID_key, const char *ID_value);
 
 /// Remove nth line of a given type from a header
 /*!
@@ -485,7 +490,7 @@ int sam_hdr_remove_line_id(bam_hdr_t *bh, const char *type, const char *ID_key, 
  * Remove a line from the header by specifying the position in the type
  * group, i.e. 3rd @SQ line.
  */
-int sam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position);
+int sam_hdr_remove_line_pos(sam_hdr_t *h, const char *type, int position);
 
 /// Add or update tag key,value pairs in a header line.
 /*!
@@ -499,9 +504,9 @@ int sam_hdr_remove_line_pos(bam_hdr_t *bh, const char *type, int position);
  * @HD line.
  *
  * Specify multiple key,value pairs ending in NULL. Eg.
- * sam_hdr_update_line(bh, "RG", "ID", "rg1", "DS", "description", "PG", "samtools", NULL)
+ * sam_hdr_update_line(h, "RG", "ID", "rg1", "DS", "description", "PG", "samtools", NULL)
  */
-int sam_hdr_update_line(bam_hdr_t *bh, const char *type,
+int sam_hdr_update_line(sam_hdr_t *h, const char *type,
         const char *ID_key, const char *ID_value, ...);
 
 /// Remove all lines of a given type from a header, except one matching an ID
@@ -514,27 +519,27 @@ int sam_hdr_update_line(bam_hdr_t *bh, const char *type,
  * Remove all lines of type <type> from the header, except the one
  * specified by tag:value, i.e. the @SQ line containing "SN:ref1".
  */
-int sam_hdr_keep_line(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value);
+int sam_hdr_keep_line(sam_hdr_t *h, const char *type, const char *ID_key, const char *ID_value);
 
 /// Remove header lines of a given type, except those in a given ID set
 /*!
  * @param type  Type of the searched line. Eg. "RG"
  * @param id    Tag key defining the line. Eg. "ID"
- * @param h     Hash set initialised by the caller with the values to be kept.
+ * @param rh    Hash set initialised by the caller with the values to be kept.
  * @return      0 on success, -1 on failure
  *
  * Remove all lines of type <type> from the header, except the one
  * specified in the hash set rh.
  */
-int sam_hdr_remove_lines(bam_hdr_t *bh, const char *type, const char *id, void *h);
+int sam_hdr_remove_lines(sam_hdr_t *h, const char *type, const char *id, void *rh);
 
 /// Count the number of lines for a given header type
 /*!
- * @param bh    BAM header
+ * @param h     BAM header
  * @param type  Header type to count. Eg. "RG"
  * @return  Number of lines of this type on success; -1 on failure
  */
-int sam_hdr_count_lines(bam_hdr_t *bh, const char *type);
+int sam_hdr_count_lines(sam_hdr_t *h, const char *type);
 
 /* ==== Key:val level methods ==== */
 
@@ -554,7 +559,7 @@ int sam_hdr_count_lines(bam_hdr_t *bh, const char *type);
  * and ID_value parameters.  Any pre-existing content in @p ks will be
  * overwritten.
  */
-int sam_hdr_find_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value, const char *key, kstring_t *ks);
+int sam_hdr_find_tag_id(sam_hdr_t *h, const char *type, const char *ID_key, const char *ID_value, const char *key, kstring_t *ks);
 
 /// Return the value associated with a key for a header line identified by position
 /*!
@@ -571,7 +576,7 @@ int sam_hdr_find_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, con
  * and @p position parameters.  Any pre-existing content in @p ks will be
  * overwritten.
  */
-int sam_hdr_find_tag_pos(bam_hdr_t *bh, const char *type, int pos, const char *key, kstring_t *ks);
+int sam_hdr_find_tag_pos(sam_hdr_t *h, const char *type, int pos, const char *key, kstring_t *ks);
 
 /// Remove the key from the line identified by type, ID_key and ID_value.
 /*!
@@ -581,7 +586,7 @@ int sam_hdr_find_tag_pos(bam_hdr_t *bh, const char *type, int pos, const char *k
  * @param key       Key of the targeted tag. Eg. "M5"
  * @return          1 if the key was removed; 0 if it was not present; -1 on error
  */
-int sam_hdr_remove_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, const char *ID_value, const char *key);
+int sam_hdr_remove_tag_id(sam_hdr_t *h, const char *type, const char *ID_key, const char *ID_value, const char *key);
 
 /// Get the target id for a given reference sequence name
 /*!
@@ -593,7 +598,7 @@ int sam_hdr_remove_tag_id(bam_hdr_t *bh, const char *type, const char *ID_key, c
  * Looks up a reference sequence by name in the reference hash table
  * and returns the numerical target id.
  */
-int sam_hdr_name2ref(bam_hdr_t *bh, const char *ref);
+int sam_hdr_name2ref(sam_hdr_t *h, const char *ref);
 
 /// Alias of sam_hdr_name2ref(), for backwards compatibility.
 /*!
@@ -602,7 +607,7 @@ int sam_hdr_name2ref(bam_hdr_t *bh, const char *ref);
  *             -1 if unknown reference,
  *             -2 if the header could not be parsed
  */
-static inline int bam_name2id(bam_hdr_t *h, const char *ref) { return sam_hdr_name2ref(h, ref); }
+static inline int bam_name2id(sam_hdr_t *h, const char *ref) { return sam_hdr_name2ref(h, ref); }
 
 /// Generate a unique \@PG ID: value
 /*!
@@ -613,7 +618,7 @@ static inline int bam_name2id(bam_hdr_t *h, const char *ref) { return sam_hdr_na
  * valid until the next call to this function, or the header is destroyed.
  * The caller should not attempt to free() or realloc() it.
  */
-const char *sam_hdr_pg_id(bam_hdr_t *bh, const char *name);
+const char *sam_hdr_pg_id(sam_hdr_t *h, const char *name);
 
 /// Add an \@PG line.
 /*!
@@ -630,14 +635,14 @@ const char *sam_hdr_pg_id(bam_hdr_t *bh, const char *name);
  * Call it as per sam_hdr_add_line() with a series of key,value pairs ending
  * in NULL.
  */
-int sam_hdr_add_pg(bam_hdr_t *bh, const char *name, ...);
+int sam_hdr_add_pg(sam_hdr_t *h, const char *name, ...);
 
 /// Increments the reference count on a header
 /*!
  * This permits multiple files to share the same header, all calling
  * bam_hdr_destroy when done, without causing errors for other open files.
  */
-void sam_hdr_incr_ref(bam_hdr_t *bh);
+void sam_hdr_incr_ref(sam_hdr_t *h);
 
 /*
  * Macros for changing the \@HD line. They eliminate the need to use NULL method arguments.
@@ -707,7 +712,7 @@ char *bam_flag2str(int flag);   /** The string must be freed by the user */
     @note This must be called after the header has been written, but before
           any other data.
 */
-int sam_idx_init(htsFile *fp, bam_hdr_t *h, int min_shift, const char *fnidx);
+int sam_idx_init(htsFile *fp, sam_hdr_t *h, int min_shift, const char *fnidx);
 
 /// Writes the index initialised with sam_idx_init to disk.
 /** @param fp        File handle for the data file being written.
@@ -824,7 +829,7 @@ The form `REF:` should be used when the reference name itself contains a colon.
 
 Note that SAM files must be bgzf-compressed for iterators to work.
  */
-hts_itr_t *sam_itr_querys(const hts_idx_t *idx, bam_hdr_t *hdr, const char *region);
+hts_itr_t *sam_itr_querys(const hts_idx_t *idx, sam_hdr_t *hdr, const char *region);
 
 /// Create a multi-region iterator
 /** @param idx       Index
@@ -840,7 +845,7 @@ in.
 The iterator will return all reads overlapping the given regions.  If a read
 overlaps more than one region, it will only be returned once.
  */
-hts_itr_t *sam_itr_regions(const hts_idx_t *idx, bam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount);
+hts_itr_t *sam_itr_regions(const hts_idx_t *idx, sam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount);
 
 /// Create a multi-region iterator
 /** @param idx       Index
@@ -866,7 +871,7 @@ The form `REF:` should be used when the reference name itself contains a colon.
 The iterator will return all reads overlapping the given regions.  If a read
 overlaps more than one region, it will only be returned once.
  */
-hts_itr_t *sam_itr_regarray(const hts_idx_t *idx, bam_hdr_t *hdr, char **regarray, unsigned int regcount);
+hts_itr_t *sam_itr_regarray(const hts_idx_t *idx, sam_hdr_t *hdr, char **regarray, unsigned int regcount);
 
 /// Get the next read from a SAM/BAM/CRAM iterator
 /** @param htsfp       Htsfile pointer for the input file
@@ -898,7 +903,7 @@ static inline int sam_itr_next(htsFile *htsfp, hts_itr_t *itr, bam1_t *r) {
  */
 #define sam_itr_multi_next(htsfp, itr, r) sam_itr_next(htsfp, itr, r)
 
-const char *sam_parse_region(bam_hdr_t *h, const char *s, int *tid, int64_t *beg, int64_t *end, int flags);
+const char *sam_parse_region(sam_hdr_t *h, const char *s, int *tid, int64_t *beg, int64_t *end, int flags);
 
     /***************
      *** SAM I/O ***
@@ -917,10 +922,10 @@ const char *sam_parse_region(bam_hdr_t *h, const char *s, int *tid, int64_t *beg
                              const char *mode,
                              const char *format);
 
-    int sam_hdr_change_HD(bam_hdr_t *h, const char *key, const char *val);
+    int sam_hdr_change_HD(sam_hdr_t *h, const char *key, const char *val);
 
-    int sam_parse1(kstring_t *s, bam_hdr_t *h, bam1_t *b) HTS_RESULT_USED;
-    int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str) HTS_RESULT_USED;
+    int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b) HTS_RESULT_USED;
+    int sam_format1(const sam_hdr_t *h, const bam1_t *b, kstring_t *str) HTS_RESULT_USED;
 
 /// sam_read1 - Read a record from a file
 /** @param fp   Pointer to the source file
@@ -928,14 +933,14 @@ const char *sam_parse_region(bam_hdr_t *h, const char *s, int *tid, int64_t *beg
  *  @param b    Pointer to the record placeholder
  *  @return >= 0 on successfully reading a new record, -1 on end of stream, < -1 on error
  */
-    int sam_read1(samFile *fp, bam_hdr_t *h, bam1_t *b) HTS_RESULT_USED;
+    int sam_read1(samFile *fp, sam_hdr_t *h, bam1_t *b) HTS_RESULT_USED;
 /// sam_write1 - Write a record to a file
 /** @param fp    Pointer to the destination file
  *  @param h     Pointer to the header structure previously read
  *  @param b     Pointer to the record to be written
  *  @return >= 0 on successfully writing the record, -1 on error
  */
-    int sam_write1(samFile *fp, const bam_hdr_t *h, const bam1_t *b) HTS_RESULT_USED;
+    int sam_write1(samFile *fp, const sam_hdr_t *h, const bam1_t *b) HTS_RESULT_USED;
 
     /*************************************
      *** Manipulating auxiliary fields ***

--- a/htslib_vars.mk
+++ b/htslib_vars.mk
@@ -26,7 +26,7 @@
 # See htslib.mk for details.
 
 htslib_bgzf_h = $(HTSPREFIX)htslib/bgzf.h $(htslib_hts_defs_h)
-htslib_cram_h = $(HTSPREFIX)htslib/cram.h $(htslib_hts_h)
+htslib_cram_h = $(HTSPREFIX)htslib/cram.h $(htslib_hts_h) $(htslib_sam_h)
 htslib_faidx_h = $(HTSPREFIX)htslib/faidx.h $(htslib_hts_defs_h)
 htslib_hfile_h = $(HTSPREFIX)htslib/hfile.h $(htslib_hts_defs_h)
 htslib_hts_h = $(HTSPREFIX)htslib/hts.h $(htslib_hts_defs_h) $(htslib_hts_log_h)

--- a/sam.c
+++ b/sam.c
@@ -1061,7 +1061,15 @@ hts_itr_t *sam_itr_regions(const hts_idx_t *idx, sam_hdr_t *hdr, hts_reglist_t *
 
 sam_hdr_t *sam_hdr_parse(size_t l_text, const char *text)
 {
-    return sam_hdr_parse_(text, l_text);
+    sam_hdr_t *bh = sam_hdr_init();
+    if (!bh) return NULL;
+
+    if (sam_hdr_add_lines(bh, text, l_text) != 0) {
+        sam_hdr_destroy(bh);
+        return NULL;
+    }
+
+    return bh;
 }
 
 // Minimal sanitisation of a header to ensure.

--- a/sam.c
+++ b/sam.c
@@ -63,14 +63,14 @@ static int8_t *cigar_tab_init() {
     return cigar_tab;
 }
 
-bam_hdr_t *bam_hdr_init()
+sam_hdr_t *bam_hdr_init()
 {
-    bam_hdr_t *bh = (bam_hdr_t*)calloc(1, sizeof(bam_hdr_t));
+    sam_hdr_t *bh = (sam_hdr_t*)calloc(1, sizeof(sam_hdr_t));
 
     return bh;
 }
 
-void bam_hdr_destroy(bam_hdr_t *bh)
+void bam_hdr_destroy(sam_hdr_t *bh)
 {
     int32_t i;
 
@@ -92,10 +92,10 @@ void bam_hdr_destroy(bam_hdr_t *bh)
     free(bh);
 }
 
-bam_hdr_t *bam_hdr_dup(const bam_hdr_t *h0)
+sam_hdr_t *bam_hdr_dup(const sam_hdr_t *h0)
 {
     if (h0 == NULL) return NULL;
-    bam_hdr_t *h;
+    sam_hdr_t *h;
     if ((h = bam_hdr_init()) == NULL) return NULL;
     // copy the simple data
     h->n_targets = 0;
@@ -147,9 +147,9 @@ bam_hdr_t *bam_hdr_dup(const bam_hdr_t *h0)
     return NULL;
 }
 
-bam_hdr_t *bam_hdr_read(BGZF *fp)
+sam_hdr_t *bam_hdr_read(BGZF *fp)
 {
-    bam_hdr_t *h;
+    sam_hdr_t *h;
     uint8_t buf[4];
     int magic_len, has_EOF;
     int32_t i, name_len, num_names = 0;
@@ -255,7 +255,7 @@ bam_hdr_t *bam_hdr_read(BGZF *fp)
     return NULL;
 }
 
-int bam_hdr_write(BGZF *fp, const bam_hdr_t *h)
+int bam_hdr_write(BGZF *fp, const sam_hdr_t *h)
 {
     int32_t i, name_len, x;
     kstring_t hdr_ks = { 0, 0, NULL };
@@ -322,7 +322,7 @@ int bam_hdr_write(BGZF *fp, const bam_hdr_t *h)
     return 0;
 }
 
-const char *sam_parse_region(bam_hdr_t *h, const char *s, int *tid, int64_t *beg, int64_t *end, int flags) {
+const char *sam_parse_region(sam_hdr_t *h, const char *s, int *tid, int64_t *beg, int64_t *end, int flags) {
     return hts_parse_region(s, tid, beg, end, (hts_name2id_f)bam_name2id, h, flags);
 }
 
@@ -639,7 +639,7 @@ static hts_idx_t *sam_index(htsFile *fp, int min_shift)
     int n_lvls, i, fmt, ret;
     bam1_t *b;
     hts_idx_t *idx;
-    bam_hdr_t *h;
+    sam_hdr_t *h;
     h = sam_hdr_read(fp);
     if (h == NULL) return NULL;
     if (min_shift > 0) {
@@ -730,7 +730,7 @@ int bam_index_build(const char *fn, int min_shift)
 
 // Initialise fp->idx for the current format type.
 // This must be called after the header has been written but no other data.
-int sam_idx_init(htsFile *fp, bam_hdr_t *h, int min_shift, const char *fnidx) {
+int sam_idx_init(htsFile *fp, sam_hdr_t *h, int min_shift, const char *fnidx) {
     fp->fnidx = fnidx;
     if (fp->format.format == bam || fp->format.format == bcf ||
         (fp->format.format == sam && fp->format.compression == bgzf)) {
@@ -999,7 +999,7 @@ static int cram_name2id(void *fdv, const char *ref)
     return sam_hdr_name2ref(fd->header, ref);
 }
 
-hts_itr_t *sam_itr_querys(const hts_idx_t *idx, bam_hdr_t *hdr, const char *region)
+hts_itr_t *sam_itr_querys(const hts_idx_t *idx, sam_hdr_t *hdr, const char *region)
 {
     const hts_cram_idx_t *cidx = (const hts_cram_idx_t *) idx;
     return hts_itr_querys(idx, region, (hts_name2id_f)(bam_name2id), hdr,
@@ -1007,7 +1007,7 @@ hts_itr_t *sam_itr_querys(const hts_idx_t *idx, bam_hdr_t *hdr, const char *regi
                           sam_readrec);
 }
 
-hts_itr_t *sam_itr_regarray(const hts_idx_t *idx, bam_hdr_t *hdr, char **regarray, unsigned int regcount)
+hts_itr_t *sam_itr_regarray(const hts_idx_t *idx, sam_hdr_t *hdr, char **regarray, unsigned int regcount)
 {
     const hts_cram_idx_t *cidx = (const hts_cram_idx_t *) idx;
     hts_reglist_t *r_list = NULL;
@@ -1037,7 +1037,7 @@ hts_itr_t *sam_itr_regarray(const hts_idx_t *idx, bam_hdr_t *hdr, char **regarra
     return itr;
 }
 
-hts_itr_t *sam_itr_regions(const hts_idx_t *idx, bam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount)
+hts_itr_t *sam_itr_regions(const hts_idx_t *idx, sam_hdr_t *hdr, hts_reglist_t *reglist, unsigned int regcount)
 {
     const hts_cram_idx_t *cidx = (const hts_cram_idx_t *) idx;
 
@@ -1059,7 +1059,7 @@ hts_itr_t *sam_itr_regions(const hts_idx_t *idx, bam_hdr_t *hdr, hts_reglist_t *
 #include "htslib/kseq.h"
 #include "htslib/kstring.h"
 
-bam_hdr_t *sam_hdr_parse(size_t l_text, const char *text)
+sam_hdr_t *sam_hdr_parse(size_t l_text, const char *text)
 {
     return sam_hdr_parse_(text, l_text);
 }
@@ -1073,7 +1073,7 @@ bam_hdr_t *sam_hdr_parse(size_t l_text, const char *text)
 // - syntax (eg checking tab separated fields).
 // - validating n_targets matches @SQ records.
 // - validating target lengths against @SQ records.
-static bam_hdr_t *sam_hdr_sanitise(bam_hdr_t *h) {
+static sam_hdr_t *sam_hdr_sanitise(sam_hdr_t *h) {
     if (!h)
         return NULL;
 
@@ -1138,10 +1138,10 @@ static bam_hdr_t *sam_hdr_sanitise(bam_hdr_t *h) {
     return h;
 }
 
-static bam_hdr_t *sam_hdr_create(htsFile* fp) {
+static sam_hdr_t *sam_hdr_create(htsFile* fp) {
     kstring_t str = { 0, 0, NULL };
     khint_t k;
-    bam_hdr_t* h = bam_hdr_init();
+    sam_hdr_t* h = bam_hdr_init();
     const char *q, *r;
     char* sn = NULL;
     khash_t(s2i) *d = kh_init(s2i);
@@ -1313,7 +1313,7 @@ static bam_hdr_t *sam_hdr_create(htsFile* fp) {
     return NULL;
 }
 
-bam_hdr_t *sam_hdr_read(htsFile *fp)
+sam_hdr_t *sam_hdr_read(htsFile *fp)
 {
     if (!fp) {
         errno = EINVAL;
@@ -1335,7 +1335,7 @@ bam_hdr_t *sam_hdr_read(htsFile *fp)
     }
 }
 
-int sam_hdr_write(htsFile *fp, const bam_hdr_t *h)
+int sam_hdr_write(htsFile *fp, const sam_hdr_t *h)
 {
     if (!fp || !h) {
         errno = EINVAL;
@@ -1434,7 +1434,7 @@ int sam_hdr_write(htsFile *fp, const bam_hdr_t *h)
     return 0;
 }
 
-static int old_sam_hdr_change_HD(bam_hdr_t *h, const char *key, const char *val)
+static int old_sam_hdr_change_HD(sam_hdr_t *h, const char *key, const char *val)
 {
     char *p, *q, *beg = NULL, *end = NULL, *newtext;
     size_t new_l_text;
@@ -1510,7 +1510,7 @@ static int old_sam_hdr_change_HD(bam_hdr_t *h, const char *key, const char *val)
 }
 
 
-int sam_hdr_change_HD(bam_hdr_t *h, const char *key, const char *val)
+int sam_hdr_change_HD(sam_hdr_t *h, const char *key, const char *val)
 {
     if (!h || !key)
         return -1;
@@ -1569,7 +1569,7 @@ static inline int64_t STRTOUL64(const char *v, char **rv, int b) {
     return n;
 }
 
-int sam_parse1(kstring_t *s, bam_hdr_t *h, bam1_t *b)
+int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
 {
 #define _read_token(_p) (_p); do { char *tab = strchr((_p), '\t'); if (!tab) goto err_ret; *tab = '\0'; (_p) = tab + 1; } while (0)
 
@@ -1868,7 +1868,7 @@ err_ret:
     return -2;
 }
 
-int sam_read1(htsFile *fp, bam_hdr_t *h, bam1_t *b)
+int sam_read1(htsFile *fp, sam_hdr_t *h, bam1_t *b)
 {
     switch (fp->format.format) {
     case bam: {
@@ -1912,7 +1912,7 @@ err_recover:
     }
 }
 
-int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str)
+int sam_format1(const sam_hdr_t *h, const bam1_t *b, kstring_t *str)
 {
     int i;
     uint8_t *s, *end;
@@ -2102,7 +2102,7 @@ int sam_format1(const bam_hdr_t *h, const bam1_t *b, kstring_t *str)
     return -1;
 }
 
-int sam_write1(htsFile *fp, const bam_hdr_t *h, const bam1_t *b)
+int sam_write1(htsFile *fp, const sam_hdr_t *h, const bam1_t *b)
 {
     switch (fp->format.format) {
     case binary_format:

--- a/sam.c
+++ b/sam.c
@@ -996,7 +996,7 @@ hts_itr_t *sam_itr_queryi(const hts_idx_t *idx, int tid, int beg, int end)
 static int cram_name2id(void *fdv, const char *ref)
 {
     cram_fd *fd = (cram_fd *) fdv;
-    return bam_hdr_name2ref(fd->header, ref);
+    return sam_hdr_name2ref(fd->header, ref);
 }
 
 hts_itr_t *sam_itr_querys(const hts_idx_t *idx, bam_hdr_t *hdr, const char *region)
@@ -1519,10 +1519,10 @@ int sam_hdr_change_HD(bam_hdr_t *h, const char *key, const char *val)
         return old_sam_hdr_change_HD(h, key, val);
 
     if (val) {
-        if (bam_hdr_update_line(h, "HD", NULL, NULL, key, val, NULL) != 0)
+        if (sam_hdr_update_line(h, "HD", NULL, NULL, key, val, NULL) != 0)
             return -1;
     } else {
-        if (bam_hdr_remove_tag_id(h, "HD", NULL, NULL, key) != 0)
+        if (sam_hdr_remove_tag_id(h, "HD", NULL, NULL, key) != 0)
             return -1;
     }
     return bam_hdr_rebuild(h);

--- a/sam.c
+++ b/sam.c
@@ -88,7 +88,7 @@ void sam_hdr_destroy(sam_hdr_t *bh)
     }
     free(bh->text);
     if (bh->hrecs)
-        bam_hrecs_free(bh->hrecs);
+        sam_hrecs_free(bh->hrecs);
     free(bh);
 }
 
@@ -122,7 +122,7 @@ sam_hdr_t *sam_hdr_dup(const sam_hdr_t *h0)
 
     if (h0->hrecs) {
         kstring_t tmp = { 0, 0, NULL };
-        if (bam_hrecs_rebuild_text(h0->hrecs, &tmp) != 0) {
+        if (sam_hrecs_rebuild_text(h0->hrecs, &tmp) != 0) {
             free(ks_release(&tmp));
             goto fail;
         }
@@ -265,7 +265,7 @@ int bam_hdr_write(BGZF *fp, const sam_hdr_t *h)
     if (!h) return -1;
 
     if (h->hrecs) {
-        if (bam_hrecs_rebuild_text(h->hrecs, &hdr_ks) != 0) return -1;
+        if (sam_hrecs_rebuild_text(h->hrecs, &hdr_ks) != 0) return -1;
         if (hdr_ks.l > INT32_MAX) {
             hts_log_error("Header too long for BAM format");
             free(hdr_ks.s);
@@ -1383,7 +1383,7 @@ int sam_hdr_write(htsFile *fp, const sam_hdr_t *h)
         int r = 0, no_sq = 0;
 
         if (h->hrecs) {
-            if (bam_hrecs_rebuild_text(h->hrecs, &hdr_ks) != 0)
+            if (sam_hrecs_rebuild_text(h->hrecs, &hdr_ks) != 0)
                 return -1;
             text = hdr_ks.s;
             l_text = hdr_ks.l;

--- a/sam.c
+++ b/sam.c
@@ -130,7 +130,7 @@ sam_hdr_t *sam_hdr_dup(const sam_hdr_t *h0)
         h->l_text = tmp.l;
         h->text   = ks_release(&tmp);
 
-        if (update_target_arrays(h, h0->hrecs, 0) != 0)
+        if (sam_hdr_update_target_arrays(h, h0->hrecs, 0) != 0)
             goto fail;
     } else {
         h->l_text = h0->l_text;
@@ -1533,7 +1533,7 @@ int sam_hdr_change_HD(sam_hdr_t *h, const char *key, const char *val)
         if (sam_hdr_remove_tag_id(h, "HD", NULL, NULL, key) != 0)
             return -1;
     }
-    return bam_hdr_rebuild(h);
+    return sam_hdr_rebuild(h);
 }
 /**********************
  *** SAM record I/O ***

--- a/test/fieldarith.c
+++ b/test/fieldarith.c
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
             check(aln, "endpos", "XE", bam_endpos(aln));
         }
 
-        bam_hdr_destroy(header);
+        sam_hdr_destroy(header);
         sam_close(in);
     }
 

--- a/test/fieldarith.c
+++ b/test/fieldarith.c
@@ -47,7 +47,7 @@ void check(const bam1_t *aln, const char *testname, const char *tag, int value)
 
 int main(int argc, char **argv)
 {
-    bam_hdr_t *header;
+    sam_hdr_t *header;
     bam1_t *aln = bam_init1();
     int i;
 

--- a/test/fuzz/hts_open_fuzzer.c
+++ b/test/fuzz/hts_open_fuzzer.c
@@ -60,13 +60,13 @@ static void view_sam(htsFile *in) {
     }
 
     if (sam_hdr_write(out, hdr) != 0) {
-        bam_hdr_destroy(hdr);
+        sam_hdr_destroy(hdr);
         hts_close_or_abort(out);
         return;
     }
     bam1_t *b = bam_init1();
     if (b == NULL) {
-        bam_hdr_destroy(hdr);
+        sam_hdr_destroy(hdr);
         hts_close_or_abort(out);
         return;
     }
@@ -77,7 +77,7 @@ static void view_sam(htsFile *in) {
     }
     bam_destroy1(b);
 
-    bam_hdr_destroy(hdr);
+    sam_hdr_destroy(hdr);
     hts_close_or_abort(out);
 }
 

--- a/test/fuzz/hts_open_fuzzer.c
+++ b/test/fuzz/hts_open_fuzzer.c
@@ -53,7 +53,7 @@ static void view_sam(htsFile *in) {
         return;
     }
     samFile *out = dup_stdout("w");
-    bam_hdr_t *hdr = sam_hdr_read(in);
+    sam_hdr_t *hdr = sam_hdr_read(in);
     if (hdr == NULL) {
         hts_close_or_abort(out);
         return;

--- a/test/pileup.c
+++ b/test/pileup.c
@@ -55,7 +55,7 @@ samtools mpileup -B -Q 0 in.bam | perl -lane \
 typedef struct ptest_t {
     const char *fname;
     samFile *fp;
-    bam_hdr_t *fp_hdr;
+    sam_hdr_t *fp_hdr;
 } ptest_t;
 
 static int readaln(void *data, bam1_t *b) {

--- a/test/pileup.c
+++ b/test/pileup.c
@@ -243,13 +243,13 @@ int main(int argc, char **argv) {
             goto fail;
     }
 
-    bam_hdr_destroy(g.fp_hdr);
+    sam_hdr_destroy(g.fp_hdr);
     sam_close(g.fp);
 
     return EXIT_SUCCESS;
 
  fail:
-    if (g.fp_hdr) bam_hdr_destroy(g.fp_hdr);
+    if (g.fp_hdr) sam_hdr_destroy(g.fp_hdr);
     if (g.fp) sam_close(g.fp);
     return EXIT_FAILURE;
 }

--- a/test/sam.c
+++ b/test/sam.c
@@ -566,10 +566,10 @@ static void use_header_api() {
         goto err;
     }
     r = sam_hdr_remove_tag_id(header, "HD", NULL, NULL, "GO");
-    if (r != 1) { fail("bam_hdr_remove_tag"); goto err; }
+    if (r != 1) { fail("sam_hdr_remove_tag_id"); goto err; }
 
     r = sam_hdr_update_hd(header, "VN", "1.5");
-    if (r != 0) { fail("bam_hdr_find_update_hd"); goto err; }
+    if (r != 0) { fail("sam_hdr_update_hd"); goto err; }
 
     r = sam_hdr_add_line(header, "SQ", "SN", "ref3", "LN", "5003", NULL);
     if (r < 0) { fail("sam_hdr_add_line"); goto err; }
@@ -596,11 +596,11 @@ static void use_header_api() {
     if (r < 0) { fail("sam_hdr_add_line"); goto err; }
 
     r = sam_hdr_remove_line_id(header, "RG", "ID", "run2");
-    if (r < 0) { fail("bam_hdr_remove_line_key"); goto err; }
+    if (r < 0) { fail("sam_hdr_remove_line_id"); goto err; }
 
     r = sam_hdr_find_tag_id(header, "RG", "ID", "run3", "ID", &ks);
     if (r < 0 || !ks.s || strcmp(ks.s, "run3") != 0) {
-        fail("bam_hdr_find_tag() expected \"run3\" got \"%s\"",
+        fail("sam_hdr_find_tag_id() expected \"run3\" got \"%s\"",
              r == 0 && ks.s ? ks.s : "NULL");
         goto err;
     }
@@ -609,14 +609,14 @@ static void use_header_api() {
     if (r < 0) { fail("sam_hdr_remove_line_pos"); goto err; }
 
     r = sam_hdr_remove_line_id(header, "SQ", "SN", "ref0");
-    if (r < 0) { fail("bam_hdr_remove_line_key"); goto err; }
+    if (r < 0) { fail("sam_hdr_remove_line_id"); goto err; }
 
     r = sam_hdr_remove_line_pos(header, "SQ", 1); // Removes ref1.5
     if (r < 0) { fail("sam_hdr_remove_line_pos"); goto err; }
 
     r = sam_hdr_find_tag_id(header, "SQ", "SN", "ref1", "M5", &ks);
     if (r < 0 || !ks.s || strcmp(ks.s, "kja8u34a2q3") != 0) {
-        fail("bam_hdr_find_tag() expected \"kja8u34a2q3\" got \"%s\"",
+        fail("sam_hdr_find_tag_id() expected \"kja8u34a2q3\" got \"%s\"",
              r == 0 && ks.s ? ks.s : "NULL");
         goto err;
     }

--- a/test/sam.c
+++ b/test/sam.c
@@ -729,7 +729,7 @@ static void use_header_api() {
     free(ks_release(&ks));
 
  err:
-    bam_hdr_destroy(header);
+    sam_hdr_destroy(header);
     header = NULL;
     if (in) sam_close(in);
     if (out) sam_close(out);
@@ -816,7 +816,7 @@ static void test_header_pg_lines() {
     }
 
  err:
-    bam_hdr_destroy(header);
+    sam_hdr_destroy(header);
     header = NULL;
     if (in) sam_close(in);
     return;

--- a/test/sam.c
+++ b/test/sam.c
@@ -215,6 +215,8 @@ static int test_update_array(bam1_t *aln, const char target_id[2],
     return 0;
 }
 
+// This function uses bam_hdr_t etc as a check ensuring the legacy typedef
+// and functions continue to compile successfully.
 static int aux_fields1(void)
 {
     static const char sam[] = "data:,"
@@ -454,6 +456,8 @@ static void iterators1(void)
     hts_itr_destroy(sam_itr_queryi(NULL, HTS_IDX_NONE, 0, 0));
 }
 
+// This function uses bam_hdr_t etc as a check ensuring the legacy typedef
+// and functions continue to compile successfully.
 static void copy_check_alignment(const char *infname, const char *informat,
     const char *outfname, const char *outmode, const char *outref)
 {
@@ -546,7 +550,7 @@ static void use_header_api() {
 
     samFile *in = sam_open(header_text, "r");
     samFile *out = sam_open(outfname, outmode);
-    bam_hdr_t *header = NULL;
+    sam_hdr_t *header = NULL;
     kstring_t ks = { 0, 0, NULL };
     size_t bytes;
     int r, i;
@@ -752,7 +756,7 @@ static void test_header_pg_lines() {
         "@PG\tPN:prog7\tID:my_id\tPP:prog6\n";
 
     samFile *in = sam_open(header_text, "r");
-    bam_hdr_t *header = NULL;
+    sam_hdr_t *header = NULL;
     const char *text = NULL;
     enum htsLogLevel old_log_level;
     int r;

--- a/test/sam.c
+++ b/test/sam.c
@@ -565,82 +565,82 @@ static void use_header_api() {
         fail("reading header from file");
         goto err;
     }
-    r = bam_hdr_remove_tag_id(header, "HD", NULL, NULL, "GO");
+    r = sam_hdr_remove_tag_id(header, "HD", NULL, NULL, "GO");
     if (r != 1) { fail("bam_hdr_remove_tag"); goto err; }
 
-    r = bam_hdr_update_hd(header, "VN", "1.5");
+    r = sam_hdr_update_hd(header, "VN", "1.5");
     if (r != 0) { fail("bam_hdr_find_update_hd"); goto err; }
 
-    r = bam_hdr_add_line(header, "SQ", "SN", "ref3", "LN", "5003", NULL);
-    if (r < 0) { fail("bam_hdr_add_line"); goto err; }
+    r = sam_hdr_add_line(header, "SQ", "SN", "ref3", "LN", "5003", NULL);
+    if (r < 0) { fail("sam_hdr_add_line"); goto err; }
 
-    r = bam_hdr_update_line(header, "SQ", "SN", "ref1",
+    r = sam_hdr_update_line(header, "SQ", "SN", "ref1",
                              "M5", "kja8u34a2q3", NULL);
-    if (r != 0) { fail("bam_hdr_update_line SQ"); goto err; }
+    if (r != 0) { fail("sam_hdr_update_line SQ"); goto err; }
 
-    r = bam_hdr_add_pg(header, "samtools", "VN", "1.9", NULL);
-    if (r != 0) { fail("bam_hdr_add_pg"); goto err; }
+    r = sam_hdr_add_pg(header, "samtools", "VN", "1.9", NULL);
+    if (r != 0) { fail("sam_hdr_add_pg"); goto err; }
 
     // Test addition with no newline or trailing NUL
-    r = bam_hdr_add_lines(header, rg_line, sizeof(rg_line));
-    if (r != 0) { fail("bam_hdr_add_lines rg_line"); goto err; }
+    r = sam_hdr_add_lines(header, rg_line, sizeof(rg_line));
+    if (r != 0) { fail("sam_hdr_add_lines rg_line"); goto err; }
 
     // Test header line removal
-    r = bam_hdr_add_line(header, "RG", "ID", "run2", NULL);
-    if (r < 0) { fail("bam_hdr_add_line"); goto err; }
+    r = sam_hdr_add_line(header, "RG", "ID", "run2", NULL);
+    if (r < 0) { fail("sam_hdr_add_line"); goto err; }
 
-    r = bam_hdr_add_line(header, "RG", "ID", "run3", NULL);
-    if (r < 0) { fail("bam_hdr_add_line"); goto err; }
+    r = sam_hdr_add_line(header, "RG", "ID", "run3", NULL);
+    if (r < 0) { fail("sam_hdr_add_line"); goto err; }
 
-    r = bam_hdr_add_line(header, "RG", "ID", "run4", NULL);
-    if (r < 0) { fail("bam_hdr_add_line"); goto err; }
+    r = sam_hdr_add_line(header, "RG", "ID", "run4", NULL);
+    if (r < 0) { fail("sam_hdr_add_line"); goto err; }
 
-    r = bam_hdr_remove_line_id(header, "RG", "ID", "run2");
+    r = sam_hdr_remove_line_id(header, "RG", "ID", "run2");
     if (r < 0) { fail("bam_hdr_remove_line_key"); goto err; }
 
-    r = bam_hdr_find_tag_id(header, "RG", "ID", "run3", "ID", &ks);
+    r = sam_hdr_find_tag_id(header, "RG", "ID", "run3", "ID", &ks);
     if (r < 0 || !ks.s || strcmp(ks.s, "run3") != 0) {
         fail("bam_hdr_find_tag() expected \"run3\" got \"%s\"",
              r == 0 && ks.s ? ks.s : "NULL");
         goto err;
     }
 
-    r = bam_hdr_remove_line_pos(header, "RG", 1); // Removes run3
-    if (r < 0) { fail("bam_hdr_remove_line_pos"); goto err; }
+    r = sam_hdr_remove_line_pos(header, "RG", 1); // Removes run3
+    if (r < 0) { fail("sam_hdr_remove_line_pos"); goto err; }
 
-    r = bam_hdr_remove_line_id(header, "SQ", "SN", "ref0");
+    r = sam_hdr_remove_line_id(header, "SQ", "SN", "ref0");
     if (r < 0) { fail("bam_hdr_remove_line_key"); goto err; }
 
-    r = bam_hdr_remove_line_pos(header, "SQ", 1); // Removes ref1.5
-    if (r < 0) { fail("bam_hdr_remove_line_pos"); goto err; }
+    r = sam_hdr_remove_line_pos(header, "SQ", 1); // Removes ref1.5
+    if (r < 0) { fail("sam_hdr_remove_line_pos"); goto err; }
 
-    r = bam_hdr_find_tag_id(header, "SQ", "SN", "ref1", "M5", &ks);
+    r = sam_hdr_find_tag_id(header, "SQ", "SN", "ref1", "M5", &ks);
     if (r < 0 || !ks.s || strcmp(ks.s, "kja8u34a2q3") != 0) {
         fail("bam_hdr_find_tag() expected \"kja8u34a2q3\" got \"%s\"",
              r == 0 && ks.s ? ks.s : "NULL");
         goto err;
     }
 
-    r = bam_hdr_remove_tag_hd(header, "SS");
+    r = sam_hdr_remove_tag_hd(header, "SS");
     if (r < 0) {
-        fail("bam_hdr_remove_tag_hd");
+        fail("sam_hdr_remove_tag_hd");
     }
 
-    r = bam_hdr_find_hd(header, &ks);
+    r = sam_hdr_find_hd(header, &ks);
     if (r < 0 || !ks.s || strcmp(ks.s, "@HD\tVN:1.5") != 0) {
-        fail("bam_hdr_find_hd() expected \"@HD\tVN:1.5\" got \"%s\"",
+        fail("sam_hdr_find_hd() expected \"@HD\tVN:1.5\" got \"%s\"",
              r == 0 && ks.s ? ks.s : "NULL");
     }
 
-    r = bam_hdr_find_tag_hd(header, "VN", &ks);
+    r = sam_hdr_find_tag_hd(header, "VN", &ks);
     if (r < 0 || !ks.s || strcmp(ks.s, "1.5") != 0) {
-        fail("bam_hdr_find_tag_hd() expected \"1.5\" got \"%s\"",
+        fail("sam_hdr_find_tag_hd() expected \"1.5\" got \"%s\"",
              r == 0 && ks.s ? ks.s : "NULL");
     }
 
-    r = bam_hdr_update_hd(header, "SO", "coordinate");
+    r = sam_hdr_update_hd(header, "SO", "coordinate");
     if (r < 0) {
-        fail("bam_hdr_update_hd");
+        fail("sam_hdr_update_hd");
     }
 
     // Check consistency of target_names array
@@ -673,23 +673,23 @@ static void use_header_api() {
         }
     }
 
-    if ((r = bam_hdr_count_lines(header, "HD")) != 1) {
+    if ((r = sam_hdr_count_lines(header, "HD")) != 1) {
         fail("incorrect HD line count - expected 1, got %d", r);
         goto err;
     }
-    if ((r = bam_hdr_count_lines(header, "SQ")) != 3) {
+    if ((r = sam_hdr_count_lines(header, "SQ")) != 3) {
         fail("incorrect SQ line count - expected 3, got %d", r);
         goto err;
     }
-    if ((r = bam_hdr_count_lines(header, "PG")) != 1) {
+    if ((r = sam_hdr_count_lines(header, "PG")) != 1) {
         fail("incorrect PG line count - expected 1, got %d", r);
         goto err;
     }
-    if ((r = bam_hdr_count_lines(header, "RG")) != 2) {
+    if ((r = sam_hdr_count_lines(header, "RG")) != 2) {
         fail("incorrect RG line count - expected 2, got %d", r);
         goto err;
     }
-    if ((r = bam_hdr_count_lines(header, "CO")) != 2) {
+    if ((r = sam_hdr_count_lines(header, "CO")) != 2) {
         fail("incorrect CO line count - expected 2, got %d", r);
         goto err;
     }
@@ -768,35 +768,35 @@ static void test_header_pg_lines() {
         goto err;
     }
 
-    r = bam_hdr_add_pg(header, "prog3", NULL);
-    if (r != 0) { fail("bam_hdr_add_pg prog3"); goto err; }
+    r = sam_hdr_add_pg(header, "prog3", NULL);
+    if (r != 0) { fail("sam_hdr_add_pg prog3"); goto err; }
 
 
-    r = bam_hdr_add_pg(header, "prog4", "PP", "prog1", NULL);
-    if (r != 0) { fail("bam_hdr_add_pg prog4"); goto err; }
+    r = sam_hdr_add_pg(header, "prog4", "PP", "prog1", NULL);
+    if (r != 0) { fail("sam_hdr_add_pg prog4"); goto err; }
 
-    r = bam_hdr_add_line(header, "PG", "ID",
+    r = sam_hdr_add_line(header, "PG", "ID",
                          "prog5", "PN", "prog5", "PP", "prog2", NULL);
-    if (r != 0) { fail("bam_hdr_add_line @PG ID:prog5"); goto err; }
+    if (r != 0) { fail("sam_hdr_add_line @PG ID:prog5"); goto err; }
 
-    r = bam_hdr_add_pg(header, "prog6", NULL);
-    if (r != 0) { fail("bam_hdr_add_pg prog6"); goto err; }
+    r = sam_hdr_add_pg(header, "prog6", NULL);
+    if (r != 0) { fail("sam_hdr_add_pg prog6"); goto err; }
 
-    r = bam_hdr_add_pg(header, "prog7", "ID", "my_id", "PP", "prog6", NULL);
-    if (r != 0) { fail("bam_hdr_add_pg prog7"); goto err; }
+    r = sam_hdr_add_pg(header, "prog7", "ID", "my_id", "PP", "prog6", NULL);
+    if (r != 0) { fail("sam_hdr_add_pg prog7"); goto err; }
 
-    text = bam_hdr_str(header);
-    if (!text) { fail("bam_hdr_str"); goto err; }
+    text = sam_hdr_str(header);
+    if (!text) { fail("sam_hdr_str"); goto err; }
 
     // These should fail
     old_log_level = hts_get_log_level();
     hts_set_log_level(HTS_LOG_OFF);
 
-    r = bam_hdr_add_pg(header, "prog8", "ID", "my_id", NULL);
-    if (r == 0) { fail("bam_hdr_add_pg prog8 (unexpected success)"); goto err; }
+    r = sam_hdr_add_pg(header, "prog8", "ID", "my_id", NULL);
+    if (r == 0) { fail("sam_hdr_add_pg prog8 (unexpected success)"); goto err; }
 
-    r = bam_hdr_add_pg(header, "prog9", "PP", "non-existent", NULL);
-    if (r == 0) { fail("bam_hdr_add_pg prog9 (unexpected success)"); goto err; }
+    r = sam_hdr_add_pg(header, "prog9", "PP", "non-existent", NULL);
+    if (r == 0) { fail("sam_hdr_add_pg prog9 (unexpected success)"); goto err; }
 
     hts_set_log_level(old_log_level);
     // End failing tests

--- a/test/test-parse-reg.c
+++ b/test/test-parse-reg.c
@@ -136,7 +136,7 @@ int reg_test(char *fn) {
     fprintf(stderr, "Expected error: ");
     reg_expected(hdr, "chr1:1,chr3", 0, NULL, 0, 0, 0);
 
-    bam_hdr_destroy(hdr);
+    sam_hdr_destroy(hdr);
     sam_close(fp);
 
     exit(0);
@@ -197,7 +197,7 @@ int main(int argc, char **argv) {
                beg, end);
     }
 
-    bam_hdr_destroy(hdr);
+    sam_hdr_destroy(hdr);
     sam_close(fp);
 
     return 0;

--- a/test/test-parse-reg.c
+++ b/test/test-parse-reg.c
@@ -47,7 +47,7 @@
 #include <htslib/hts.h>
 #include <htslib/sam.h>
 
-void reg_expected(bam_hdr_t *hdr, const char *reg, int flags,
+void reg_expected(sam_hdr_t *hdr, const char *reg, int flags,
                  char *reg_exp, int tid_exp, int64_t beg_exp, int64_t end_exp) {
     const char *reg_out;
     int tid_out = -1;
@@ -71,7 +71,7 @@ void reg_expected(bam_hdr_t *hdr, const char *reg, int flags,
 
 int reg_test(char *fn) {
     samFile *fp;
-    bam_hdr_t *hdr;
+    sam_hdr_t *hdr;
 
     if (!(fp = sam_open(fn, "r")))
         return 1;
@@ -143,7 +143,7 @@ int reg_test(char *fn) {
 }
 
 int main(int argc, char **argv) {
-    bam_hdr_t *hdr;
+    sam_hdr_t *hdr;
     samFile *fp;
     int flags = 0;
 

--- a/test/test_realn.c
+++ b/test/test_realn.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
     char *ref_seq = NULL;
     char modew[8] = "w";
     faidx_t *fai = NULL;
-    bam_hdr_t *hdr = NULL;
+    sam_hdr_t *hdr = NULL;
     bam1_t *rec = NULL;
     int c, res, last_ref = -1, ref_len = 0;
     int adjust = 0, extended = 0, recalc = 0, flags = 0;

--- a/test/test_realn.c
+++ b/test/test_realn.c
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
         goto fail;
     }
 
-    bam_hdr_destroy(hdr);
+    sam_hdr_destroy(hdr);
     bam_destroy1(rec);
     free(ref_seq);
     fai_destroy(fai);
@@ -159,7 +159,7 @@ int main(int argc, char **argv) {
     return EXIT_SUCCESS;
 
  fail:
-    if (hdr) bam_hdr_destroy(hdr);
+    if (hdr) sam_hdr_destroy(hdr);
     if (rec) bam_destroy1(rec);
     if (in) hts_close(in);
     if (out) hts_close(out);

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -61,7 +61,7 @@ enum test_op {
 
 int sam_loop(int argc, char **argv, int optind, struct opts *opts, htsFile *in, htsFile *out) {
     int r = 0;
-    bam_hdr_t *h = NULL;
+    sam_hdr_t *h = NULL;
     hts_idx_t *idx = NULL;
     bam1_t *b = NULL;
 

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -179,12 +179,12 @@ int sam_loop(int argc, char **argv, int optind, struct opts *opts, htsFile *in, 
     }
 
     bam_destroy1(b);
-    bam_hdr_destroy(h);
+    sam_hdr_destroy(h);
 
     return 0;
  fail:
     if (b) bam_destroy1(b);
-    if (h) bam_hdr_destroy(h);
+    if (h) sam_hdr_destroy(h);
     if (idx) hts_idx_destroy(idx);
 
     return 1;


### PR DESCRIPTION
With the exception of some early functions, HTSlib's convention for generic SAM/BAM/CRAM functions is a `sam_` prefix. (cf e.g. `bam_hdr_read()` which works for BAM files only vs. `sam_hdr_read()` which is for any of SAM/BAM/CRAM.)

For your consideration, this PR renames the newly added public header API functions to use a `sam_hdr_` prefix rather than the `bam_hdr_` prefix of PR #812. If the maintainers' consensus is that they would like to go down this route, I would be happy to add commits to rename the new internal functions similarly and/or to add renaming shims for e.g. `sam_hdr_init()` and `sam_hdr_t`, i.e., things that have long had a somewhat unfortunate `bam_hdr_` prefix.

I have also tried out the renaming on samtools/samtools#998; that compiles cleanly, and both htslib and samtools test suites pass.

(In https://github.com/samtools/htslib/pull/812#issuecomment-504064969 Rob alluded to clashes with pre-existing bits of API. I think that problem must have been mostly limited to an intermediate version of the API. Once cram.h's `sam_hdr_length`/`_str` declarations were tidied up, this PR had no such problems.)

