### PR TITLE
Add flags to control bam1_t memory ownership

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ cram/cram_encode.o cram/cram_encode.pico: cram/cram_encode.c config.h $(cram_h) 
 cram/cram_external.o cram/cram_external.pico: cram/cram_external.c config.h $(htslib_hfile_h) $(cram_h)
 cram/cram_index.o cram/cram_index.pico: cram/cram_index.c config.h $(htslib_bgzf_h) $(htslib_hfile_h) $(hts_internal_h) $(cram_h) $(cram_os_h)
 cram/cram_io.o cram/cram_io.pico: cram/cram_io.c config.h os/lzma_stub.h $(cram_h) $(cram_os_h) $(htslib_hts_h) $(cram_open_trace_file_h) cram/rANS_static.h $(htslib_hfile_h) $(htslib_bgzf_h) $(htslib_faidx_h) $(hts_internal_h)
-cram/cram_samtools.o cram/cram_samtools.pico: cram/cram_samtools.c config.h $(cram_h) $(htslib_sam_h)
+cram/cram_samtools.o cram/cram_samtools.pico: cram/cram_samtools.c config.h $(cram_h) $(htslib_sam_h) $(sam_internal_h)
 cram/cram_stats.o cram/cram_stats.pico: cram/cram_stats.c config.h $(cram_h) $(cram_os_h)
 cram/mFILE.o cram/mFILE.pico: cram/mFILE.c config.h $(htslib_hts_log_h) $(cram_os_h) cram/mFILE.h
 cram/open_trace_file.o cram/open_trace_file.pico: cram/open_trace_file.c config.h $(cram_os_h) $(cram_open_trace_file_h) $(cram_misc_h) $(htslib_hfile_h) $(htslib_hts_log_h)

--- a/NEWS
+++ b/NEWS
@@ -63,6 +63,9 @@ Noteworthy changes in release a.b
 
   - htsFile has a new 'state' member to support SAM multi-threading.
 
+  - A new field has been added to the bam1_t structure, and others
+    have been rearranged to remove structure holes.
+
 * A new SAM/BAM/CRAM header API has been added to HTSlib, allowing header
   data to be updated without having to parse or rewrite large parts of the
   header text.  See htslib/sam.h for function definitions and documentation.
@@ -137,6 +140,11 @@ Noteworthy changes in release a.b
   attempting to download a remote index.  It also checks that the remote
   file it downloads is actually an index before trying to save and use
   it.  (https://github.com/samtools/samtools/issues/1045)
+
+* New API functions bam_set_mempolicy() and bam_get_mempolicy() have
+  been added.  These allow more control over the ownership of bam1_t
+  alignment record data; see documentation in htslib/sam.h for more
+  information.
 
 * Changes to hfile_s3, which provides support for the AWS S3 API.
 

--- a/cram/cram_samtools.c
+++ b/cram/cram_samtools.c
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cram/cram.h"
 #include "htslib/sam.h"
+#include "../sam_internal.h"
 
 /*---------------------------------------------------------------------------
  * Samtools compatibility portion
@@ -80,13 +81,8 @@ int bam_construct_seq(bam_seq_t **bp, size_t extra_len,
 
     qname_nuls = 4 - qname_len%4;
     bam_len = qname_len + qname_nuls + ncigar*4 + (len+1)/2 + len + extra_len;
-    if (b->m_data < bam_len) {
-        b->m_data = bam_len;
-        kroundup32(b->m_data);
-        b->data = (uint8_t*)realloc(b->data, b->m_data);
-        if (!b->data)
-            return -1;
-    }
+    if (realloc_bam_data(b, bam_len) < 0)
+        return -1;
     b->l_data = bam_len;
 
     b->core.tid     = rname;

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -204,6 +204,7 @@ typedef struct {
  @field  l_data     current length of bam1_t::data
  @field  m_data     maximum length of bam1_t::data
  @field  data       all variable-length data, concatenated; structure: qname-cigar-seq-qual-aux
+ @field  mempolicy  memory handling policy, see bam_set_mempolicy()
 
  @discussion Notes:
 
@@ -223,9 +224,10 @@ typedef struct {
 typedef struct {
     bam1_core_t core;
     int l_data;
-    uint32_t m_data;
     uint8_t *data;
     uint64_t id;
+    uint32_t m_data;
+    uint32_t mempolicy:2, :30 /* Reserved */;
 } bam1_t;
 
 /*! @function
@@ -770,6 +772,106 @@ bam1_t *bam_init1(void);
    accessed after calling this function.
  */
 void bam_destroy1(bam1_t *b);
