### PR TITLE
More various minor tidy ups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,9 +196,9 @@ bcf_sr_sort_h = bcf_sr_sort.h $(htslib_synced_bcf_reader_h) $(htslib_kbitset_h)
 header_h = header.h cram/string_alloc.h cram/pooled_alloc.h $(htslib_khash_h) $(htslib_kstring_h) $(htslib_sam_h)
 hfile_internal_h = hfile_internal.h $(htslib_hfile_h) $(textutils_internal_h)
 hts_internal_h = hts_internal.h $(htslib_hts_h) $(textutils_internal_h)
+sam_internal_h = sam_internal.h $(htslib_sam_h)
 textutils_internal_h = textutils_internal.h $(htslib_kstring_h)
 thread_pool_internal_h = thread_pool_internal.h $(htslib_thread_pool_h)
-sam_internal_h = sam_internal.h $(htslib_sam_h)
 
 
 # To be effective, config.mk needs to appear after most Makefile variables are
@@ -318,7 +318,7 @@ hfile.o hfile.pico: hfile.c config.h $(htslib_hfile_h) $(hfile_internal_h) $(hts
 hfile_gcs.o hfile_gcs.pico: hfile_gcs.c config.h $(htslib_hts_h) $(htslib_kstring_h) $(hfile_internal_h)
 hfile_libcurl.o hfile_libcurl.pico: hfile_libcurl.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_net.o hfile_net.pico: hfile_net.c config.h $(hfile_internal_h) $(htslib_knetfile_h)
-hfile_s3_write.o hfile_s3_write.pico: hfile_s3_write.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
+hfile_s3_write.o hfile_s3_write.pico: hfile_s3_write.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
 hts.o hts.pico: hts.c config.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_hts_endian_h) version.h $(hts_internal_h) $(hfile_internal_h) $(sam_internal_h) $(htslib_hts_os_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h) $(htslib_tbx_h)
 hts_os.o hts_os.pico: hts_os.c config.h os/rand.c
@@ -453,7 +453,7 @@ test/pileup.o: test/pileup.c config.h $(htslib_sam_h) $(htslib_kstring_h)
 test/sam.o: test/sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h) $(htslib_hts_log_h)
 test/test_bgzf.o: test/test_bgzf.c config.h $(htslib_bgzf_h) $(htslib_hfile_h) $(hfile_internal_h)
 test/test_kstring.o: test/test_kstring.c config.h $(htslib_kstring_h)
-test/test-parse-reg.o: test/test-parse-reg.c $(htslib_hts_h) $(htslib_sam_h)
+test/test-parse-reg.o: test/test-parse-reg.c config.h $(htslib_hts_h) $(htslib_sam_h)
 test/test_realn.o: test/test_realn.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h)
 test/test-regidx.o: test/test-regidx.c config.h $(htslib_regidx_h) $(hts_internal_h)
 test/test_view.o: test/test_view.c config.h $(cram_h) $(htslib_sam_h) $(htslib_vcf_h)

--- a/header.c
+++ b/header.c
@@ -2439,6 +2439,7 @@ sam_hrec_rg_t *sam_hrecs_find_rg(sam_hrecs_t *hrecs, const char *rg) {
         : &hrecs->rg[kh_val(hrecs->rg_hash, k)];
 }
 
+#if DEBUG_HEADER
 void sam_hrecs_dump(sam_hrecs_t *hrecs) {
     khint_t k;
     int i;
@@ -2486,6 +2487,7 @@ void sam_hrecs_dump(sam_hrecs_t *hrecs) {
 
     puts("===END DUMP===");
 }
+#endif
 
 /*
  * Returns the sort order:

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -739,7 +739,9 @@ static size_t recv_callback(char *ptr, size_t size, size_t nmemb, void *fpv)
 }
 
 
-size_t header_callback(void *contents, size_t size, size_t nmemb, void *userp) {
+static size_t header_callback(void *contents, size_t size, size_t nmemb,
+                              void *userp)
+{
     size_t realsize = size * nmemb;
     kstring_t *resp = (kstring_t *)userp;
 

--- a/hfile_s3_write.c
+++ b/hfile_s3_write.c
@@ -194,7 +194,7 @@ static void cleanup(hFILE_s3_write *fp) {
 }
 
 
-struct curl_slist *set_html_headers(hFILE_s3_write *fp, kstring_t *auth, kstring_t *date, kstring_t *content, kstring_t *token) {
+static struct curl_slist *set_html_headers(hFILE_s3_write *fp, kstring_t *auth, kstring_t *date, kstring_t *content, kstring_t *token) {
     struct curl_slist *headers = NULL;
 
     headers = curl_slist_append(headers, "Content-Type:"); // get rid of this

--- a/hts.c
+++ b/hts.c
@@ -342,7 +342,7 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
         return 0;
     }
 
-    if (len >= 6 && memcmp(s,"CRAM",4) == 0 && s[4]>=1 && s[4]<=3 && s[5]<=1) {
+    if (len >= 6 && memcmp(s,"CRAM",4) == 0 && s[4]>=1 && s[4]<=7 && s[5]<=7) {
         fmt->category = sequence_data;
         fmt->format = cram;
         fmt->version.major = s[4], fmt->version.minor = s[5];

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -125,6 +125,7 @@ typedef struct kstring_t {
         }                                                               \
     } while (0)
 
+// For internal use (by hts_resize()) only
 int hts_resize_array_(size_t, size_t, size_t, void *, void **, int,
                       const char *);
 
@@ -140,6 +141,8 @@ int hts_resize_array_(size_t, size_t, size_t, void *, void **, int,
                             array is stored.
  * @param[in,out] ptr       Location of the pointer to the array
  * @param[in]     flags     Option flags
+ *
+ * @return        0 for success, or negative if an error occurred.
  *
  * @discussion
  * The array *ptr will be expanded if necessary so that it can hold @p num

--- a/sam.c
+++ b/sam.c
@@ -2242,7 +2242,7 @@ static void *sam_parse_worker(void *arg) {
     return NULL;
 }
 
-void *sam_parse_eof(void *arg) {
+static void *sam_parse_eof(void *arg) {
     return NULL;
 }
 

--- a/vcf.c
+++ b/vcf.c
@@ -3011,7 +3011,7 @@ int bcf_index_build(const char *fn, int min_shift)
 
 // Initialise fp->idx for the current format type.
 // This must be called after the header has been written but no other data.
-int vcf_idx_init(htsFile *fp, bcf_hdr_t *h, int min_shift, const char *fnidx) {
+static int vcf_idx_init(htsFile *fp, bcf_hdr_t *h, int min_shift, const char *fnidx) {
     int n_lvls, i, fmt;
     int64_t max_len = 0;
 


### PR DESCRIPTION
Various minor tidy ups, as described in the commit messages.

Potentially interesting ones are:

* Future-proof CRAM magic detection by recognising up to `CRAM\x07\x07`, “CRAM v7.7”

* `hts_resize()` documentation didn't appear to describe its return value and error codes