### PR TITLE
Bug fix to cram index query.

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -496,10 +496,12 @@ int cram_seek_to_refpos(cram_fd *fd, cram_range *r) {
 
     pthread_mutex_lock(&fd->range_lock);
     fd->range = *r;
-    if (r->refid == HTS_IDX_NOCOOR)
+    if (r->refid == HTS_IDX_NOCOOR) {
         fd->range.refid = -1;
-    else if (r->refid == HTS_IDX_START || r->refid == HTS_IDX_REST)
+        fd->range.start = 0;
+    } else if (r->refid == HTS_IDX_START || r->refid == HTS_IDX_REST) {
         fd->range.refid = -2; // special case in cram_next_slice
+    }
     pthread_mutex_unlock(&fd->range_lock);
 
     if (fd->ctr) {


### PR DESCRIPTION
Query on ref "*" sometimes fails if the unmapped data is in a ref -1
block (rather than ref -2 == multi-ref). This is now more commonly
triggered due to the change in switching back out of multi-ref mode.

The problem was the range start..end is 1 to 0 (a bit odd) which
causes the slices to be skipped as unmapped slices have start 0.
In addition to the old fix from #958, we now also reset the range
query start pos.