### PR TITLE
Cram mem fixes

### DIFF
--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -211,7 +211,10 @@ void cram_block_set_size(cram_block *b, int32_t size) { BLOCK_SIZE(b) = size; }
 
 int cram_block_append(cram_block *b, const void *data, int size) {
     BLOCK_APPEND(b, data, size);
-    return BLOCK_DATA(b) ? 0 : -1; // It'll do for now...
+    return 0;
+
+ block_err:
+    return -1;
 }
 void cram_block_update_size(cram_block *b) { BLOCK_UPLEN(b); }
 

--- a/cram/cram_stats.c
+++ b/cram/cram_stats.c
@@ -47,7 +47,7 @@ cram_stats *cram_stats_create(void) {
     return calloc(1, sizeof(cram_stats));
 }
 
-void cram_stats_add(cram_stats *st, int32_t val) {
+int cram_stats_add(cram_stats *st, int32_t val) {
     st->nsamp++;
 
     //assert(val >= 0);
@@ -60,6 +60,8 @@ void cram_stats_add(cram_stats *st, int32_t val) {
 
         if (!st->h) {
             st->h = kh_init(m_i2i);
+            if (!st->h)
+                return -1;
         }
 
         k = kh_put(m_i2i, st->h, val, &r);
@@ -68,8 +70,9 @@ void cram_stats_add(cram_stats *st, int32_t val) {
         else if (r != -1)
             kh_val(st->h, k) = 1;
         else
-            ; // FIXME: handle error
+            return -1;
     }
+    return 0;
 }
 
 void cram_stats_del(cram_stats *st, int32_t val) {

--- a/cram/cram_stats.h
+++ b/cram/cram_stats.h
@@ -36,7 +36,7 @@ extern "C" {
 #endif
 
 cram_stats *cram_stats_create(void);
-void cram_stats_add(cram_stats *st, int32_t val);
+int cram_stats_add(cram_stats *st, int32_t val);
 void cram_stats_del(cram_stats *st, int32_t val);
 void cram_stats_dump(cram_stats *st);
 void cram_stats_free(cram_stats *st);

--- a/header.c
+++ b/header.c
@@ -442,7 +442,8 @@ static int sam_hrecs_vadd(sam_hrecs_t *hrecs, const char *type, va_list ap, ...)
 
     if (!(h_type = pool_alloc(hrecs->type_pool)))
         return -1;
-    if (-1 == (k = kh_put(sam_hrecs_t, hrecs->h, type_i, &new)))
+    k = kh_put(sam_hrecs_t, hrecs->h, type_i, &new);
+    if (new < 0)
         return -1;
 
     h_type->type = type_i;
@@ -699,7 +700,8 @@ static int sam_hrecs_parse_lines(sam_hrecs_t *hrecs, const char *hdr, size_t len
         // Add the header line type
         if (!(h_type = pool_alloc(hrecs->type_pool)))
             return -1;
-        if (-1 == (k = kh_put(sam_hrecs_t, hrecs->h, type, &new)))
+        k = kh_put(sam_hrecs_t, hrecs->h, type, &new);
+        if (new < 0)
             return -1;
 
         h_type->type = type;

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -235,7 +235,7 @@ static inline int kputc(int c, kstring_t *s)
 		return EOF;
 	s->s[s->l++] = c;
 	s->s[s->l] = 0;
-	return c;
+	return (unsigned char)c;
 }
 
 static inline int kputc_(int c, kstring_t *s)


### PR DESCRIPTION
(And also a few SAM ones.)

These have been found by exhaustively making the Nth malloc, calloc or realloc fail and testing the behaviour of reading and writing.  This found several crashes due to not spotting the failure.

This PR fixes those, but it does NOT fix all the potential memory leaks that may ensue when running out of memory and bubbling the error back up the chain to the calling application.  That's a bug too, but in the whole spectrum of bug severity "meh" to "OMG it's on fire" it's down the feeble end so in the interests of time this focuses on the crash / incorrect behaviour issues.

It passes htslib and samtools test harnesses, but I want to hammer it on some large files to check it doesn't have undesireable speed issues or problems.