### PR TITLE
[header API] Add methods `sam_hdr_line_index` and `sam_hdr_line_name`.

### DIFF
--- a/header.c
+++ b/header.c
@@ -1572,12 +1572,15 @@ int sam_hdr_count_lines(sam_hdr_t *bh, const char *type) {
     case 'S':
         if (type[1] == 'Q')
             return bh->hrecs->nref;
+        break;
     case 'R':
         if (type[1] == 'G')
             return bh->hrecs->nrg;
+        break;
     case 'P':
         if (type[1] == 'G')
             return bh->hrecs->npg;
+        break;
     default:
         break;
     }
@@ -1616,6 +1619,8 @@ int sam_hdr_line_index(sam_hdr_t *bh,
             k = kh_get(m_s2i, hrecs->ref_hash, key);
             if (k != kh_end(hrecs->ref_hash))
                 idx = kh_val(hrecs->ref_hash, k);
+        } else {
+            hts_log_warning("Type '%s' not supported. Only @SQ, @RG and @PG lines are indexed", type);
         }
         break;
     case 'R':
@@ -1623,6 +1628,8 @@ int sam_hdr_line_index(sam_hdr_t *bh,
             k = kh_get(m_s2i, hrecs->rg_hash, key);
             if (k != kh_end(hrecs->rg_hash))
                 idx = kh_val(hrecs->rg_hash, k);
+        } else {
+            hts_log_warning("Type '%s' not supported. Only @SQ, @RG and @PG lines are indexed", type);
         }
         break;
     case 'P':
@@ -1630,10 +1637,12 @@ int sam_hdr_line_index(sam_hdr_t *bh,
             k = kh_get(m_s2i, hrecs->pg_hash, key);
             if (k != kh_end(hrecs->pg_hash))
                 idx = kh_val(hrecs->pg_hash, k);
+        } else {
+            hts_log_warning("Type '%s' not supported. Only @SQ, @RG and @PG lines are indexed", type);
         }
         break;
     default:
-        break;
+        hts_log_warning("Type '%s' not supported. Only @SQ, @RG and @PG lines are indexed", type);
     }
 
     return idx;
