### PR TITLE
Fixes to issues found by fuzzing

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -542,6 +542,7 @@ cram_codec *cram_beta_decode_init(char *data, int size,
         c->decode = cram_beta_decode_char;
     else {
         hts_log_error("BYTE_ARRAYs not supported by this codec");
+        free(c);
         return NULL;
     }
     c->free   = cram_beta_decode_free;

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -355,6 +355,8 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
         int32_t size = 0;
         ptrdiff_t offset;
         cram_map *m;
+        enum cram_DS_ID ds_id;
+        enum cram_external_type type;
 
         if (endp - cp < 4) {
             cram_free_compression_header(hdr);
@@ -386,221 +388,85 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
          * Neither this C code nor Java reference implementations did this,
          * so we gloss over it and treat them as int.
          */
-
+        ds_id = DS_CORE;
         if (key[0] == 'B' && key[1] == 'F') {
-            if (!(hdr->codecs[DS_BF] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_BF; type = E_INT;
         } else if (key[0] == 'C' && key[1] == 'F') {
-            if (!(hdr->codecs[DS_CF] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_CF; type = E_INT;
         } else if (key[0] == 'R' && key[1] == 'I') {
-            if (!(hdr->codecs[DS_RI] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_RI; type = E_INT;
         } else if (key[0] == 'R' && key[1] == 'L') {
-            if (!(hdr->codecs[DS_RL] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_RL; type = E_INT;
         } else if (key[0] == 'A' && key[1] == 'P') {
-            if (!(hdr->codecs[DS_AP] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_AP; type = E_INT;
         } else if (key[0] == 'R' && key[1] == 'G') {
-            if (!(hdr->codecs[DS_RG] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_RG; type = E_INT;
         } else if (key[0] == 'M' && key[1] == 'F') {
-            if (!(hdr->codecs[DS_MF] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_MF; type = E_INT;
         } else if (key[0] == 'N' && key[1] == 'S') {
-            if (!(hdr->codecs[DS_NS] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_NS; type = E_INT;
         } else if (key[0] == 'N' && key[1] == 'P') {
-            if (!(hdr->codecs[DS_NP] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_NP; type = E_INT;
         } else if (key[0] == 'T' && key[1] == 'S') {
-            if (!(hdr->codecs[DS_TS] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_TS; type = E_INT;
         } else if (key[0] == 'N' && key[1] == 'F') {
-            if (!(hdr->codecs[DS_NF] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_NF; type = E_INT;
         } else if (key[0] == 'T' && key[1] == 'C') {
-            if (!(hdr->codecs[DS_TC] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_TC; type = E_BYTE;
         } else if (key[0] == 'T' && key[1] == 'N') {
-            if (!(hdr->codecs[DS_TN] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_TN; type = E_INT;
         } else if (key[0] == 'F' && key[1] == 'N') {
-            if (!(hdr->codecs[DS_FN] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_FN; type = E_INT;
         } else if (key[0] == 'F' && key[1] == 'C') {
-            if (!(hdr->codecs[DS_FC] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_FC; type = E_BYTE;
         } else if (key[0] == 'F' && key[1] == 'P') {
-            if (!(hdr->codecs[DS_FP] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_FP; type = E_INT;
         } else if (key[0] == 'B' && key[1] == 'S') {
-            if (!(hdr->codecs[DS_BS] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_BS; type = E_BYTE;
         } else if (key[0] == 'I' && key[1] == 'N') {
-            if (!(hdr->codecs[DS_IN] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE_ARRAY,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_IN; type = E_BYTE_ARRAY;
         } else if (key[0] == 'S' && key[1] == 'C') {
-            if (!(hdr->codecs[DS_SC] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE_ARRAY,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_SC; type = E_BYTE_ARRAY;
         } else if (key[0] == 'D' && key[1] == 'L') {
-            if (!(hdr->codecs[DS_DL] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_DL; type = E_INT;
         } else if (key[0] == 'B' && key[1] == 'A') {
-            if (!(hdr->codecs[DS_BA] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_BA; type = E_BYTE;
         } else if (key[0] == 'B' && key[1] == 'B') {
-            if (!(hdr->codecs[DS_BB] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE_ARRAY,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_BB; type = E_BYTE_ARRAY;
         } else if (key[0] == 'R' && key[1] == 'S') {
-            if (!(hdr->codecs[DS_RS] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_RS; type = E_INT;
         } else if (key[0] == 'P' && key[1] == 'D') {
-            if (!(hdr->codecs[DS_PD] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_PD; type = E_INT;
         } else if (key[0] == 'H' && key[1] == 'C') {
-            if (!(hdr->codecs[DS_HC] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_HC; type = E_INT;
         } else if (key[0] == 'M' && key[1] == 'Q') {
-            if (!(hdr->codecs[DS_MQ] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_MQ; type = E_INT;
         } else if (key[0] == 'R' && key[1] == 'N') {
-            if (!(hdr->codecs[DS_RN] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE_ARRAY_BLOCK,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_RN; type = E_BYTE_ARRAY_BLOCK;
         } else if (key[0] == 'Q' && key[1] == 'S') {
-            if (!(hdr->codecs[DS_QS] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_QS; type = E_BYTE;
         } else if (key[0] == 'Q' && key[1] == 'Q') {
-            if (!(hdr->codecs[DS_QQ] = cram_decoder_init(encoding, cp, size,
-                                                         E_BYTE_ARRAY,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_QQ; type = E_BYTE_ARRAY;
         } else if (key[0] == 'T' && key[1] == 'L') {
-            if (!(hdr->codecs[DS_TL] = cram_decoder_init(encoding, cp, size,
-                                                         E_INT,
-                                                         fd->version))) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
+            ds_id = DS_TL; type = E_INT;
         } else if (key[0] == 'T' && key[1] == 'M') {
         } else if (key[0] == 'T' && key[1] == 'V') {
         } else {
             hts_log_warning("Unrecognised key: %.2s", key);
+        }
+
+        if (ds_id != DS_CORE) {
+            if (hdr->codecs[ds_id] != NULL) {
+                hts_log_warning("Codec for key %.2s defined more than once",
+                                key);
+                hdr->codecs[ds_id]->free(hdr->codecs[ds_id]);
+            }
+            hdr->codecs[ds_id] = cram_decoder_init(encoding, cp, size,
+                                                   type, fd->version);
+            if (!hdr->codecs[ds_id]) {
+                cram_free_compression_header(hdr);
+                return NULL;
+            }
         }
 
         cp += size;

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -484,7 +484,7 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
             cram_free_compression_header(hdr);
             free(m);
         }
-        m->key = (key[0]<<8)|key[1];
+        m->key = CRAM_KEY(key[0], key[1]);
         m->encoding = encoding;
         m->size     = size;
         m->offset   = offset;
@@ -505,7 +505,7 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
         int32_t encoding = E_NULL;
         int32_t size = 0;
         cram_map *m = malloc(sizeof(*m)); // FIXME: use pooled_alloc
-        char *key;
+        uint8_t *key;
 
         if (!m || endp - cp < 6) {
             free(m);
@@ -513,7 +513,7 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
             return NULL;
         }
 
-        key = cp + 1;
+        key = (uint8_t *) cp + 1;
         m->key = (key[0]<<16)|(key[1]<<8)|key[2];
 
         cp += 4; // Strictly ITF8, but this suffices

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -372,8 +372,8 @@ int ltf8_decode(cram_fd *fd, int64_t *val_p) {
 
 int ltf8_decode_crc(cram_fd *fd, int64_t *val_p, uint32_t *crc) {
     unsigned char c[9];
-    int64_t val = (unsigned char)hgetc(fd->fp);
-    if (val == -1)
+    int64_t val = hgetc(fd->fp);
+    if (val < 0)
         return -1;
 
     c[0] = val;
@@ -384,79 +384,98 @@ int ltf8_decode_crc(cram_fd *fd, int64_t *val_p, uint32_t *crc) {
         return 1;
 
     } else if (val < 0xc0) {
-        val = (val<<8) | (c[1]=hgetc(fd->fp));;
+        int v = hgetc(fd->fp);
+        if (v < 0)
+            return -1;
+        val = (val<<8) | (c[1]=v);
         *val_p = val & (((1LL<<(6+8)))-1);
         *crc = crc32(*crc, c, 2);
         return 2;
 
     } else if (val < 0xe0) {
-        val = (val<<8) | (c[1]=hgetc(fd->fp));;
-        val = (val<<8) | (c[2]=hgetc(fd->fp));;
+        if (hread(fd->fp, &c[1], 2) < 2)
+            return -1;
+        val = (val<<8) | c[1];
+        val = (val<<8) | c[2];
         *val_p = val & ((1LL<<(5+2*8))-1);
         *crc = crc32(*crc, c, 3);
         return 3;
 
     } else if (val < 0xf0) {
-        val = (val<<8) | (c[1]=hgetc(fd->fp));;
-        val = (val<<8) | (c[2]=hgetc(fd->fp));;
-        val = (val<<8) | (c[3]=hgetc(fd->fp));;
+        if (hread(fd->fp, &c[1], 3) < 3)
+            return -1;
+        val = (val<<8) | c[1];
+        val = (val<<8) | c[2];
+        val = (val<<8) | c[3];
         *val_p = val & ((1LL<<(4+3*8))-1);
         *crc = crc32(*crc, c, 4);
         return 4;
 
     } else if (val < 0xf8) {
-        val = (val<<8) | (c[1]=hgetc(fd->fp));;
-        val = (val<<8) | (c[2]=hgetc(fd->fp));;
-        val = (val<<8) | (c[3]=hgetc(fd->fp));;
-        val = (val<<8) | (c[4]=hgetc(fd->fp));;
+        if (hread(fd->fp, &c[1], 4) < 4)
+            return -1;
+        val = (val<<8) | c[1];
+        val = (val<<8) | c[2];
+        val = (val<<8) | c[3];
+        val = (val<<8) | c[4];
         *val_p = val & ((1LL<<(3+4*8))-1);
         *crc = crc32(*crc, c, 5);
         return 5;
 
     } else if (val < 0xfc) {
-        val = (val<<8) | (c[1]=hgetc(fd->fp));;
-        val = (val<<8) | (c[2]=hgetc(fd->fp));;
-        val = (val<<8) | (c[3]=hgetc(fd->fp));;
-        val = (val<<8) | (c[4]=hgetc(fd->fp));;
-        val = (val<<8) | (c[5]=hgetc(fd->fp));;
+        if (hread(fd->fp, &c[1], 5) < 5)
+            return -1;
+        val = (val<<8) | c[1];
+        val = (val<<8) | c[2];
+        val = (val<<8) | c[3];
+        val = (val<<8) | c[4];
+        val = (val<<8) | c[5];
         *val_p = val & ((1LL<<(2+5*8))-1);
         *crc = crc32(*crc, c, 6);
         return 6;
 
     } else if (val < 0xfe) {
-        val = (val<<8) | (c[1]=hgetc(fd->fp));;
-        val = (val<<8) | (c[2]=hgetc(fd->fp));;
-        val = (val<<8) | (c[3]=hgetc(fd->fp));;
-        val = (val<<8) | (c[4]=hgetc(fd->fp));;
-        val = (val<<8) | (c[5]=hgetc(fd->fp));;
-        val = (val<<8) | (c[6]=hgetc(fd->fp));;
+        if (hread(fd->fp, &c[1], 6) < 6)
+            return -1;
+        val = (val<<8) | c[1];
+        val = (val<<8) | c[2];
+        val = (val<<8) | c[3];
+        val = (val<<8) | c[4];
+        val = (val<<8) | c[5];
+        val = (val<<8) | c[6];
         *val_p = val & ((1LL<<(1+6*8))-1);
         *crc = crc32(*crc, c, 7);
         return 7;
 
     } else if (val < 0xff) {
-        val = (val<<8) | (c[1]=hgetc(fd->fp));;
-        val = (val<<8) | (c[2]=hgetc(fd->fp));;
-        val = (val<<8) | (c[3]=hgetc(fd->fp));;
-        val = (val<<8) | (c[4]=hgetc(fd->fp));;
-        val = (val<<8) | (c[5]=hgetc(fd->fp));;
-        val = (val<<8) | (c[6]=hgetc(fd->fp));;
-        val = (val<<8) | (c[7]=hgetc(fd->fp));;
-        *val_p = val & ((1LL<<(7*8))-1);
+        uint64_t uval = val;
+        if (hread(fd->fp, &c[1], 7) < 7)
+            return -1;
+        uval = (uval<<8) | c[1];
+        uval = (uval<<8) | c[2];
+        uval = (uval<<8) | c[3];
+        uval = (uval<<8) | c[4];
+        uval = (uval<<8) | c[5];
+        uval = (uval<<8) | c[6];
+        uval = (uval<<8) | c[7];
+        *val_p = uval & ((1ULL<<(7*8))-1);
         *crc = crc32(*crc, c, 8);
         return 8;
 
     } else {
-        val = (val<<8) | (c[1]=hgetc(fd->fp));;
-        val = (val<<8) | (c[2]=hgetc(fd->fp));;
-        val = (val<<8) | (c[3]=hgetc(fd->fp));;
-        val = (val<<8) | (c[4]=hgetc(fd->fp));;
-        val = (val<<8) | (c[5]=hgetc(fd->fp));;
-        val = (val<<8) | (c[6]=hgetc(fd->fp));;
-        val = (val<<8) | (c[7]=hgetc(fd->fp));;
-        val = (val<<8) | (c[8]=hgetc(fd->fp));;
+        uint64_t uval;
+        if (hread(fd->fp, &c[1], 8) < 8)
+            return -1;
+        uval =             c[1];
+        uval = (uval<<8) | c[2];
+        uval = (uval<<8) | c[3];
+        uval = (uval<<8) | c[4];
+        uval = (uval<<8) | c[5];
+        uval = (uval<<8) | c[6];
+        uval = (uval<<8) | c[7];
+        uval = (uval<<8) | c[8];
         *crc = crc32(*crc, c, 9);
-        *val_p = val;
+        *val_p = c[1] < 0x80 ? uval : -((int64_t) (0xffffffffffffffffULL - uval)) - 1;
     }
 
     return 9;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -238,7 +238,8 @@ int itf8_decode_crc(cram_fd *fd, int32_t *val_p, uint32_t *crc) {
             uv = (uv<<8) |   (c[2]=hgetc(fd->fp));
             uv = (uv<<8) |   (c[3]=hgetc(fd->fp));
             uv = (uv<<4) | (((c[4]=hgetc(fd->fp))) & 0x0f);
-            *val_p = uv < 0x80000000UL ? uv : -((int32_t) (0xffffffffUL - uv)) - 1;
+            // Avoid implementation-defined behaviour on negative values
+            *val_p = uv < 0x80000000UL ? (int32_t) uv : -((int32_t) (0xffffffffUL - uv)) - 1;
             *crc = crc32(*crc, c, 5);
         }
     }
@@ -475,7 +476,8 @@ int ltf8_decode_crc(cram_fd *fd, int64_t *val_p, uint32_t *crc) {
         uval = (uval<<8) | c[7];
         uval = (uval<<8) | c[8];
         *crc = crc32(*crc, c, 9);
-        *val_p = c[1] < 0x80 ? uval : -((int64_t) (0xffffffffffffffffULL - uval)) - 1;
+        // Avoid implementation-defined behaviour on negative values
+        *val_p = c[1] < 0x80 ? (int64_t) uval : -((int64_t) (0xffffffffffffffffULL - uval)) - 1;
     }
 
     return 9;
@@ -536,7 +538,8 @@ int int32_get_blk(cram_block *b, int32_t *val) {
         (((uint32_t) b->data[b->byte+1]) <<  8) |
         (((uint32_t) b->data[b->byte+2]) << 16) |
         (((uint32_t) b->data[b->byte+3]) << 24);
-    *val = v < 0x80000000U ? v : -((int32_t) (0xffffffffU - v)) - 1;
+    // Avoid implementation-defined behaviour on negative values
+    *val = v < 0x80000000U ? (int32_t) v : -((int32_t) (0xffffffffU - v)) - 1;
     BLOCK_SIZE(b) += 4;
     return 4;
 }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -531,11 +531,12 @@ int int32_get_blk(cram_block *b, int32_t *val) {
     if (b->uncomp_size - BLOCK_SIZE(b) < 4)
         return -1;
 
-    *val =
-         b->data[b->byte  ]        |
-        (b->data[b->byte+1] <<  8) |
-        (b->data[b->byte+2] << 16) |
-        (b->data[b->byte+3] << 24);
+    uint32_t v =
+         ((uint32_t) b->data[b->byte  ])        |
+        (((uint32_t) b->data[b->byte+1]) <<  8) |
+        (((uint32_t) b->data[b->byte+2]) << 16) |
+        (((uint32_t) b->data[b->byte+3]) << 24);
+    *val = v < 0x80000000U ? v : -((int32_t) (0xffffffffU - v)) - 1;
     BLOCK_SIZE(b) += 4;
     return 4;
 }
@@ -543,10 +544,11 @@ int int32_get_blk(cram_block *b, int32_t *val) {
 /* As int32_decoded/encode, but from/to blocks instead of cram_fd */
 int int32_put_blk(cram_block *b, int32_t val) {
     unsigned char cp[4];
-    cp[0] = ( val      & 0xff);
-    cp[1] = ((val>>8)  & 0xff);
-    cp[2] = ((val>>16) & 0xff);
-    cp[3] = ((val>>24) & 0xff);
+    uint32_t v = val;
+    cp[0] = ( v      & 0xff);
+    cp[1] = ((v>>8)  & 0xff);
+    cp[2] = ((v>>16) & 0xff);
+    cp[3] = ((v>>24) & 0xff);
 
     BLOCK_APPEND(b, cp, 4);
     return b->data ? 0 : -1;

--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -56,7 +56,7 @@ extern "C" {
  */
 
 /*! INTERNAL: Converts two characters into an integer for use in switch{} */
-#define CRAM_KEY(a,b) (((a)<<8)|((b)))
+#define CRAM_KEY(a,b) ((((unsigned char) a)<<8)|(((unsigned char) b)))
 
 /*! Reads an integer in ITF-8 encoding from 'fd' and stores it in
  * *val.

--- a/cram/rANS_byte.h
+++ b/cram/rANS_byte.h
@@ -120,10 +120,10 @@ static inline void RansDecInit(RansState* r, uint8_t** pptr)
     uint32_t x;
     uint8_t* ptr = *pptr;
 
-    x  = ptr[0] << 0;
-    x |= ptr[1] << 8;
-    x |= ptr[2] << 16;
-    x |= ptr[3] << 24;
+    x  = ((uint32_t) ptr[0]) << 0;
+    x |= ((uint32_t) ptr[1]) << 8;
+    x |= ((uint32_t) ptr[2]) << 16;
+    x |= ((uint32_t) ptr[3]) << 24;
     ptr += 4;
 
     *pptr = ptr;

--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -44,6 +44,7 @@
 #include <assert.h>
 #include <string.h>
 #include <sys/time.h>
+#include <limits.h>
 
 #include "cram/rANS_static.h"
 #include "cram/rANS_byte.h"
@@ -224,6 +225,9 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
     out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | ((in[7])<<24);
     if (in_sz != in_size-9)
         return NULL;
+
+    if (out_sz >= INT_MAX)
+        return NULL; // protect against some overflow cases
 
     // Precompute reverse lookup of frequency.
     rle = x = 0;
@@ -586,6 +590,9 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
     out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | ((in[7])<<24);
     if (in_sz != in_size-9)
         return NULL;
+
+    if (out_sz >= INT_MAX)
+        return NULL; // protect against some overflow cases
 
     // calloc may add 2% overhead to CRAM decode, but on linux with glibc it's
     // often the same thing due to using mmap.

--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -221,8 +221,10 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
     if (*in++ != 0) // Order-0 check
         return NULL;
 
-    in_sz  = ((in[0])<<0) | ((in[1])<<8) | ((in[2])<<16) | ((in[3])<<24);
-    out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | ((in[7])<<24);
+    in_sz  = ((((uint32_t) in[0])<<0) | (((uint32_t) in[1])<<8) |
+              (((uint32_t) in[2])<<16) | (((uint32_t) in[3])<<24));
+    out_sz = ((((uint32_t) in[4])<<0) | (((uint32_t) in[5])<<8) |
+              (((uint32_t) in[6])<<16) | (((uint32_t) in[7])<<24));
     if (in_sz != in_size-9)
         return NULL;
 
@@ -586,8 +588,10 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
     if (*in++ != 1) // Order-1 check
         return NULL;
 
-    in_sz  = ((in[0])<<0) | ((in[1])<<8) | ((in[2])<<16) | ((in[3])<<24);
-    out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | ((in[7])<<24);
+    in_sz  = ((((uint32_t) in[0])<<0) | (((uint32_t) in[1])<<8) |
+              (((uint32_t) in[2])<<16) | (((uint32_t) in[3])<<24));
+    out_sz = ((((uint32_t) in[4])<<0) | (((uint32_t) in[5])<<8) |
+              (((uint32_t) in[6])<<16) | (((uint32_t) in[7])<<24));
     if (in_sz != in_size-9)
         return NULL;
 

--- a/header.c
+++ b/header.c
@@ -685,7 +685,7 @@ static int sam_hrecs_parse_lines(sam_hrecs_t *hrecs, const char *hdr, size_t len
             return -1;
         }
 
-        type = (hdr[i+1]<<8) | hdr[i+2];
+        type = (((uint8_t) hdr[i+1])<<8) | (uint8_t) hdr[i+2];
         if (!isalpha_c(hdr[i+1]) || !isalpha_c(hdr[i+2])) {
             sam_hrecs_error("Header line does not have a two character key",
                           &hdr[l_start], len - l_start, lno);

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -249,7 +249,7 @@ static inline int kputc_(int c, kstring_t *s)
 static inline int kputsn_(const void *p, size_t l, kstring_t *s)
 {
 	size_t new_sz = s->l + l;
-	if (new_sz < s->l || ks_resize(s, new_sz) < 0)
+	if (new_sz < s->l || ks_resize(s, new_sz ? new_sz : 1) < 0)
 		return EOF;
 	memcpy(s->s + s->l, p, l);
 	s->l += l;

--- a/sam.c
+++ b/sam.c
@@ -2292,7 +2292,7 @@ static inline uint8_t *skip_aux(uint8_t *s, uint8_t *end)
     switch (size) {
     case 'Z':
     case 'H':
-        while (*s && s < end) ++s;
+        while (s < end && *s) ++s;
         return s < end ? s + 1 : end;
     case 'B':
         if (end - s < 5) return NULL;

--- a/test/fuzz/hts_open_fuzzer.c
+++ b/test/fuzz/hts_open_fuzzer.c
@@ -55,6 +55,9 @@ static void view_sam(htsFile *in) {
         return;
     }
 
+    // This will force the header to be parsed.
+    (void) sam_hdr_count_lines(hdr, "SQ");
+
     if (sam_hdr_write(out, hdr) != 0) {
         sam_hdr_destroy(hdr);
         hts_close_or_abort(out);

--- a/test/fuzz/hts_open_fuzzer.c
+++ b/test/fuzz/hts_open_fuzzer.c
@@ -35,13 +35,6 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/sam.h"
 #include "htslib/vcf.h"
 
-// Duplicated from: htsfile.c
-static htsFile *dup_stdout(const char *mode) {
-    int fd = dup(STDOUT_FILENO);
-    hFILE *hfp = (fd >= 0) ? hdopen(fd, mode) : NULL;
-    return hfp ? hts_hopen(hfp, "-", mode) : NULL;
-}
-
 static void hts_close_or_abort(htsFile* file) {
     if (hts_close(file) != 0) {
         abort();
@@ -52,7 +45,10 @@ static void view_sam(htsFile *in) {
     if (!in) {
         return;
     }
-    samFile *out = dup_stdout("w");
+    samFile *out = sam_open("/dev/null", "w");
+    if (!out) {
+        abort();
+    }
     sam_hdr_t *hdr = sam_hdr_read(in);
     if (hdr == NULL) {
         hts_close_or_abort(out);
@@ -85,7 +81,10 @@ static void view_vcf(htsFile *in) {
     if (!in) {
         return;
     }
-    vcfFile *out = dup_stdout("w");
+    vcfFile *out = vcf_open("/dev/null", "w");
+    if (!out) {
+        abort();
+    }
     bcf_hdr_t *hdr = bcf_hdr_read(in);
     if (hdr == NULL) {
         hts_close_or_abort(out);

--- a/vcf.c
+++ b/vcf.c
@@ -1210,7 +1210,6 @@ static inline int bcf_read1_core(BGZF *fp, bcf1_t *v)
 
 static int bcf_dec_typed_int1_safe(uint8_t *p, uint8_t *end, uint8_t **q,
                                    int32_t *val) {
-    uint32_t v;
     uint32_t t;
     if (end - p < 2) return -1;
     t = *p++ & 0xf;
@@ -1222,13 +1221,11 @@ static int bcf_dec_typed_int1_safe(uint8_t *p, uint8_t *end, uint8_t **q,
     } else if (t == BCF_BT_INT16) {
         if (end - p < 2) return -1;
         *q = p + 2;
-        v = p[0] | (p[1] << 8);
-        *val = v < 0x8000 ? v : -((int32_t) (0xffff - v)) - 1;
+        *val = le_to_i16(p);
     } else if (t == BCF_BT_INT32) {
         if (end - p < 4) return -1;
         *q = p + 4;
-        v = p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
-        *val = v < 0x80000000UL ? v : -((int32_t) (0xffffffffUL - v)) - 1;
+        *val = le_to_i32(p);
     } else {
         return -1;
     }

--- a/vcf.c
+++ b/vcf.c
@@ -186,6 +186,7 @@ int bcf_hdr_sync(bcf_hdr_t *h)
 
 void bcf_hrec_destroy(bcf_hrec_t *hrec)
 {
+    if (!hrec) return;
     free(hrec->key);
     if ( hrec->value ) free(hrec->value);
     int i;
@@ -1847,7 +1848,10 @@ int bcf_hdr_set(bcf_hdr_t *hdr, const char *fname)
         int k;
         bcf_hrec_t *hrec = bcf_hdr_parse_line(hdr,lines[i],&k);
         if (!hrec) goto fail;
-        if (bcf_hdr_add_hrec(hdr, hrec) < 0) goto fail;
+        if (bcf_hdr_add_hrec(hdr, hrec) < 0) {
+            bcf_hrec_destroy(hrec);
+            goto fail;
+        }
         free(lines[i]);
         lines[i] = NULL;
     }
@@ -2168,6 +2172,7 @@ static int vcf_parse_format(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v, char *p
             bcf_hrec_t *hrec = bcf_hdr_parse_line(h,tmp.s,&l);
             free(tmp.s);
             int res = hrec ? bcf_hdr_add_hrec((bcf_hdr_t*)h, hrec) : -1;
+            if (res < 0) bcf_hrec_destroy(hrec);
             if (res > 0) res = bcf_hdr_sync((bcf_hdr_t*)h);
 
             k = kh_get(vdict, d, t);
@@ -2439,6 +2444,7 @@ int vcf_parse(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v)
                 bcf_hrec_t *hrec = bcf_hdr_parse_line(h,tmp.s,&l);
                 free(tmp.s);
                 int res = hrec ? bcf_hdr_add_hrec((bcf_hdr_t*)h, hrec) : -1;
+                if (res < 0) bcf_hrec_destroy(hrec);
                 if (res > 0) res = bcf_hdr_sync((bcf_hdr_t*)h);
                 k = kh_get(vdict, d, p);
                 v->errcode = BCF_ERR_CTG_UNDEF;
@@ -2506,6 +2512,7 @@ int vcf_parse(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v)
                         bcf_hrec_t *hrec = bcf_hdr_parse_line(h,tmp.s,&l);
                         free(tmp.s);
                         int res = hrec ? bcf_hdr_add_hrec((bcf_hdr_t*)h, hrec) : -1;
+                        if (res < 0) bcf_hrec_destroy(hrec);
                         if (res > 0) res = bcf_hdr_sync((bcf_hdr_t*)h);
                         k = kh_get(vdict, d, t);
                         v->errcode = BCF_ERR_TAG_UNDEF;
@@ -2549,6 +2556,7 @@ int vcf_parse(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v)
                         bcf_hrec_t *hrec = bcf_hdr_parse_line(h,tmp.s,&l);
                         free(tmp.s);
                         int res = hrec ? bcf_hdr_add_hrec((bcf_hdr_t*)h, hrec) : -1;
+                        if (res < 0) bcf_hrec_destroy(hrec);
                         if (res > 0) res = bcf_hdr_sync((bcf_hdr_t*)h);
                         k = kh_get(vdict, d, key);
                         v->errcode = BCF_ERR_TAG_UNDEF;


### PR DESCRIPTION
- Stops `hts_open_fuzzer` from spamming log files with useless output.

- Updates `hts_open_fuzzer` so that SAM/BAM/CRAM headers get parsed, which should exercise more code paths.

- Fixes numerous bugs (see individual commits).