### PR TITLE
Make CRAM multi-ref mode more transitive.

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -3135,7 +3135,7 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
             multi_seq = 1;
         } else if (fd->multi_seq == 1) {
             pthread_mutex_lock(&fd->metrics_lock);
-            if (fd->last_RI_count <= c->max_slice) {
+            if (fd->last_RI_count <= c->max_slice && fd->multi_seq_user != 1) {
                 multi_seq = 0;
                 hts_log_info("Multi-ref disabled for next container");
             }
@@ -3168,8 +3168,8 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
             // User selected auto-mode, we're currently using multi-seq, but
             // have detected we don't need to.  Switch back to auto.
             fd->multi_seq = -1;
-        } else if (multi_seq || fd->multi_seq == 1) {
-            // We either detected multi-seq needed or user explicitly asked for it.
+        } else if (multi_seq) {
+            // We detected we need multi-seq
             fd->multi_seq = 1;
             c->multi_seq = 1;
             c->pos_sorted = 0; // required atm for multi_seq slices

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -4256,7 +4256,7 @@ cram_fd *cram_dopen(hFILE *fp, const char *filename, const char *mode) {
     fd->shared_ref = 0;
     fd->store_md = 0;
     fd->store_nm = 0;
-    fd->last_RI = 0;
+    fd->last_RI_count = 0;
 
     fd->index       = NULL;
     fd->own_pool    = 0;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -4251,10 +4251,12 @@ cram_fd *cram_dopen(hFILE *fp, const char *filename, const char *mode) {
     fd->use_rans = (CRAM_MAJOR_VERS(fd->version) >= 3);
     fd->use_lzma = 0;
     fd->multi_seq = -1;
+    fd->multi_seq_user = -1;
     fd->unsorted   = 0;
     fd->shared_ref = 0;
     fd->store_md = 0;
     fd->store_nm = 0;
+    fd->last_RI = 0;
 
     fd->index       = NULL;
     fd->own_pool    = 0;
@@ -4616,7 +4618,7 @@ int cram_set_voption(cram_fd *fd, enum hts_fmt_option opt, va_list args) {
     }
 
     case CRAM_OPT_MULTI_SEQ_PER_SLICE:
-        fd->multi_seq = va_arg(args, int);
+        fd->multi_seq_user = fd->multi_seq = va_arg(args, int);
         break;
 
     case CRAM_OPT_NTHREADS: {

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -741,7 +741,9 @@ typedef struct cram_fd {
     off_t curr_position;
     int eof;
     int last_slice;                     // number of recs encoded in last slice
+    int last_RI;                        // number of references encoded in last container
     int multi_seq;
+    int multi_seq_user;
     int unsorted;
     int empty_container;                // Marker for EOF block
 

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -741,9 +741,9 @@ typedef struct cram_fd {
     off_t curr_position;
     int eof;
     int last_slice;                     // number of recs encoded in last slice
-    int last_RI;                        // number of references encoded in last container
-    int multi_seq;
-    int multi_seq_user;
+    int last_RI_count;                  // number of references encoded in last container
+    int multi_seq;                      // -1 is auto, 0 is one ref per container, 1 is multi...
+    int multi_seq_user;                 // Original user setting (CRAM_OPT_MULTI_SEQ_PER_SLICE)
     int unsorted;
     int empty_container;                // Marker for EOF block
 


### PR DESCRIPTION
There was already code to automatically enable it, but now it has code to automatically disable again when appropriate.  This can have a considerable size reduction for some data sets (due to re-enabling AP_delta mainly).

I've checked it using `-fsanitize=thread` too to validate the new lock.