### PR TITLE
Curl is now in the default non-configure build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ AR     = ar
 RANLIB = ranlib
 
 # Default libraries to link if configure is not used
-htslib_default_libs = -lz -lm -lbz2 -llzma
+htslib_default_libs = -lz -lm -lbz2 -llzma -lcurl
 
 CPPFLAGS =
 # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
@@ -174,7 +174,13 @@ LIBHTS_OBJS = \
 	cram/open_trace_file.o \
 	cram/pooled_alloc.o \
 	cram/rANS_static.o \
-	cram/string_alloc.o
+	cram/string_alloc.o \
+	$(NONCONFIGURE_OBJS)
+
+# Without configure we wish to have a rich set of default figures,
+# but we still need conditional inclusion as we wish to still
+# support ./configure --disable-blah.
+NONCONFIGURE_OBJS = hfile_libcurl.o
 
 PLUGIN_EXT  =
 PLUGIN_OBJS =
@@ -212,6 +218,7 @@ config.h:
 	echo '#define HAVE_LZMA_H 1' >> $@
 	echo '#define HAVE_FSEEKO 1' >> $@
 	echo '#define HAVE_DRAND48 1' >> $@
+	echo '#define HAVE_LIBCURL 1' >> $@
 
 # And similarly for htslib.pc.tmp ("pkg-config template").  No dependency
 # on htslib.pc.in listed, as if that file is newer the usual way to regenerate

--- a/config.mk.in
+++ b/config.mk.in
@@ -48,6 +48,10 @@ LIBS     = @LIBS@
 PLATFORM   = @PLATFORM@
 PLUGIN_EXT = @PLUGIN_EXT@
 
+# The default Makefile enables some of the optional files, but we blank
+# them so they can be controlled by configure instead.
+NONCONFIGURE_OBJS =
+
 # Lowercase here indicates these are "local" to config.mk
 plugin_OBJS =
 noplugin_LDFLAGS =


### PR DESCRIPTION
This makes a naive build using `make` (ie not `./configure;make`) still build with https support.  This is important as it's required for htsget, refget, and hence the default operation of CRAM.  The ease with which users can build a non-functioning samtools has repeatedly lead to queries, so hopefully this is a non-contentious change. 

Note this does not deny the ability to build without curl, using knet for http and ftp only (although I'd argue that's a mental thing to do and we shouldn't provide an alternative half-baked web support at all).  It simply makes it the non-default option.  Users wishing to build a reduced-functionality htslib will now need to consciously make that decision using `./configure --disable-libcurl`.

The *ideal* change (ie not this PR) would be to totally throw away the Makefile and produce a Makefile.in which is a merge of current Makefile and config.mk.in and make configure mandatory.  That will also mean it's not possible to accidentally build an htslib without gcs or s3 support too, which this PR doesn't fix - it's complex due to the HMAC searching code.  (However sadly that's met great resistance historically, as has completely ditching knet, so neither are a topic for this PR.)