### PR TITLE
sam_parse1(): return to allowing FLAGs in hex/octal; avoid overflow

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -98,8 +98,10 @@ static int kget_int32(kstring_t *k, size_t *pos, int32_t *val_p) {
     if (p >= k->l || !(k->s[p] >= '0' && k->s[p] <= '9'))
         return -1;
 
-    while (p < k->l && k->s[p] >= '0' && k->s[p] <= '9')
-        val = val*10 + k->s[p++]-'0';
+    while (p < k->l && k->s[p] >= '0' && k->s[p] <= '9') {
+        int digit = k->s[p++]-'0';
+        val = val*10 + digit;
+    }
 
     *pos = p;
     *val_p = sign*val;
@@ -121,8 +123,10 @@ static int kget_int64(kstring_t *k, size_t *pos, int64_t *val_p) {
     if (p >= k->l || !(k->s[p] >= '0' && k->s[p] <= '9'))
         return -1;
 
-    while (p < k->l && k->s[p] >= '0' && k->s[p] <= '9')
-        val = val*10 + k->s[p++]-'0';
+    while (p < k->l && k->s[p] >= '0' && k->s[p] <= '9') {
+        int digit = k->s[p++]-'0';
+        val = val*10 + digit;
+    }
 
     *pos = p;
     *val_p = sign*val;

--- a/sam.c
+++ b/sam.c
@@ -1609,6 +1609,22 @@ static inline uint64_t STRTOUL64(const char *v, char **rv, int b) {
     return n;
 }
 
+static inline unsigned int parse_sam_flag(char *v, char **rv) {
+    if (*v >= '1' && *v <= '9') {
+        return STRTOUL64(v, rv, 10);
+    }
+    else if (*v == '0') {
+        // handle single-digit "0" directly; otherwise it's hex or octal
+        if (v[1] == '\t') { *rv = v+1; return 0; }
+        else return strtoul(v, rv, 0);
+    }
+    else {
+        // TODO implement symbolic flag letters
+        *rv = v;
+        return 0;
+    }
+}
+
 int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
 {
 #define _read_token(_p) (_p); do { char *tab = strchr((_p), '\t'); if (!tab) goto err_ret; *tab = '\0'; (_p) = tab + 1; } while (0)
@@ -1677,7 +1693,7 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
     c->l_qname = p - q + c->l_extranul;
 
     // flag
-    c->flag = STRTOL64(p, &p, 0);
+    c->flag = parse_sam_flag(p, &p);
     if (*p++ != '\t') goto err_ret; // malformated flag
 
     // chr

--- a/sam.c
+++ b/sam.c
@@ -1588,19 +1588,23 @@ static inline int64_t STRTOL64(const char *v, char **rv, int b) {
 
     v++;
 
-    while (*v>='0' && *v<='9')
-        n = n*10 + *v++ - '0';
+    while (*v>='0' && *v<='9') {
+        int digit = *v++ - '0';
+        n = n*10 + digit;
+    }
     *rv = (char *)v;
     return neg*n;
 }
 
-static inline int64_t STRTOUL64(const char *v, char **rv, int b) {
-    int64_t n = 0;
+static inline uint64_t STRTOUL64(const char *v, char **rv, int b) {
+    uint64_t n = 0;
     if (*v == '+')
         v++;
 
-    while (*v>='0' && *v<='9')
-        n = n*10 + *v++ - '0';
+    while (*v>='0' && *v<='9') {
+        int digit = *v++ - '0';
+        n = n*10 + digit;
+    }
     *rv = (char *)v;
     return n;
 }


### PR DESCRIPTION
[More things noticed while going over the header code…]

Avoid overflow in `STRTOL64()` and `STRTOUL64()` (and similar functions in _cram/cram_index.c_) by ensuring that the subtraction occurs first. Compiling with `-fsanitize=undefined` (for the unsigned ones, use `-fsanitize=unsigned-integer-overflow` as well) demonstrates these overflows.

At the moment this doesn't matter too much for the _sam.c_ functions as they are used only up to 32 bits, but this prepares them for actual 64-bit use. Also changed the return type of `STRTOUL64()` to be unsigned — @jkbonfield was it intentional to use `int64_t` for `STRTOUL64` (performance reasons?) or is changing this to `uint64_t` okay?

Prior to the recent 9f28a4f1bee95eb0842e92a8a994c34bdfb657ae, `sam_parse1()` used `strtol(p, &p, 0)` to parse SAM's FLAG field, which thus accepted decimal/hex/octal. HTSJDK has reimplemented the historical samtools decimal/hex/symbolic-letters FLAG field (cf old `samtools view -x -X`; see samtools/htsjdk#232, which implements decimal/hex/octal/symbolic), and it is planned to propose hex/symbolic-letters for inclusion in the SAM spec sometime (probably at a point when HTSlib at least has the infrastructure to implement it!). So it would be a shame to remove HTSlib's existing hex/octal FLAG parsing ability at this point.

This PR adds a `parse_sam_flag()` function to parse decimal/hex/octal while preserving James's fast implementation for the common decimal case. The function also provides a slot for the eventual implementation of parsing symbolic-letters FLAGs.

(Prior to that change, B-arrays were also parsed with `strtol(…, 0)` so accepted decimal/hex/ octal, but HTSJDK doesn't accept that, there's no precedent or desire to extend the spec to allow hex/etc there, and non-array `i` tag values were always decimal-only so this appeared to be unintentional; hence this PR leaves the new decimal-only behaviour for B-arrays as is.)