### PR TITLE
Fixed CRAM_OPT_REFERENCE handling for files with reordered headers.

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -832,6 +832,9 @@ int hts_opt_apply(htsFile *fp, hts_opt *opts) {
     for (; opts;  opts = (last=opts)->next) {
         switch (opts->opt) {
             case CRAM_OPT_REFERENCE:
+                if (!(fp->fn_aux = strdup(opts->val.s)))
+                    return -1;
+                // fall through
             case CRAM_OPT_VERSION:
             case CRAM_OPT_PREFIX:
                 if (hts_set_opt(fp,  opts->opt,  opts->val.s) != 0)

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -89,7 +89,7 @@ int sam_loop(int argc, char **argv, int optind, struct opts *opts, htsFile *in, 
     }
 
     /* CRAM output */
-    if (opts->flag & WRITE_CRAM) {
+    if ((opts->flag & WRITE_CRAM) && opts->fn_ref) {
         // Create CRAM references arrays
         int ret = hts_set_fai_filename(out, opts->fn_ref);
 


### PR DESCRIPTION
With samtools view -t ref.fa, fp->fn_aux is set.
With samtools view -o reference=ref.fa, this didn't happen.

Both of them load the reference and generate a CRAM_OPT_REFERENCE
parameter, but when writing the CRAM header if fn_aux is set it'll
cause a reload to validate the order in the fai file matches the order
in the header, and if not reorders the structures.

The result of this is using -o to set reference could sometimes get
M5 values out of sync with SQ SNs.