+
+#define BAM_USER_OWNS_STRUCT 1
+#define BAM_USER_OWNS_DATA   2
+
+/// Set alignment record memory policy
+/**
+   @param b       Alignment record
+   @param policy  Desired policy
+
+   Allows the way HTSlib reallocates and frees bam1_t data to be
+   changed.  @policy can be set to the bitwise-or of the following
+   values:
+
+   \li \c BAM_USER_OWNS_STRUCT
+   If this is set then bam_destroy1() will not try to free the bam1_t struct.
+
+   \li \c BAM_USER_OWNS_DATA
+   If this is set, bam_destroy1() will not free the bam1_t::data pointer.
+   Also, functions which need to expand bam1_t::data memory will change
+   behaviour.  Instead of calling realloc() on the pointer, they will
+   allocate a new data buffer and copy any existing content in to it.
+   The existing memory will \b not be freed.  bam1_t::data will be
+   set to point to the new memory and the BAM_USER_OWNS_DATA flag will be
+   cleared.
+
+   BAM_USER_OWNS_STRUCT allows bam_destroy1() to be called on bam1_t
+   structures that are members of an array.
+
+   BAM_USER_OWNS_DATA can be used by applications that want more control
+   over where the variable-length parts of the bam record will be stored.
+   By preventing calls to free() and realloc(), it allows bam1_t::data
+   to hold pointers to memory that cannot be passed to those functions.
+
+   Example:  Read a block of alignment records, storing the variable-length
+   data in a single buffer and the records in an array.  Stop when either
+   the array or the buffer is full.
+
+   \code{.c}
+   #define MAX_RECS 1000
+   #define REC_LENGTH 400  // Average length estimate, to get buffer size
+   size_t bufsz = MAX_RECS * REC_LENGTH, nrecs, buff_used = 0;
+   bam1_t *recs = calloc(MAX_RECS, sizeof(bam1_t));
+   uint8_t *buffer = malloc(bufsz);
+   int res = 0, result = EXIT_FAILURE;
+   uint32_t new_m_data;
+
+   if (!recs || !buffer) goto cleanup;
+   for (nrecs = 0; nrecs < MAX_RECS; nrecs++) {
+      bam_set_mempolicy(BAM_USER_OWNS_STRUCT|BAM_USER_OWNS_DATA);
+
+      // Set data pointer to unused part of buffer
+      recs[nrecs].data = &buffer[buff_used];
+
+      // Set m_data to size of unused part of buffer.  On 64-bit platforms it
+      // will be necessary to limit this to UINT32_MAX due to the size of
+      // bam1_t::m_data (not done here as our buffer is only 400K).
+      recs[nrecs].m_data = bufsz - buff_used;
+
+      // Read the record
+      res = sam_read1(file_handle, header, &recs[nrecs]);
+      if (res <= 0) break; // EOF or error
+
+      // Check if the record data didn't fit - if not, stop reading
+      if ((bam_get_mempolicy(&recs[nrecs]) & BAM_USER_OWNS_DATA) == 0) {
+         nrecs++; // Include last record in count
+         break;
+      }
+
+      // Adjust m_data to the space actually used.  If space is available,
+      // round up to eight bytes so the next record aligns nicely.
+      new_m_data = ((uint32_t) recs[nrecs].l_data + 7) & (~7U);
+      if (new_m_data < recs[nrecs].m_data) recs[nrecs].m_data = new_m_data;
+
+      buff_used += recs[nrecs].m_data;
+   }
+   if (res < 0) goto cleanup;
+   result = EXIT_SUCCESS;
+
+   // ... use data ...
+
+ cleanup:
+   for (size_t i = 0; i < nrecs; i++)
+     bam_destroy1(i);
+   free(buffer);
+   free(recs);
+
+   \endcode
+*/
+static inline void bam_set_mempolicy(bam1_t *b, uint32_t policy) {
+    b->mempolicy = policy;
+}
+
+/// Get alignment record memory policy
+/** @param b    Alignment record
+
+    See bam_set_mempolicy()
+ */
+static inline uint32_t bam_get_mempolicy(bam1_t *b) {
+    return b->mempolicy;
+}
 
 /// Read a BAM format alignment record
 /**

--- a/test/sam.c
+++ b/test/sam.c
@@ -982,7 +982,8 @@ static void samrecord_layout(void)
 
     size_t bam1_t_size, bam1_t_size2;
 
-    bam1_t_size = 36 + sizeof(int) + 4 + sizeof (char *) + sizeof(uint64_t);
+    bam1_t_size = (36 + sizeof(int) + 4 + sizeof (char *) + sizeof(uint64_t)
+                   + sizeof(uint32_t));
     bam1_t_size2 = bam1_t_size + 4;  // Account for padding on some platforms
 
     if (sizeof (bam1_core_t) != 36)
@@ -1102,6 +1103,291 @@ static void check_cigar_tab(void)
             fail("bam_cigar_table['%c'] is not %d", BAM_CIGAR_STR[i], i);
 }
 
+#define MAX_RECS 1000
+#define SEQ_LEN 100
+#define REC_LENGTH 150 // Undersized so some won't fit.
+
+static int generator(const char *name)
+{
+    FILE *f = fopen(name, "w");
+    char *ref = NULL;
+    char qual[101];
+    size_t i;
+    uint32_t lfsr = 0xbadcafe;
+    int res = -1;
+
+    if (!f) {
+        fail("Couldn't open \"%s\"", name);
+        return -1;
+    }
+
+    ref = malloc(MAX_RECS + SEQ_LEN + 1);
+    if (!ref) goto cleanup;
+    for (i = 0; i < MAX_RECS + SEQ_LEN; i++) {
+        // Linear-feedback shift register to make random reference
+        lfsr ^= lfsr << 13;
+        lfsr ^= lfsr >> 17;
+        lfsr ^= lfsr << 5;
+        ref[i] = "ACGT"[lfsr & 3];
+    }
+    ref[MAX_RECS + SEQ_LEN] = '\0';
+    for (i = 0; i < SEQ_LEN; i++) {
+        qual[i] = 'A' + (i & 0xf);
+    }
+
+    if (fputs("@HD\tVN:1.4\n", f) < 0) goto cleanup;
+    if (fprintf(f, "@SQ\tSN:ref1\tLN:%u\n", MAX_RECS + SEQ_LEN) < 0)
+        goto cleanup;
+    for (i = 0; i < MAX_RECS; i++) {
+        if (fprintf(f, "read%zu\t0\tref1\t%zu\t64\t100M\t*\t0\t0\t%.*s\t%.*s\n",
+                    i + 1, i + 1, SEQ_LEN, ref + i, SEQ_LEN, qual) < 0)
+            goto cleanup;
+    }
+
+    if (fclose(f) == 0)
+        res = 0;
+    f = NULL;
+
+ cleanup:
+    if (f) fclose(f);
+    free(ref);
+    return res;
+}
+
+static int read_data_block(const char *in_name, samFile *fp_in,
+                           const char *out_name, samFile *fp_out,
+                           sam_hdr_t *header, bam1_t *recs, size_t max_recs,
+                           uint8_t *buffer, size_t bufsz, size_t *nrecs_out) {
+    size_t buff_used = 0, nrecs;
+    uint32_t new_m_data;
+    int ret = -1, res = -1;
+
+    for (nrecs = 0; nrecs < max_recs; nrecs++) {
+        bam_set_mempolicy(&recs[nrecs],
+                          BAM_USER_OWNS_STRUCT|BAM_USER_OWNS_DATA);
+
+        recs[nrecs].data = &buffer[buff_used];
+        recs[nrecs].m_data = bufsz - buff_used;
+
+        res = sam_read1(fp_in, header, &recs[nrecs]);
+        if (res < 0) break; // EOF or error
+
+        if (fp_out) {
+            if (sam_write1(fp_out, header, &recs[nrecs]) < 0) {
+                nrecs++; // To return correct count
+                fail("sam_write1() to \"%s\"", out_name);
+                goto out;
+            }
+        }
+
+        if ((bam_get_mempolicy(&recs[nrecs]) & BAM_USER_OWNS_DATA) == 0) {
+            continue;  // Data not put in buffer
+        }
+
+        new_m_data = ((uint32_t) recs[nrecs].l_data + 7) & (~7U);
+        if (new_m_data < recs[nrecs].m_data) recs[nrecs].m_data = new_m_data;
+
+        buff_used += recs[nrecs].m_data;
+    }
+    if (res < -1) {
+        fail("sam_read1() from \"%s\" failed", in_name);
+    } else {
+        ret = 0;
+    }
+
+ out:
+    *nrecs_out = nrecs;
+    return ret;
+}
+
+static void test_mempolicy(void)
+{
+    size_t bufsz = MAX_RECS * REC_LENGTH, nrecs = 0, i;
+    bam1_t *recs = calloc(MAX_RECS, sizeof(bam1_t));
+    uint8_t *buffer = malloc(bufsz);
+    const char *fname = "test/sam_alignment.tmp.sam";
+    const char *bam_name = "test/sam_alignment.tmp.bam";
+    const char *cram_name = "test/sam_alignment.tmp.cram";
+    const char *tag_text =
+        "lengthy text ... lengthy text ... lengthy text ... lengthy text ... "
+        "lengthy text ... lengthy text ... lengthy text ... lengthy text ... "
+        "lengthy text ... lengthy text ... lengthy text ... lengthy text ... "
+        "lengthy text ... lengthy text ... lengthy text ... lengthy text ... "
+        "lengthy text ... lengthy text ... lengthy text ... lengthy text ... ";
+    int res = 0;
+    samFile *fp = NULL, *bam_fp = NULL, *cram_fp = NULL;
+    htsFormat cram_fmt;
+    sam_hdr_t *header = NULL;
+
+    if (!recs || !buffer) {
+        fail("Allocating buffer");
+        goto cleanup;
+    }
+
+    memset(&cram_fmt, 0, sizeof(cram_fmt));
+
+    // Make test file
+    if (generator(fname) < 0)
+        goto cleanup;
+
+    // Open and read header
+    fp = sam_open(fname, "r");
+    if (!fp) {
+        fail("sam_open(\"%s\")", fname);
+        goto cleanup;
+    }
+
+    bam_fp = sam_open(bam_name, "wb");
+    if (!fp) {
+        fail("sam_open(\"%s\")", bam_name);
+        goto cleanup;
+    }
+
+    header = sam_hdr_read(fp);
+    if (!header) {
+        fail("read header from \"%s\"", fname);
+        goto cleanup;
+    }
+
+    if (sam_hdr_write(bam_fp, header) < 0) {
+        fail("sam_hdr_write() to \"%s\"", bam_name);
+        goto cleanup;
+    }
+
+    if (read_data_block(fname, fp, bam_name, bam_fp, header, recs,
+                        MAX_RECS, buffer, bufsz, &nrecs) < 0)
+        goto cleanup;
+
+    res = sam_close(bam_fp);
+    bam_fp = NULL;
+    if (res < 0) {
+        fail("sam_close(\"%s\")", bam_name);
+        goto cleanup;
+    }
+
+    // Add a big tag to some records so they no longer fit in the allocated
+    // buffer space.
+    for (i = 0; i < MAX_RECS; i += 11) {
+        if (bam_aux_update_str(&recs[i], "ZZ",
+                               sizeof(tag_text) - 1, tag_text) < 0) {
+            fail("bam_aux_update_str()");
+            goto cleanup;
+        }
+    }
+
+    // Delete all the records.  bam_destroy1() should free the data
+    // for the ones that were expanded.
+    for (i = 0; i < nrecs; i++) {
+        bam_destroy1(&recs[i]);
+    }
+
+    res = sam_close(fp);
+    fp = NULL;
+    if (res < 0) {
+        fail("sam_close(\"%s\")", fname);
+        goto cleanup;
+    }
+
+    // Same test but reading BAM, writing CRAM
+    nrecs = 0;
+    sam_hdr_destroy(header);
+    header = NULL;
+
+    bam_fp = sam_open(bam_name, "r");
+    if (!bam_fp) {
+        fail("sam_open(\"%s\", \"r\")", bam_name);
+        goto cleanup;
+    }
+
+    if (hts_parse_format(&cram_fmt, "cram,no_ref") < 0) {
+        fail("hts_parse_format");
+        goto cleanup;
+    }
+    cram_fp = hts_open_format(cram_name, "wc", &cram_fmt);
+    if (!cram_fp) {
+        fail("hts_open_format(\"%s\", \"wc\")", cram_name);
+        goto cleanup;
+    }
+
+    header = sam_hdr_read(bam_fp);
+    if (!header) {
+        fail("read header from \"%s\"", bam_name);
+        goto cleanup;
+    }
+
+    if (sam_hdr_write(cram_fp, header) < 0) {
+        fail("sam_hdr_write() to \"%s\"", cram_name);
+        goto cleanup;
+    }
+
+    if (read_data_block(bam_name, bam_fp, cram_name, cram_fp, header, recs,
+                        MAX_RECS, buffer, bufsz, &nrecs) < 0)
+        goto cleanup;
+
+    res = sam_close(cram_fp);
+    cram_fp = NULL;
+    if (res < 0) {
+        fail("sam_close(\"%s\")", cram_name);
+        goto cleanup;
+    }
+
+    for (i = 0; i < MAX_RECS; i += 11) {
+        if (bam_aux_update_str(&recs[i], "ZZ",
+                               sizeof(tag_text) - 1, tag_text) < 0) {
+            fail("bam_aux_update_str()");
+            goto cleanup;
+        }
+    }
+
+    for (i = 0; i < nrecs; i++) {
+        bam_destroy1(&recs[i]);
+    }
+
+    // Now try reading the cram file
+    nrecs = 0;
+    sam_hdr_destroy(header);
+    header = NULL;
+
+    cram_fp = sam_open(cram_name, "r");
+    if (!cram_fp) {
+        fail("sam_open(\"%s\", \"r\")", cram_name);
+        goto cleanup;
+    }
+
+    header = sam_hdr_read(cram_fp);
+    if (!header) {
+        fail("read header from \"%s\"", cram_name);
+        goto cleanup;
+    }
+
+    if (read_data_block(cram_name, cram_fp, NULL, NULL, header, recs,
+                        MAX_RECS, buffer, bufsz, &nrecs) < 0)
+        goto cleanup;
+
+    for (i = 0; i < MAX_RECS; i += 11) {
+        if (bam_aux_update_str(&recs[i], "ZZ",
+                               sizeof(tag_text) - 1, tag_text) < 0) {
+            fail("bam_aux_update_str()");
+            goto cleanup;
+        }
+    }
+
+ cleanup:
+    sam_hdr_destroy(header);
+    if (fp) sam_close(fp);
+    if (bam_fp) sam_close(bam_fp);
+    if (cram_fp) sam_close(cram_fp);
+
+    for (i = 0; i < nrecs; i++) {
+        bam_destroy1(&recs[i]);
+    }
+    free(buffer);
+    free(recs);
+    if (cram_fmt.specific) {
+        hts_opt_free(cram_fmt.specific);
+    }
+}
+
 int main(int argc, char **argv)
 {
     int i;
@@ -1121,6 +1407,7 @@ int main(int argc, char **argv)
     test_text_file("test/fastqs.fq", 500);
     check_enum1();
     check_cigar_tab();
+    test_mempolicy();
     for (i = 1; i < argc; i++) faidx1(argv[i]);
 
     return status;


### PR DESCRIPTION
First three commits do some preliminary work:

- Remove `#ifdef BAM_NO_ID`, which doesn't seem to be used and would probably break things for anyone who did define it.

- Add doxygen documentation for some `bam1_t` related functions.

- Add allocation failure checks to `bam_copy1()` and `bam_dup1()`.  `bam_copy1()` gets annotated `HTS_RESULT_USED` to encourage checking of the return value.

The last one adds an interface to allow more control over `bam1_t` memory.  It can be used to prevent `bam_destroy1()` from trying to free the `bam1_t` structure (for example when it is part of an array).  It can also be used to change how the `bam1_t::data` memory is managed, so any existing data will not be freed by either `bam_destroy1()` or a reallocation in order to grow the buffer.  This allows programs to efficiently pack data for many alignment records into a single buffer (currently samtools sort does this, but has to [copy the data](https://github.com/samtools/samtools/blob/abc98cd7/bam_sort.c#L2096) into its buffer instead or storing it there directly).  Being able to do this allows much more efficient memory management when dealing with thousands of alignment records (see samtools/samtools#593).