@@ -1654,16 +1663,31 @@ const char *sam_hdr_line_name(sam_hdr_t *bh,
 
     switch (type[0]) {
     case 'S':
-        if (type[1] == 'Q' && pos < hrecs->nref)
-            return hrecs->ref[pos].name;
-    case 'R':
-        if (type[1] == 'G' && pos < hrecs->nrg)
-            return hrecs->rg[pos].name;
-    case 'P':
-        if (type[1] == 'G' && pos < hrecs->npg)
-            return hrecs->pg[pos].name;
-    default:
+        if (type[1] == 'Q') {
+            if (pos < hrecs->nref)
+                return hrecs->ref[pos].name;
+        } else {
+            hts_log_warning("Type '%s' not supported. Only @SQ, @RG and @PG lines are indexed", type);
+        }
         break;
+    case 'R':
+        if (type[1] == 'G') {
+            if (pos < hrecs->nrg)
+                return hrecs->rg[pos].name;
+        } else {
+            hts_log_warning("Type '%s' not supported. Only @SQ, @RG and @PG lines are indexed", type);
+        }
+        break;
+    case 'P':
+        if (type[1] == 'G') {
+            if (pos < hrecs->npg)
+                return hrecs->pg[pos].name;
+        } else {
+            hts_log_warning("Type '%s' not supported. Only @SQ, @RG and @PG lines are indexed", type);
+        }
+        break;
+    default:
+        hts_log_warning("Type '%s' not supported. Only @SQ, @RG and @PG lines are indexed", type);
     }
 
     return NULL;

--- a/header.c
+++ b/header.c
@@ -1595,6 +1595,80 @@ int sam_hdr_count_lines(sam_hdr_t *bh, const char *type) {
     return count;
 }
 
+int sam_hdr_line_index(sam_hdr_t *bh,
+                       const char *type,
+                       const char *key) {
+    sam_hrecs_t *hrecs;
+    if (!bh || !type || !key)
+        return -2;
+
+    if (!(hrecs = bh->hrecs)) {
+        if (sam_hdr_fill_hrecs(bh) != 0)
+            return -2;
+        hrecs = bh->hrecs;
+    }
+
+    khint_t k;
+    int idx = -1;
+    switch (type[0]) {
+    case 'S':
+        if (type[1] == 'Q') {
+            k = kh_get(m_s2i, hrecs->ref_hash, key);
+            if (k != kh_end(hrecs->ref_hash))
+                idx = kh_val(hrecs->ref_hash, k);
+        }
+        break;
+    case 'R':
+        if (type[1] == 'G') {
+            k = kh_get(m_s2i, hrecs->rg_hash, key);
+            if (k != kh_end(hrecs->rg_hash))
+                idx = kh_val(hrecs->rg_hash, k);
+        }
+        break;
+    case 'P':
+        if (type[1] == 'G') {
+            k = kh_get(m_s2i, hrecs->pg_hash, key);
+            if (k != kh_end(hrecs->pg_hash))
+                idx = kh_val(hrecs->pg_hash, k);
+        }
+        break;
+    default:
+        break;
+    }
+
+    return idx;
+}
+
+const char *sam_hdr_line_name(sam_hdr_t *bh,
+                              const char *type,
+                              int pos) {
+    sam_hrecs_t *hrecs;
+    if (!bh || !type || pos < 0)
+        return NULL;
+
+    if (!(hrecs = bh->hrecs)) {
+        if (sam_hdr_fill_hrecs(bh) != 0)
+            return NULL;
+        hrecs = bh->hrecs;
+    }
+
+    switch (type[0]) {
+    case 'S':
+        if (type[1] == 'Q' && pos < hrecs->nref)
+            return hrecs->ref[pos].name;
+    case 'R':
+        if (type[1] == 'G' && pos < hrecs->nrg)
+            return hrecs->rg[pos].name;
+    case 'P':
+        if (type[1] == 'G' && pos < hrecs->npg)
+            return hrecs->pg[pos].name;
+    default:
+        break;
+    }
+
+    return NULL;
+}
+
 /* ==== Key:val level methods ==== */
 
 int sam_hdr_find_tag_id(sam_hdr_t *bh,

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -587,6 +587,24 @@ int sam_hdr_remove_lines(sam_hdr_t *h, const char *type, const char *id, void *r
  */
 int sam_hdr_count_lines(sam_hdr_t *h, const char *type);
 
+/// Index of the line for the types that have dedicated look-up tables (SQ, RG, PG)
+/*!
+ * @param h     BAM header
+ * @param type  Type of the searched line. Eg. "RG"
+ * @param key   The value of the identifying key. Eg. "rg1"
+ * @return  0-based index on success; -1 if line does not exist; -2 on failure
+ */
+int sam_hdr_line_index(sam_hdr_t *bh, const char *type, const char *key);
+
+/// Id key of the line for the types that have dedicated look-up tables (SQ, RG, PG)
+/*!
+ * @param h     BAM header
+ * @param type  Type of the searched line. Eg. "RG"
+ * @param pos   Zero-based index inside the type group. Eg. 2 (for the third RG line)
+ * @return  Valid key string on success; NULL on failure
+ */
+const char *sam_hdr_line_name(sam_hdr_t *bh, const char *type, int pos);
+
 /* ==== Key:val level methods ==== */
 
 /// Return the value associated with a key for a header line identified by ID_key:ID_val

--- a/test/sam.c
+++ b/test/sam.c
@@ -604,6 +604,7 @@ static void use_header_api(void) {
     kstring_t ks = { 0, 0, NULL };
     size_t bytes;
     int r;
+    const char *name;
 
     if (!in) {
         fail("couldn't open file");
@@ -649,6 +650,18 @@ static void use_header_api(void) {
     r = sam_hdr_add_line(header, "RG", "ID", "run4", NULL);
     if (r < 0) { fail("sam_hdr_add_line"); goto err; }
 
+    r = sam_hdr_line_index(header, "RG", "run4");
+    if (r != 3) { fail("sam_hdr_line_index - run4~3"); goto err; }
+
+    r = sam_hdr_line_index(header, "RG", "run5");
+    if (r != -1) { fail("sam_hdr_line_index - run5~-1"); goto err; }
+
+    name = sam_hdr_line_name(header, "RG", 2);
+    if (!name || strcmp(name, "run3")) { fail("sam_hdr_line_name - 2~run3"); goto err; }
+
+    name = sam_hdr_line_name(header, "RG", 10);
+    if (name) { fail("sam_hdr_line_name - 10~NULL"); goto err; }
+
     r = sam_hdr_remove_line_id(header, "RG", "ID", "run2");
     if (r < 0) { fail("sam_hdr_remove_line_id"); goto err; }
 
@@ -674,6 +687,12 @@ static void use_header_api(void) {
              r == 0 && ks.s ? ks.s : "NULL");
         goto err;
     }
+
+    r = sam_hdr_line_index(header, "RG", "run4");
+    if (r != 1) { fail("sam_hdr_line_index - run4~1"); goto err; }
+
+    name = sam_hdr_line_name(header, "RG", 2);
+    if (name) { fail("sam_hdr_line_name - 2~NULL"); goto err; }
 
     r = sam_hdr_remove_tag_hd(header, "SS");
     if (r < 0) {


### PR DESCRIPTION
`@SQ`, `@RG` and `@PG` lines have dedicated look-up tables and arrays, that should be exposed via the header API for faster retrieval of line position and identifier string.