### PR TITLE
Fix sam_parse1() / cigar_tab[] race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ lib*.so.*
 /test/test_bgzf
 /test/test_index
 /test/test_kstring
+/test/test-parse-reg
 /test/test_realn
 /test/test-regidx
 /test/test-vcf-api

--- a/Makefile
+++ b/Makefile
@@ -445,7 +445,7 @@ test/sam.o: test/sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_fa
 test/test_bgzf.o: test/test_bgzf.c config.h $(htslib_bgzf_h) $(htslib_hfile_h) $(hfile_internal_h)
 test/test_kstring.o: test/test_kstring.c config.h $(htslib_kstring_h)
 test/test-parse-reg.o: test/test-parse-reg.c $(htslib_hts_h) $(htslib_sam_h)
-test/test-realn.o: test/test_realn.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h)
+test/test_realn.o: test/test_realn.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h)
 test/test-regidx.o: test/test-regidx.c config.h $(htslib_regidx_h) $(hts_internal_h)
 test/test_view.o: test/test_view.c config.h $(cram_h) $(htslib_sam_h) $(htslib_vcf_h)
 test/test_index.o: test/test_index.c config.h $(htslib_sam_h) $(htslib_vcf_h)

--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hfile_internal_h) $(htslib_hts_h
 hts.o hts.pico: hts.c config.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_hts_endian_h) version.h $(hts_internal_h) $(hfile_internal_h) $(htslib_hts_os_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h) $(htslib_tbx_h)
 hts_os.o hts_os.pico: hts_os.c config.h os/rand.c
 vcf.o vcf.pico: vcf.c config.h $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_hfile_h) $(hts_internal_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_sam_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_hts_endian_h)
-sam.o sam.pico: sam.c config.h $(htslib_sam_h) $(htslib_bgzf_h) $(cram_h) $(hts_internal_h) $(htslib_hfile_h) $(htslib_hts_endian_h) $(header_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_kstring_h)
+sam.o sam.pico: sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_bgzf_h) $(cram_h) $(hts_internal_h) $(htslib_hfile_h) $(htslib_hts_endian_h) $(header_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_kstring_h)
 tbx.o tbx.pico: tbx.c config.h $(htslib_tbx_h) $(htslib_bgzf_h) $(htslib_hts_endian_h) $(hts_internal_h) $(htslib_khash_h)
 faidx.o faidx.pico: faidx.c config.h $(htslib_bgzf_h) $(htslib_faidx_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kstring_h) $(hts_internal_h)
 bcf_sr_sort.o bcf_sr_sort.pico: bcf_sr_sort.c config.h $(bcf_sr_sort_h) $(htslib_khash_str2int_h) $(htslib_kbitset_h)

--- a/NEWS
+++ b/NEWS
@@ -49,7 +49,8 @@ Noteworthy changes in release a.b
     and l_text fields have been left for backwards compatibility, but
     should not be accessed directly in code that uses the new header API.
     To access the header text, the new functions sam_hdr_length() and
-    sam_hdr_str() should be used instead.
+    sam_hdr_str() should be used instead.  The old cigar_tab field is
+    now marked as deprecated; use the new bam_cigar_table[] instead.
 
   - bcf_index_load() no longer tries the '.tbi' suffix when looking for
     BCF index files (.tbi indexes are for text files, not binary BCF).

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -71,7 +71,7 @@ typedef struct sam_hdr_t {
     int32_t n_targets, ignore_sam_err;
     size_t l_text;
     uint32_t *target_len;
-    int8_t *cigar_tab;
+    const int8_t *cigar_tab HTS_DEPRECATED("Use bam_cigar_table[] instead");
     char **target_name;
     char *text;
     void *sdict HTS_DEPRECATED("Unused since 1.10");
@@ -103,6 +103,12 @@ typedef sam_hdr_t bam_hdr_t;
 #define BAM_CIGAR_SHIFT 4
 #define BAM_CIGAR_MASK  0xf
 #define BAM_CIGAR_TYPE  0x3C1A7
+
+/*! @abstract Table for converting a CIGAR operator character to BAM_CMATCH etc.
+Result is operator code or -1. Be sure to cast the index if it is a plain char:
+    int op = bam_cigar_table[(unsigned char) ch];
+*/
+extern const int8_t bam_cigar_table[256];
 
 #define bam_cigar_op(c) ((c)&BAM_CIGAR_MASK)
 #define bam_cigar_oplen(c) ((c)>>BAM_CIGAR_SHIFT)

--- a/test/sam.c
+++ b/test/sam.c
@@ -903,6 +903,21 @@ static void check_enum1(void)
     if (bgzf != 2) fail("bgzf is %d", bgzf);
 }
 
+static void check_cigar_tab(void)
+{
+    int i, n_neg = 0;
+
+    for (i = 0; i < 256; ++i)
+        if (bam_cigar_table[i] < 0) n_neg++;
+
+    if (n_neg + strlen(BAM_CIGAR_STR) != 256)
+        fail("bam_cigar_table has %d unset entries", n_neg);
+
+    for (i = 0; BAM_CIGAR_STR[i]; ++i)
+        if (bam_cigar_table[(unsigned char) BAM_CIGAR_STR[i]] != i)
+            fail("bam_cigar_table['%c'] is not %d", BAM_CIGAR_STR[i], i);
+}
+
 int main(int argc, char **argv)
 {
     int i;
@@ -915,6 +930,7 @@ int main(int argc, char **argv)
     use_header_api();
     test_header_pg_lines();
     check_enum1();
+    check_cigar_tab();
     for (i = 1; i < argc; i++) faidx1(argv[i]);
 
     return status;


### PR DESCRIPTION
[Something that I noticed while going over the header code…]

Since 3bb8fd1b1a940ca6c30f744451e58bafdf177461 all SAM file readers share a static `cigar_tab` that is reinitialised each time a `sam_hdr_t` is given to `sam_parse1()` for the first time. If multiple SAM files are being read by a multithreaded program, in theory this could cause spurious parse failures if `cigar_tab` is reinitialised while another thread is parsing a CIGAR string.

This could be improved by only actually writing to `cigar_tab` the first time `cigar_tab_init()` is called, but to be really threading-correct I think this would need a mutex. Easier just to do what should have been done years ago and write out the contents of the table explicitly and make it `const`! :smile:

Also a small commit to fix a dependency that caused spurious test failures while testing this as one of the test programs wasn't getting rebuilt.

This PR removes `sam_hdr_t`'s `cigar_tab` field on the basis that surely no-one is using it (as it's not set up until after you've already read the first read). If you prefer, I can redo this to just change it to `const int8_t *cigar_tab` (preferably) and initialise it to the prebuilt table early on.

This PR makes the table public, mostly so that _test/sam.c_ can check it's correct. I guess that's not really necessary as other test cases will fail if their CIGARs can't be parsed so it could get away with just making sure there are test SAM files that exercise all the operators. But it fills a gap anyway…