### PR TITLE
More documentation + bam_copy1() and bam_dup1() memory checks

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -3225,11 +3225,14 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
     }
 
     /* Copy or alloc+copy the bam record, for later encoding */
-    if (c->bams[c->curr_c_rec])
-        bam_copy1(c->bams[c->curr_c_rec], b);
-    else
-        c->bams[c->curr_c_rec] = bam_dup(b);
-
+    if (c->bams[c->curr_c_rec]) {
+        if (bam_copy1(c->bams[c->curr_c_rec], b) == NULL)
+            return -1;
+    } else {
+        c->bams[c->curr_c_rec] = bam_dup1(b);
+        if (c->bams[c->curr_c_rec] == NULL)
+            return -1;
+    }
     c->curr_rec++;
     c->curr_c_rec++;
     c->s_num_bases += bam_seq_len(b);

--- a/cram/cram_samtools.h
+++ b/cram/cram_samtools.h
@@ -52,8 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define bam_cigar(b)     bam_get_cigar((b))
 #define bam_aux(b)       bam_get_aux((b))
 
-#define bam_dup(b)       bam_copy1(bam_init1(), (b))
-
 #define bam_free(b)      bam_destroy1((b))
 
 #define bam_reg2bin(beg,end) hts_reg2bin((beg),(end),14,5)

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -802,7 +802,7 @@ int bam_write1(BGZF *fp, const bam1_t *b) HTS_RESULT_USED;
    @param bsrc  Source alignment record
    @return bdst on success; NULL on failure
  */
-bam1_t *bam_copy1(bam1_t *bdst, const bam1_t *bsrc);
+bam1_t *bam_copy1(bam1_t *bdst, const bam1_t *bsrc) HTS_RESULT_USED;
 
 /// Create a duplicate alignment record
 /**

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -755,14 +755,92 @@ void sam_hdr_incr_ref(sam_hdr_t *h);
 
 /* Alignment */
 
+/// Create a new bam1_t alignment structure
+/**
+   @return An empty bam1_t structure on success, NULL on failure
+ */
 bam1_t *bam_init1(void);
+
+/// Destory a bam1_t structure
+/**
+   @param b  structure to destroy
+
+   Does nothing if @p b is NULL.  If not, all memory associated with @p b
+   will be freed, along with the structure itself.  @p b should not be
+   accessed after calling this function.
+ */
 void bam_destroy1(bam1_t *b);
+
+/// Read a BAM format alignment record
+/**
+   @param fp   BGZF file being read
+   @param b    Destination for the alignment data
+   @return number of bytes read on success
+           -1 at end of file
+           < -1 on failure
+
+   This function can only read BAM format files.  Most code should use
+   sam_read1() instead, which can be used with BAM, SAM and CRAM formats.
+*/
 int bam_read1(BGZF *fp, bam1_t *b) HTS_RESULT_USED;
+
+/// Write a BAM format alignment record
+/**
+   @param fp  BGZF file being written
+   @param b   Alignment record to write
+   @return number of bytes written on success
+           -1 on error
+
+   This function can only write BAM format files.  Most code should use
+   sam_write1() instead, which can be used with BAM, SAM and CRAM formats.
+*/
 int bam_write1(BGZF *fp, const bam1_t *b) HTS_RESULT_USED;
+
+/// Copy alignment record data
+/**
+   @param bdst  Destination alignment record
+   @param bsrc  Source alignment record
+   @return bdst on success; NULL on failure
+ */
 bam1_t *bam_copy1(bam1_t *bdst, const bam1_t *bsrc);
+
+/// Create a duplicate alignment record
+/**
+   @param bsrc  Source alignment record
+   @return Pointer to a new alignment record on success; NULL on failure
+ */
 bam1_t *bam_dup1(const bam1_t *bsrc);
 
+/// Calculate query length from CIGAR data
+/**
+   @param n_cigar   Number of items in @p cigar
+   @param cigar     CIGAR data
+   @return Query length
+
+   CIGAR data is stored as in the BAM format, i.e. (op_len << 4) | op
+   where op_len is the length in bases and op is a value between 0 and 8
+   representing one of the operations "MIDNSHP=X" (M = 0; X = 8)
+
+   This function returns the sum of the lengths of the M, I, S, = and X
+   operations in @p cigar (these are the operations that "consume" query
+   bases).  All other operations (including invalid ones) are ignored.
+ */
 int bam_cigar2qlen(int n_cigar, const uint32_t *cigar);
