### PR TITLE
Support seeking in uncompressed files with bgzf_seek and bgzf_tell

### DIFF
--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -201,7 +201,7 @@ typedef struct BGZF BGZF;
      * call to bgzf_seek can be used to position the file at the same point.
      * Return value is non-negative on success.
      */
-    #define bgzf_tell(fp) (((fp)->block_address << 16) | ((fp)->block_offset & 0xFFFF))
+    #define bgzf_tell(fp) ((fp)->is_compressed ? ((fp)->block_address << 16) | ((fp)->block_offset & 0xFFFF) : (fp)->block_address + (fp)->block_offset)
 
     /**
      * Set the file to read from the location specified by _pos_.


### PR DESCRIPTION
This modifies bgzf_tell and bgzf_seek to pass through the real offset as the
virtual offset in uncompressed files. It also makes sure to consistently use
only block_address and not block_offset when passing around the seek location
in uncompressed files.

This fixes #899.