### PR TITLE
Move stringify_argv() from htslib/cram.h to htslib/sam.h

### DIFF
--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -457,17 +457,6 @@ static inline void sam_hdr_free(SAM_hdr *hdr) { sam_hdr_destroy(hdr); }
  */
 #define sam_hdr_add_PG sam_hdr_add_pg
 
-/*!
- * A function to help with construction of CL tags in @PG records.
- * Takes an argc, argv pair and returns a single space-separated string.
- * This string should be deallocated by the calling function.
- *
- * @return
- * Returns malloced char * on success;
- *         NULL on failure
- */
-char *stringify_argv(int argc, char *argv[]);
-
 /**@{ -------------------------------------------------------------------*/
 
 /*!

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -724,6 +724,17 @@ const char *sam_hdr_pg_id(sam_hdr_t *h, const char *name);
  */
 int sam_hdr_add_pg(sam_hdr_t *h, const char *name, ...);
 
+/*!
+ * A function to help with construction of CL tags in @PG records.
+ * Takes an argc, argv pair and returns a single space-separated string.
+ * This string should be deallocated by the calling function.
+ *
+ * @return
+ * Returns malloced char * on success;
+ *         NULL on failure
+ */
+char *stringify_argv(int argc, char *argv[]);
+
 /// Increments the reference count on a header
 /*!
  * This permits multiple files to share the same header, all calling


### PR DESCRIPTION
Allows it to be used without having to include "htslib/cram.h" just for the one function.
"htslib/cram.h" includes "htslib/sam.h" itself, so anyone looking for it there will still get it.