+
+/// Calculate reference length from CIGAR data
+/**
+   @param n_cigar   Number of items in @p cigar
+   @param cigar     CIGAR data
+   @return Reference length
+
+   CIGAR data is stored as in the BAM format, i.e. (op_len << 4) | op
+   where op_len is the length in bases and op is a value between 0 and 8
+   representing one of the operations "MIDNSHP=X" (M = 0; X = 8)
+
+   This function returns the sum of the lengths of the M, D, N, = and X
+   operations in @p cigar (these are the operations that "consume" reference
+   bases).  All other operations (including invalid ones) are ignored.
+ */
 int bam_cigar2rlen(int n_cigar, const uint32_t *cigar);
 
 /*!

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -225,9 +225,7 @@ typedef struct {
     int l_data;
     uint32_t m_data;
     uint8_t *data;
-#ifndef BAM_NO_ID
     uint64_t id;
-#endif
 } bam1_t;
 
 /*! @function

--- a/sam.c
+++ b/sam.c
@@ -3358,9 +3358,7 @@ int bam_plp_push(bam_plp_t iter, const bam1_t *b)
             return 0;
         }
         bam_copy1(&iter->tail->b, b);
-#ifndef BAM_NO_ID
         iter->tail->b.id = iter->id++;
-#endif
         iter->tail->beg = b->core.pos;
         iter->tail->end = bam_endpos(b);
         iter->tail->s = g_cstate_null; iter->tail->s.end = iter->tail->end - 1; // initialize cstate_t

--- a/sam.c
+++ b/sam.c
@@ -406,10 +406,11 @@ void bam_destroy1(bam1_t *b)
 bam1_t *bam_copy1(bam1_t *bdst, const bam1_t *bsrc)
 {
     uint8_t *data = bdst->data;
-    int m_data = bdst->m_data;   // backup data and m_data
-    if (m_data < bsrc->l_data) { // double the capacity
+    uint32_t m_data = bdst->m_data;   // backup data and m_data
+    if (m_data < bsrc->l_data) { // increase the capacity
         m_data = bsrc->l_data; kroundup32(m_data);
         data = (uint8_t*)realloc(data, m_data);
+        if (!data) return NULL;
     }
     memcpy(data, bsrc->data, bsrc->l_data); // copy var-len data
     *bdst = *bsrc; // copy the rest
@@ -424,7 +425,11 @@ bam1_t *bam_dup1(const bam1_t *bsrc)
     if (bsrc == NULL) return NULL;
     bam1_t *bdst = bam_init1();
     if (bdst == NULL) return NULL;
-    return bam_copy1(bdst, bsrc);
+    if (bam_copy1(bdst, bsrc) == NULL) {
+        bam_destroy1(bdst);
+        return NULL;
+    }
+    return bdst;
 }
 
 void bam_cigar2rqlens(int n_cigar, const uint32_t *cigar, int *rlen, int *qlen)
@@ -3357,7 +3362,8 @@ int bam_plp_push(bam_plp_t iter, const bam1_t *b)
             overlap_remove(iter, b);
             return 0;
         }
-        bam_copy1(&iter->tail->b, b);
+        if (bam_copy1(&iter->tail->b, b) == NULL)
+            return -1;
         iter->tail->b.id = iter->id++;
         iter->tail->beg = b->core.pos;
         iter->tail->end = bam_endpos(b);

--- a/test/sam.c
+++ b/test/sam.c
@@ -982,10 +982,7 @@ static void samrecord_layout(void)
 
     size_t bam1_t_size, bam1_t_size2;
 
-    bam1_t_size = 36 + sizeof (int) + 4 + sizeof (char *);
-#ifndef BAM_NO_ID
-    bam1_t_size += 8;
-#endif
+    bam1_t_size = 36 + sizeof(int) + 4 + sizeof (char *) + sizeof(uint64_t);
     bam1_t_size2 = bam1_t_size + 4;  // Account for padding on some platforms
 
     if (sizeof (bam1_core_t) != 36)


### PR DESCRIPTION

- Remove #ifdef BAM_NO_ID, which doesn't seem to be used and would probably break things for anyone who did define it.

 - Add doxygen documentation for some bam1_t related functions.

 - Add allocation failure checks to bam_copy1() and bam_dup1(). bam_copy1() gets annotated HTS_RESULT_USED to encourage checking of the return value.
