### PR TITLE
Restore support for QNAMEs longer than 251 characters

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -52,6 +52,12 @@ Noteworthy changes in release a.b
     sam_hdr_str() should be used instead.  The old cigar_tab field is
     now marked as deprecated; use the new bam_cigar_table[] instead.
 
+  - The bam1_core_t structure's l_qname and l_extranul fields have been
+    rearranged and enlarged; l_qname still includes the extra NULs.
+    (Almost all code should use bam_get_qname(), bam_get_cigar(), etc,
+    and has no need to use these fields directly.)  HTSlib now supports
+    the SAM specification's full 254 QNAME length again.  (#520)
+
   - bcf_index_load() no longer tries the '.tbi' suffix when looking for
     BCF index files (.tbi indexes are for text files, not binary BCF).
 

--- a/cram/cram_samtools.c
+++ b/cram/cram_samtools.c
@@ -79,8 +79,6 @@ int bam_construct_seq(bam_seq_t **bp, size_t extra_len,
     //b->l_aux = extra_len; // we fill this out later
 
     qname_nuls = 4 - qname_len%4;
-    if (qname_len + qname_nuls > 255) // Check for core.l_qname overflow
-        return -1;
     bam_len = qname_len + qname_nuls + ncigar*4 + (len+1)/2 + len + extra_len;
     if (b->m_data < bam_len) {
         b->m_data = bam_len;

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -188,10 +188,9 @@ typedef struct {
     int32_t pos;
     uint16_t bin;
     uint8_t qual;
-    uint8_t l_qname;
-    uint16_t flag;
-    uint8_t unused1;
     uint8_t l_extranul;
+    uint16_t flag;
+    uint16_t l_qname;
     uint32_t n_cigar;
     int32_t l_qseq;
     int32_t mtid;

--- a/sam.c
+++ b/sam.c
@@ -545,8 +545,6 @@ int bam_read1(BGZF *fp, bam1_t *b)
     c->tid = x[0]; c->pos = x[1];
     c->bin = x[2]>>16; c->qual = x[2]>>8&0xff; c->l_qname = x[2]&0xff;
     c->l_extranul = (c->l_qname%4 != 0)? (4 - c->l_qname%4) : 0;
-    if ((uint32_t) c->l_qname + c->l_extranul > 255) // l_qname would overflow
-        return -4;
     c->flag = x[3]>>16; c->n_cigar = x[3]&0xffff;
     c->l_qseq = x[4];
     c->mtid = x[5]; c->mpos = x[6]; c->isize = x[7];
@@ -1662,7 +1660,7 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
     q = _read_token(p);
 
     _parse_warn(p - q <= 1, "empty query name");
-    _parse_err(p - q > 252, "query name too long");
+    _parse_err(p - q > 255, "query name too long");
     // resize large enough for name + extranul
     if ((p-q)+4 > SIZE_MAX - s->l || ks_resize(&str, str.l+(p-q)+4) < 0) goto err_ret;
     memcpy(str.s+str.l, q, p-q); str.l += p-q;

--- a/sam.c
+++ b/sam.c
@@ -588,6 +588,11 @@ int bam_write1(BGZF *fp, const bam1_t *b)
     const bam1_core_t *c = &b->core;
     uint32_t x[8], block_len = b->l_data - c->l_extranul + 32, y;
     int i, ok;
+    if (c->l_qname - c->l_extranul > 255) {
+        hts_log_error("QNAME \"%s\" is longer than 254 characters", bam_get_qname(b));
+        errno = EOVERFLOW;
+        return -1;
+    }
     if (c->n_cigar > 0xffff) block_len += 16; // "16" for "CGBI", 4-byte tag length and 8-byte fake CIGAR
     x[0] = c->tid;
     x[1] = c->pos;

--- a/test/sam.c
+++ b/test/sam.c
@@ -928,6 +928,9 @@ static void test_header_updates(void) {
     sam_hdr_destroy(header);
 }
 
+#define ABC50   "abcdefghijklmnopqrstuvwxyabcdefghijklmnopqrstuvwxy"
+#define ABC250  ABC50 ABC50 ABC50 ABC50 ABC50
+
 static void samrecord_layout(void)
 {
     static const char qnames[] = "data:,"
@@ -936,7 +939,13 @@ static void samrecord_layout(void)
    "bc\t0\tCHROMOSOME_II\t200\t10\t4M\t*\t0\t0\tATGC\tqqqq\n"
   "def\t0\tCHROMOSOME_II\t300\t10\t4M\t*\t0\t0\tATGC\tqqqq\n"
  "ghij\t0\tCHROMOSOME_II\t400\t10\t4M\t*\t0\t0\tATGC\tqqqq\n"
-"klmno\t0\tCHROMOSOME_II\t500\t10\t4M\t*\t0\t0\tATGC\tqqqq\n";
+"klmno\t0\tCHROMOSOME_II\t500\t10\t4M\t*\t0\t0\tATGC\tqqqq\n"
+     ABC250 "\t0\tCHROMOSOME_II\t600\t10\t4M\t*\t0\t0\tATGC\tqqqq\n"
+    ABC250 "1\t0\tCHROMOSOME_II\t650\t10\t4M\t*\t0\t0\tATGC\tqqqq\n"
+   ABC250 "12\t0\tCHROMOSOME_II\t700\t10\t4M\t*\t0\t0\tATGC\tqqqq\n"
+  ABC250 "123\t0\tCHROMOSOME_II\t750\t10\t4M\t*\t0\t0\tATGC\tqqqq\n"
+ ABC250 "1234\t0\tCHROMOSOME_II\t800\t10\t4M\t*\t0\t0\tATGC\tqqqq\n"
+;
 
     size_t bam1_t_size, bam1_t_size2;
 


### PR DESCRIPTION
Another ABI breaker that was in danger of being forgotten about while the ABI change window is open (leastwise I for one had forgotten about it!): change `l_qname` to `uint16_t` so QNAME length can be returned to the spec's 254 from 079c7b81d3eb740f575d6ee07f8d0df36932559e's 251 — see #520.

As the soversion is being bumped, we have the luxury of fixing this by simply enlarging the `l_qname` field. It needs to represent the values 0…256 so most of the new bits are wasted, but ¯\\\_(ツ)\_/¯ and maybe one day we may have a format wanting longer QNAMEs…

Adds test cases with long read names. I wish I had though of such test cases when I first implemented the align-the-CIGAR-data thing in 5d114ebd8e9b80622769b8e575c5a9359cd51273!

Fixes #520. Supersedes and closes #523.