### PR TITLE
[header API] Change return value of sam_hdr_length

### DIFF
--- a/header.c
+++ b/header.c
@@ -1051,7 +1051,7 @@ static sam_hrec_type_t *sam_hrecs_find_type_pos(sam_hrecs_t *hrecs,
 
 size_t sam_hdr_length(sam_hdr_t *bh) {
     if (!bh || -1 == sam_hdr_rebuild(bh))
-        return -1;
+        return SIZE_MAX;
 
     return bh->l_text;
 }
@@ -1071,7 +1071,7 @@ int sam_hdr_nref(const sam_hdr_t *bh) {
 }
 
 /*
- * Reconstructs the kstring from the header hash table.
+ * Reconstructs the text representation from the header hash table.
  * Returns 0 on success
  *        -1 on failure
  */
@@ -1084,8 +1084,10 @@ int sam_hdr_rebuild(sam_hdr_t *bh) {
         return bh->text ? 0 : -1;
 
     if (hrecs->refs_changed >= 0) {
-        if (rebuild_target_arrays(bh) < 0)
+        if (rebuild_target_arrays(bh) < 0) {
+            hts_log_error("Header target array rebuild has failed");
             return -1;
+        }
     }
 
     /* If header text wasn't changed or header is empty, don't rebuild it. */
@@ -1098,6 +1100,7 @@ int sam_hdr_rebuild(sam_hdr_t *bh) {
     kstring_t ks = KS_INITIALIZER;
     if (sam_hrecs_rebuild_text(hrecs, &ks) != 0) {
         KS_FREE(&ks);
+        hts_log_error("Header text rebuild has failed");
         return -1;
     }
 

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -549,10 +549,34 @@ int sam_hdr_keep_line(sam_hdr_t *h, const char *type, const char *ID_key, const 
  * @param type  Type of the searched line. Eg. "RG"
  * @param id    Tag key defining the line. Eg. "ID"
  * @param rh    Hash set initialised by the caller with the values to be kept.
+ *              See description for how to create this.
  * @return      0 on success, -1 on failure
  *
  * Remove all lines of type <type> from the header, except the one
- * specified in the hash set rh.
+ * specified in the hash set @p rh.
+ * Declaration of @rh is done using KHASH_SET_INIT_STR macro. Eg.
+ * @code{.c}
+ *              KHASH_SET_INIT_STR(remove)
+ *              typedef khash_t(remove) *remhash_t;
+ *
+ *              void your_method() {
+ *                  samFile *sf = sam_open("alignment.bam", "r");
+ *                  sam_hdr_t *h = sam_hdr_read(sf);
+ *                  remhash_t rh = kh_init(remove);
+ *                  int ret = 0;
+ *                  kh_put(remove, rh, strdup("chr2"), &ret);
+ *                  kh_put(remove, rh, strdup("chr3"), &ret);
+ *                  if (sam_hdr_remove_lines(h, "SQ", "SN", rh) == -1)
+ *                      fprintf(stderr, "Error removing lines\n");
+ *                  khint_t k;
+ *                  for (k = 0; k < kh_end(rh); ++k)
+ *                     if (kh_exist(rh, k)) free((char*)kh_key(rh, k));
+ *                  kh_destroy(remove, rh);
+ *                  sam_hdr_destroy(h);
+ *                  sam_close(sf);
+ *              }
+ * @endcode
+ *
  */
 int sam_hdr_remove_lines(sam_hdr_t *h, const char *type, const char *id, void *rh);
 

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -381,7 +381,7 @@ int sam_hdr_write(samFile *fp, const sam_hdr_t *h) HTS_RESULT_USED;
 
 /// Returns the current length of the header text.
 /*!
- * @return  >= 0 on success, -1 on failure
+ * @return  >= 0 on success, SIZE_MAX on failure
  */
 size_t sam_hdr_length(sam_hdr_t *h);
 


### PR DESCRIPTION
Make `sam_hdr_length` return **SIZE_MAX** in case of error, thus matching its return type range.

The underlying error would be logged by the called method that produced it.