### PR TITLE
Make .travis.yml conditional statements readable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,11 +56,40 @@ matrix:
 
 # For MacOSX systems
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$USE_CONFIG" == "no" ]]; then HOMEBREW_NO_AUTO_UPDATE=1 brew install xz || ( brew update && brew install xz ); fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" && "$USE_CONFIG" == "no" ]]; then
+      HOMEBREW_NO_AUTO_UPDATE=1 brew install xz || ( brew update && brew install xz )
+    fi
 
 before_script:
-  - if test "x$USE_LIBDEFLATE" == "xyes" ; then ( cd "$HOME" && git clone --depth 1 https://github.com/ebiggers/libdeflate.git && cd libdeflate && make -j 2 CFLAGS='-fPIC -O3' libdeflate.a ); fi
+  - |
+    if test "x$USE_LIBDEFLATE" == "xyes"; then
+      pushd "$HOME" && \
+        git clone --depth 1 https://github.com/ebiggers/libdeflate.git && \
+        pushd libdeflate && \
+        make -j 2 CFLAGS='-fPIC -O3' libdeflate.a && \
+        popd && \
+        popd
+    fi
 
 script:
-  - if test "x$USE_LIBDEFLATE" = "xyes" ; then CONFIG_OPTS='CPPFLAGS="-I$HOME/libdeflate" LDFLAGS="$LDFLAGS -L$HOME/libdeflate" --with-libdeflate' ; else CONFIG_OPTS='--without-libdeflate' ; fi
-  - if test "$USE_CONFIG" = "yes" ; then MAKE_OPTS= ; autoreconf && eval ./configure --enable-werror $CONFIG_OPTS CFLAGS=\"-g -O3 $CFLAGS\" || { cat config.log ; false ; } ; else MAKE_OPTS=-e ; fi && if test "x$DO_MAINTAINER_CHECKS" = "xyes" ; then make maintainer-check ; fi && make -j 2 $MAKE_OPTS && make test
+  - |
+    if test "x$USE_LIBDEFLATE" = "xyes"; then
+      CONFIG_OPTS='CPPFLAGS="-I$HOME/libdeflate" LDFLAGS="$LDFLAGS -L$HOME/libdeflate" --with-libdeflate'
+    else
+      CONFIG_OPTS='--without-libdeflate'
+    fi
+  - |
+    if test "$USE_CONFIG" = "yes"; then
+      MAKE_OPTS= ;
+      autoreconf && \
+        eval ./configure --enable-werror $CONFIG_OPTS CFLAGS=\"-g -O3 $CFLAGS\" || \
+        ( cat config.log; false )
+    else
+      MAKE_OPTS=-e
+    fi && \
+    if test "x$DO_MAINTAINER_CHECKS" = "xyes"; then
+      make maintainer-check
+    fi && \
+    make -j 2 $MAKE_OPTS && \
+    make test


### PR DESCRIPTION
I just send a pull-request to do refactoring to make `.travis.yml`'s conditional statements more readable.

YAML's `|` block style enables it.
Thanks.
