### PR TITLE
Fix libdeflate configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -275,9 +275,10 @@ fi
 AS_IF([test "x$with_libdeflate" != "xno"],
   [libdeflate=ok
    AC_CHECK_HEADER([libdeflate.h],[],[libdeflate='missing header'],[;])
-   AC_CHECK_LIB([deflate], [libdeflate_deflate_compress],[],[libdeflate='missing library'])
+   AC_CHECK_LIB([deflate], [libdeflate_deflate_compress],[:],[libdeflate='missing library'])
    AS_IF([test "$libdeflate" = "ok"],
     [AC_DEFINE([HAVE_LIBDEFLATE], 1, [Define if libdeflate is available.])
+     LIBS="-ldeflate $LIBS"
      private_LIBS="$private_LIBS -ldeflate"
      static_LIBS="$static_LIBS -ldeflate"],
     [AS_IF([test "x$with_libdeflate" != "xcheck"],


### PR DESCRIPTION
By default or with --with-libdeflate=check, the intention is to carry on as per --without-libdeflate when either header or library is missing.

For the case when libdeflate.h is missing but the library is found (admittedly an odd case!), the default AC_CHECK_LIB ACTION-IF-FOUND will define HAVE_LIBDEFLATE and add to $LIBS itself — leading to later build failures as we (ab)use that macro to mean both HAVE_LIBDEFLATE_H and HAVE_LIBDEFLATE.

Instead use a no-op found action, and only AC_DEFINE(HAVE_LIBDEFLATE) and add to $LIBS when **both** checks have succeeded.

This scenario was the cause of the Travis failures in pysam-developers/pysam#829.