### PR TITLE
Validate record range when constructing BAI/CSI indexes

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -1583,6 +1583,11 @@ int hts_idx_push(hts_idx_t *idx, int tid, int beg, int end, uint64_t offset, int
         hts_log_error("Unsorted positions on sequence #%d: %d followed by %d", tid+1, idx->z.last_coor+1, beg+1);
         return -1;
     }
+    else if (end < beg) {
+        // Malformed ranges are errors. (Empty ranges (beg==end) are unusual but acceptable.)
+        hts_log_error("Invalid record on sequence #%d: end %d < begin %d", tid+1, end, beg+1);
+        return -1;
+    }
     if ( tid>=0 )
     {
         if (idx->bidx[tid] == 0) idx->bidx[tid] = kh_init(bin);


### PR DESCRIPTION
Inserting malformed ranges into the index leads to a broken index for which `hts_itr_query()` produces incorrect results for nearby query regions. This pretty much can't happen for SAM/BAM/CRAM (the CIGAR calculation produces a length >= 0), but does happen for VCF/BCF when the input record has an invalid INFO/END field that's < POS.

In particular, this will make `bcftools index` refuse to index files where INFO/END is being used for a different purpose — see samtools/hts-specs#425. Previously it would happily produce an index that didn't work properly.

Instead of this PR, it would be possible to validate that `rlen >= 0` in the _vcf.c_ code that computes `rlen` from an input INFO/END field value. However that would mean that HTSlib would refuse to read in these delly/gnomad/etc records at all, which would not be reasonable. Better just to refuse to build an index, as indexing is what gets broken by these misused INFO/END fields.