### PR TITLE
Add HTS_VERSION macro for compile-time HTSlib version checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ NUMERIC_VERSION := $(shell ./version.sh numeric)
 version.h: $(if $(wildcard version.h),$(if $(findstring "$(PACKAGE_VERSION)",$(shell cat version.h)),,force))
 
 version.h:
-	echo '#define HTS_VERSION "$(PACKAGE_VERSION)"' > $@
+	echo '#define HTS_VERSION_TEXT "$(PACKAGE_VERSION)"' > $@
 
 print-version:
 	@echo $(PACKAGE_VERSION)

--- a/NEWS
+++ b/NEWS
@@ -162,6 +162,11 @@ Noteworthy changes in release a.b
   alignment record data; see documentation in htslib/sam.h for more
   information.
 
+* In addition to the existing hts_version() function, which reflects the
+  HTSlib version being used at runtime, <htslib/hts.h> now also provides
+  HTS_VERSION, a preprocessor macro reflecting the HTSlib version that
+  a program is being compiled against.  (#794, PR #951)
+
 * Changes to hfile_s3, which provides support for the AWS S3 API.
 
   - hfile_s3 now uses version 4 signatures by default.  Attempting to write to

--- a/hfile_gcs.c
+++ b/hfile_gcs.c
@@ -124,7 +124,7 @@ int PLUGIN_GLOBAL(hfile_plugin_init,_gcs)(struct hFILE_plugin *self)
 
 #ifdef ENABLE_PLUGINS
     // Embed version string for examination via strings(1) or what(1)
-    static const char id[] = "@(#)hfile_gcs plugin (htslib)\t" HTS_VERSION;
+    static const char id[] = "@(#)hfile_gcs plugin (htslib)\t" HTS_VERSION_TEXT;
     if (hts_verbose >= 9)
         fprintf(stderr, "[M::hfile_gcs.init] version %s\n", strchr(id, '\t')+1);
 #endif

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -1435,7 +1435,8 @@ int PLUGIN_GLOBAL(hfile_plugin_init,_libcurl)(struct hFILE_plugin *self)
 
 #ifdef ENABLE_PLUGINS
     // Embed version string for examination via strings(1) or what(1)
-    static const char id[] = "@(#)hfile_libcurl plugin (htslib)\t" HTS_VERSION;
+    static const char id[] =
+        "@(#)hfile_libcurl plugin (htslib)\t" HTS_VERSION_TEXT;
     const char *version = strchr(id, '\t')+1;
 #else
     const char *version = hts_version();

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -1243,7 +1243,7 @@ int PLUGIN_GLOBAL(hfile_plugin_init,_s3)(struct hFILE_plugin *self)
 
 #ifdef ENABLE_PLUGINS
     // Embed version string for examination via strings(1) or what(1)
-    static const char id[] = "@(#)hfile_s3 plugin (htslib)\t" HTS_VERSION;
+    static const char id[] = "@(#)hfile_s3 plugin (htslib)\t" HTS_VERSION_TEXT;
     if (hts_verbose >= 9)
         fprintf(stderr, "[M::hfile_s3.init] version %s\n", strchr(id, '\t')+1);
 #endif

--- a/hfile_s3_write.c
+++ b/hfile_s3_write.c
@@ -818,7 +818,8 @@ int PLUGIN_GLOBAL(hfile_plugin_init,_s3_write)(struct hFILE_plugin *self) {
 
 #ifdef ENABLE_PLUGINS
     // Embed version string for examination via strings(1) or what(1)
-    static const char id[] = "@(#)hfile_s3_write plugin (htslib)\t" HTS_VERSION;
+    static const char id[] =
+        "@(#)hfile_s3_write plugin (htslib)\t" HTS_VERSION_TEXT;
     const char *version = strchr(id, '\t') + 1;
 
     if (hts_verbose >= 9)

--- a/hts.c
+++ b/hts.c
@@ -64,7 +64,7 @@ int hts_verbose = HTS_LOG_WARNING;
 
 const char *hts_version()
 {
-    return HTS_VERSION;
+    return HTS_VERSION_TEXT;
 }
 
 const unsigned char seq_nt16_table[256] = {

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -394,6 +394,18 @@ extern const int seq_nt16_int[];
 const char *hts_version(void);
 
 /*!
+  @abstract  Compile-time HTSlib version number, for use in #if checks
+  @return    For released versions X.Y[.Z], an integer of the form XYYYZZ;
+  useful for preprocessor conditionals such as
+      #if HTS_VERSION >= 101000  // Check for v1.10 or later
+*/
+// Maintainers: Bump this in the final stage of preparing a new release.
+// Immediately after release, bump ZZ to 90 to distinguish in-development
+// Git repository builds from the release; you may wish to increment this
+// further when significant features are merged.
+#define HTS_VERSION 100990
+
+/*!
   @abstract    Determine format by peeking at the start of a file
   @param fp    File opened for reading, positioned at the beginning
   @param fmt   Format structure that will be filled out on return

--- a/test/sam.c
+++ b/test/sam.c
@@ -47,6 +47,13 @@ DEALINGS IN THE SOFTWARE.  */
 KHASH_SET_INIT_STR(keep)
 typedef khash_t(keep) *keephash_t;
 
+#ifndef HTS_VERSION
+#error HTS_VERSION not defined
+#endif
+#if HTS_VERSION < 100900
+#error HTS_VERSION comparison incorrect
+#endif
+
 int status;
 
 static void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) fail(const char *fmt, ...)


### PR DESCRIPTION
Here is a proposal for adding a public `HTS_VERSION` macro, for use by third-party code wishing to probe for the existence of newly-added HTSlib capabilities (without going to the effort of writing configure tests to check for them!), as wished for in #794.

HTSlib already has a `hts_version()` function that reports the version of HTSlib that a program is _running against_, which is the most useful thing for third-party programs to report as it reflects the HTSlib behaviour observed and in particular what library bugs may have been fixed.

It would additionally be useful for HTSlib to have a preprocessor macro so that programs could enquire about the version of HTSlib being _compiled against_ at compile time, and emit an understandable `#error` or (if they are overachievers) adjust their code accordingly. This PR adds a macro so that user code can write tests like

```c
#if HTS_VERSION >= 101000  // Check for v1.10 or later
// …use hts_parse_region() or some other new API functions
#endif
```
    
This encodes the version number X.Y.Z into a single integer XYYYZZ so that comparisons are easy. The XYYYZZ encoding is the same as that used by [Boost](https://www.boost.org/doc/libs/1_71_0/boost/version.hpp).

(I had prepared a version of this with an associated `HTS_VERNUM` macro to hide the numeric encoding details (see jmarshall/htslib@debead4d39d7d97ac0f05ed7d91651aa27c00df1) to be used as `#if HTS_VERSION >= HTS_VERNUM(1,10,0)`, but that alas leads to errors when compiling against earlier HTSlib releases that do not define `HTS_VERNUM`. See also https://github.com/irods/irods/issues/2671#issuecomment-100267437.)

Because you don't want a public header to be dependent on configuration or building — cf https://github.com/samtools/htslib/issues/559#issuecomment-314106899 and the following conversation — this would be updated manually (or via the release scripts) during and after each release. Bumping the patch-number after release means that the value in a development Git repository header is distinct from the value in the preceding release, but it's not proposed to update it constantly with each commit to **develop**! OTOH from time to time during development, you may wish to bump the patch-number from 90 to 91 to 92 etc when truly significant facilities are merged — somewhat similarly to the current `TWO_TO_THREE_TRANSITION_COUNT` development counter.

There's some pain in this as like the version numbers in _version.sh_, _NEWS_, and the manual pages, it would need to be updated during the release process. However you already have the _mkrelease_ and _tag_release_ scripts for that so after it was added to those, it would not be onerous.