### PR TITLE
[header API] Methods for retrieving reference sequence name and length

### DIFF
--- a/header.c
+++ b/header.c
@@ -1455,19 +1455,13 @@ int sam_hdr_name2id(sam_hdr_t *bh, const char *ref) {
     return k == kh_end(hrecs->ref_hash) ? -1 : kh_val(hrecs->ref_hash, k);
 }
 
-const char *sam_hdr_id2name(sam_hdr_t *h, int tid) {
+const char *sam_hdr_id2name(const sam_hdr_t *h, int tid) {
     sam_hrecs_t *hrecs;
 
     if (!h)
         return NULL;
 
-    if (!(hrecs = h->hrecs)) {
-        if (sam_hdr_fill_hrecs(h) != 0)
-            return NULL;
-        hrecs = h->hrecs;
-    }
-
-    if (tid < hrecs->nref) {
+    if ((hrecs = h->hrecs) != NULL && tid < hrecs->nref) {
         return hrecs->ref[tid].name;
     } else {
         if (tid < h->n_targets)
@@ -1477,19 +1471,13 @@ const char *sam_hdr_id2name(sam_hdr_t *h, int tid) {
     return NULL;
 }
 
-uint32_t sam_hdr_id2len(sam_hdr_t *h, int tid) {
+uint32_t sam_hdr_id2len(const sam_hdr_t *h, int tid) {
     sam_hrecs_t *hrecs;
 
     if (!h)
         return 0;
 
-    if (!(hrecs = h->hrecs)) {
-        if (sam_hdr_fill_hrecs(h) != 0)
-            return 0;
-        hrecs = h->hrecs;
-    }
-
-    if (tid < hrecs->nref) {
+    if ((hrecs = h->hrecs) != NULL && tid < hrecs->nref) {
         return hrecs->ref[tid].len;
     } else {
         if (tid < h->n_targets)

--- a/header.c
+++ b/header.c
@@ -1435,7 +1435,7 @@ int sam_hrecs_rebuild_text(const sam_hrecs_t *hrecs, kstring_t *ks) {
  * Looks up a reference sequence by name and returns the numerical ID.
  * Returns -1 if unknown reference; -2 if header could not be parsed.
  */
-int sam_hdr_name2ref(sam_hdr_t *bh, const char *ref) {
+int sam_hdr_name2id(sam_hdr_t *bh, const char *ref) {
     sam_hrecs_t *hrecs;
     khint_t k;
 
@@ -1453,6 +1453,50 @@ int sam_hdr_name2ref(sam_hdr_t *bh, const char *ref) {
 
     k = kh_get(m_s2i, hrecs->ref_hash, ref);
     return k == kh_end(hrecs->ref_hash) ? -1 : kh_val(hrecs->ref_hash, k);
+}
+
+const char *sam_hdr_id2name(sam_hdr_t *h, int tid) {
+    sam_hrecs_t *hrecs;
+
+    if (!h)
+        return NULL;
+
+    if (!(hrecs = h->hrecs)) {
+        if (sam_hdr_fill_hrecs(h) != 0)
+            return NULL;
+        hrecs = h->hrecs;
+    }
+
+    if (tid < hrecs->nref) {
+        return hrecs->ref[tid].name;
+    } else {
+        if (tid < h->n_targets)
+            return h->target_name[tid];
+    }
+
+    return NULL;
+}
+
+uint32_t sam_hdr_id2len(sam_hdr_t *h, int tid) {
+    sam_hrecs_t *hrecs;
+
+    if (!h)
+        return 0;
+
+    if (!(hrecs = h->hrecs)) {
+        if (sam_hdr_fill_hrecs(h) != 0)
+            return 0;
+        hrecs = h->hrecs;
+    }
+
+    if (tid < hrecs->nref) {
+        return hrecs->ref[tid].len;
+    } else {
+        if (tid < h->n_targets)
+            return h->target_len[tid];
+    }
+
+    return 0;
 }
 
 /*

--- a/header.c
+++ b/header.c
@@ -1435,7 +1435,7 @@ int sam_hrecs_rebuild_text(const sam_hrecs_t *hrecs, kstring_t *ks) {
  * Looks up a reference sequence by name and returns the numerical ID.
  * Returns -1 if unknown reference; -2 if header could not be parsed.
  */
-int sam_hdr_name2id(sam_hdr_t *bh, const char *ref) {
+int sam_hdr_name2tid(sam_hdr_t *bh, const char *ref) {
     sam_hrecs_t *hrecs;
     khint_t k;
 
@@ -1455,7 +1455,7 @@ int sam_hdr_name2id(sam_hdr_t *bh, const char *ref) {
     return k == kh_end(hrecs->ref_hash) ? -1 : kh_val(hrecs->ref_hash, k);
 }
 
-const char *sam_hdr_id2name(const sam_hdr_t *h, int tid) {
+const char *sam_hdr_tid2name(const sam_hdr_t *h, int tid) {
     sam_hrecs_t *hrecs;
 
     if (!h)
@@ -1471,7 +1471,7 @@ const char *sam_hdr_id2name(const sam_hdr_t *h, int tid) {
     return NULL;
 }
 
-uint32_t sam_hdr_id2len(const sam_hdr_t *h, int tid) {
+uint32_t sam_hdr_tid2len(const sam_hdr_t *h, int tid) {
     sam_hrecs_t *hrecs;
 
     if (!h)

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -611,7 +611,7 @@ int sam_hdr_remove_tag_id(sam_hdr_t *h, const char *type, const char *ID_key, co
  * Looks up a reference sequence by name in the reference hash table
  * and returns the numerical target id.
  */
-int sam_hdr_name2id(sam_hdr_t *h, const char *ref);
+int sam_hdr_name2tid(sam_hdr_t *h, const char *ref);
 
 /// Get the reference sequence name from a target index
 /*!
@@ -621,7 +621,7 @@ int sam_hdr_name2id(sam_hdr_t *h, const char *ref);
  * Fetch the reference sequence name from the target name array,
  * using the numerical target id.
  */
-const char *sam_hdr_id2name(const sam_hdr_t *h, int tid);
+const char *sam_hdr_tid2name(const sam_hdr_t *h, int tid);
 
 /// Get the reference sequence length from a target index
 /*!
@@ -631,16 +631,16 @@ const char *sam_hdr_id2name(const sam_hdr_t *h, int tid);
  * Fetch the reference sequence length from the target length array,
  * using the numerical target id.
  */
-uint32_t sam_hdr_id2len(const sam_hdr_t *h, int tid);
+uint32_t sam_hdr_tid2len(const sam_hdr_t *h, int tid);
 
-/// Alias of sam_hdr_name2id(), for backwards compatibility.
+/// Alias of sam_hdr_name2tid(), for backwards compatibility.
 /*!
  * @param ref  Reference name
  * @return     Positive value on success,
  *             -1 if unknown reference,
  *             -2 if the header could not be parsed
  */
-static inline int bam_name2id(sam_hdr_t *h, const char *ref) { return sam_hdr_name2id(h, ref); }
+static inline int bam_name2id(sam_hdr_t *h, const char *ref) { return sam_hdr_name2tid(h, ref); }
 
 /// Generate a unique \@PG ID: value
 /*!

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -621,7 +621,7 @@ int sam_hdr_name2id(sam_hdr_t *h, const char *ref);
  * Fetch the reference sequence name from the target name array,
  * using the numerical target id.
  */
-const char *sam_hdr_id2name(sam_hdr_t *h, int tid);
+const char *sam_hdr_id2name(const sam_hdr_t *h, int tid);
 
 /// Get the reference sequence length from a target index
 /*!
@@ -631,7 +631,7 @@ const char *sam_hdr_id2name(sam_hdr_t *h, int tid);
  * Fetch the reference sequence length from the target length array,
  * using the numerical target id.
  */
-uint32_t sam_hdr_id2len(sam_hdr_t *h, int tid);
+uint32_t sam_hdr_id2len(const sam_hdr_t *h, int tid);
 
 /// Alias of sam_hdr_name2id(), for backwards compatibility.
 /*!

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -611,16 +611,36 @@ int sam_hdr_remove_tag_id(sam_hdr_t *h, const char *type, const char *ID_key, co
  * Looks up a reference sequence by name in the reference hash table
  * and returns the numerical target id.
  */
-int sam_hdr_name2ref(sam_hdr_t *h, const char *ref);
+int sam_hdr_name2id(sam_hdr_t *h, const char *ref);
 
-/// Alias of sam_hdr_name2ref(), for backwards compatibility.
+/// Get the reference sequence name from a target index
+/*!
+ * @param tid  Target index
+ * @return     Valid reference name on success, NULL on failure
+ *
+ * Fetch the reference sequence name from the target name array,
+ * using the numerical target id.
+ */
+const char *sam_hdr_id2name(sam_hdr_t *h, int tid);
+
+/// Get the reference sequence length from a target index
+/*!
+ * @param tid  Target index
+ * @return     Strictly positive value on success, 0 on failure
+ *
+ * Fetch the reference sequence length from the target length array,
+ * using the numerical target id.
+ */
+uint32_t sam_hdr_id2len(sam_hdr_t *h, int tid);
+
+/// Alias of sam_hdr_name2id(), for backwards compatibility.
 /*!
  * @param ref  Reference name
  * @return     Positive value on success,
  *             -1 if unknown reference,
  *             -2 if the header could not be parsed
  */
-static inline int bam_name2id(sam_hdr_t *h, const char *ref) { return sam_hdr_name2ref(h, ref); }
+static inline int bam_name2id(sam_hdr_t *h, const char *ref) { return sam_hdr_name2id(h, ref); }
 
 /// Generate a unique \@PG ID: value
 /*!

--- a/sam.c
+++ b/sam.c
@@ -1024,7 +1024,7 @@ hts_itr_t *sam_itr_queryi(const hts_idx_t *idx, int tid, int beg, int end)
 static int cram_name2id(void *fdv, const char *ref)
 {
     cram_fd *fd = (cram_fd *) fdv;
-    return sam_hdr_name2id(fd->header, ref);
+    return sam_hdr_name2tid(fd->header, ref);
 }
 
 hts_itr_t *sam_itr_querys(const hts_idx_t *idx, sam_hdr_t *hdr, const char *region)

--- a/sam.c
+++ b/sam.c
@@ -1024,7 +1024,7 @@ hts_itr_t *sam_itr_queryi(const hts_idx_t *idx, int tid, int beg, int end)
 static int cram_name2id(void *fdv, const char *ref)
 {
     cram_fd *fd = (cram_fd *) fdv;
-    return sam_hdr_name2ref(fd->header, ref);
+    return sam_hdr_name2id(fd->header, ref);
 }
 
 hts_itr_t *sam_itr_querys(const hts_idx_t *idx, sam_hdr_t *hdr, const char *region)


### PR DESCRIPTION
Rename `sam_hdr_name2ref` to `sam_hdr_name2id`.
Add methods `sam_hdr_id2name` and `sam_hdr_id2len`.