### PR TITLE
Make the sam parser detect out-of-range numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ BUILT_TEST_PROGRAMS = \
 	test/test_kstring \
 	test/test_realn \
 	test/test-regidx \
+	test/test_str2int \
 	test/test_view \
 	test/test_index \
 	test/test-vcf-api \
@@ -384,6 +385,7 @@ maintainer-check:
 check test: $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS)
 	test/hts_endian
 	test/test_kstring
+	test/test_str2int
 	test/fieldarith test/fieldarith.sam
 	test/hfile
 	test/test_bgzf test/bgziptest.txt
@@ -427,6 +429,9 @@ test/test-regidx: test/test-regidx.o libhts.a
 test/test-parse-reg: test/test-parse-reg.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test-parse-reg.o libhts.a $(LIBS) -lpthread
 
+test/test_str2int: test/test_str2int.o
+	$(CC) $(LDFLAGS) -o $@ test/test_str2int.o
+
 test/test_view: test/test_view.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_view.o libhts.a $(LIBS) -lpthread
 
@@ -456,6 +461,7 @@ test/test_kstring.o: test/test_kstring.c config.h $(htslib_kstring_h)
 test/test-parse-reg.o: test/test-parse-reg.c config.h $(htslib_hts_h) $(htslib_sam_h)
 test/test_realn.o: test/test_realn.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h)
 test/test-regidx.o: test/test-regidx.c config.h $(htslib_regidx_h) $(hts_internal_h)
+test/test_str2int.o: test/test_str2int.c config.h $(textutils_internal_h)
 test/test_view.o: test/test_view.c config.h $(cram_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_hts_log_h)
 test/test_index.o: test/test_index.c config.h $(htslib_sam_h) $(htslib_vcf_h)
 test/test-vcf-api.o: test/test-vcf-api.c config.h $(htslib_hts_h) $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_kseq_h)

--- a/sam.c
+++ b/sam.c
@@ -1710,56 +1710,151 @@ int sam_hdr_change_HD(sam_hdr_t *h, const char *key, const char *val)
  *** SAM record I/O ***
  **********************/
 
-/* Custom strtol for aux tags, always base 10 */
-static inline int64_t STRTOL64(const char *v, char **rv, int b) {
-    int64_t n = 0;
-    int neg = 1;
-    switch(*v) {
-    case '-':
-        neg=-1;
-        break;
-    case '+':
-        break;
-    case '0': case '1': case '2': case '3': case '4':
-    case '5': case '6': case '7': case '8': case '9':
-        n = *v - '0';
-        break;
-    default:
-        *rv = (char *)v;
+static int sam_parse_B_vals(char type, uint32_t n, char *in, char **end,
+                            char *r, bam1_t *b)
+{
+    int orig_l = b->l_data;
+    char *q = in;
+    int32_t size;
+    size_t bytes;
+    int overflow = 0;
+
+    size = aux_type2size(type);
+    if (size <= 0 || size > 4) {
+        hts_log_error("Unrecognized type B:%c", type);
+        return -1;
+    }
+
+    // Ensure space for type + values
+    bytes = (size_t) n * (size_t) size;
+    if (bytes / size != n
+        || possibly_expand_bam_data(b, bytes + 2 + sizeof(uint32_t))) {
+        hts_log_error("Out of memory");
+        return -1;
+    }
+
+    b->data[b->l_data++] = 'B';
+    b->data[b->l_data++] = type;
+    i32_to_le(n, b->data + b->l_data);
+    b->l_data += sizeof(uint32_t);
+    // This ensures that q always ends up at the next comma after
+    // reading a number even if it's followed by junk.  It
+    // prevents the possibility of trying to read more than n items.
+#define skip_to_comma_(q) do { while (*(q) > '\t' && *(q) != ',') (q)++; } while (0)
+    if (type == 'c') {
+        while (q < r) {
+            *(b->data + b->l_data) = hts_str2int(q + 1, &q, 8, &overflow);
+            b->l_data++;
+            skip_to_comma_(q);
+        }
+    } else if (type == 'C') {
+        while (q < r) {
+            if (*q != '-') {
+                *(b->data + b->l_data) = hts_str2uint(q + 1, &q, 8, &overflow);
+                b->l_data++;
+            } else {
+                overflow = 1;
+            }
+            skip_to_comma_(q);
+        }
+    } else if (type == 's') {
+        while (q < r) {
+            i16_to_le(hts_str2int(q + 1, &q, 16, &overflow), b->data + b->l_data);
+            b->l_data += 2;
+            skip_to_comma_(q);
+        }
+    } else if (type == 'S') {
+        while (q < r) {
+            if (*q != '-') {
+                u16_to_le(hts_str2uint(q + 1, &q, 16, &overflow), b->data + b->l_data);
+                b->l_data += 2;
+            } else {
+                overflow = 1;
+            }
+            skip_to_comma_(q);
+        }
+    } else if (type == 'i') {
+        while (q < r) {
+            i32_to_le(hts_str2int(q + 1, &q, 32, &overflow), b->data + b->l_data);
+            b->l_data += 4;
+            skip_to_comma_(q);
+        }
+    } else if (type == 'I') {
+        while (q < r) {
+            if (*q != '-') {
+                u32_to_le(hts_str2uint(q + 1, &q, 32, &overflow), b->data + b->l_data);
+                b->l_data += 4;
+            } else {
+                overflow = 1;
+            }
+            skip_to_comma_(q);
+        }
+    } else if (type == 'f') {
+        while (q < r) {
+            float_to_le(strtod(q + 1, &q), b->data + b->l_data);
+            b->l_data += 4;
+            skip_to_comma_(q);
+        }
+    } else {
+        hts_log_error("Unrecognized type B:%c", type);
+        return -1;
+    }
+
+    if (!overflow) {
+        *end = q;
         return 0;
+    } else {
+        int64_t max = 0, min = 0, val;
+        // Given type was incorrect.  Try to rescue the situation.
+        q = in;
+        overflow = 0;
+        b->l_data = orig_l;
+        // Find out what range of values is present
+        while (q < r) {
+            val = hts_str2int(q + 1, &q, 64, &overflow);
+            if (max < val) max = val;
+            if (min > val) min = val;
+            skip_to_comma_(q);
+        }
+        // Retry with appropriate type
+        if (!overflow) {
+            if (min < 0) {
+                if (min >= INT8_MIN && max <= INT8_MAX) {
+                    return sam_parse_B_vals('c', n, in, end, r, b);
+                } else if (min >= INT16_MIN && max <= INT16_MAX) {
+                    return sam_parse_B_vals('s', n, in, end, r, b);
+                } else if (min >= INT32_MIN && max <= INT32_MAX) {
+                    return sam_parse_B_vals('i', n, in, end, r, b);
+                }
+            } else {
+                if (max < UINT8_MAX) {
+                    return sam_parse_B_vals('C', n, in, end, r, b);
+                } else if (max <= UINT16_MAX) {
+                    return sam_parse_B_vals('S', n, in, end, r, b);
+                } else if (max <= UINT32_MAX) {
+                    return sam_parse_B_vals('I', n, in, end, r, b);
+                }
+            }
+        }
+        // If here then at least one of the values is too big to store
+        hts_log_error("Numeric value in B array out of allowed range");
+        return -1;
     }
-
-    v++;
-
-    while (*v>='0' && *v<='9') {
-        int digit = *v++ - '0';
-        n = n*10 + digit;
-    }
-    *rv = (char *)v;
-    return neg*n;
+#undef skip_to_comma_
 }
 
-static inline uint64_t STRTOUL64(const char *v, char **rv, int b) {
-    uint64_t n = 0;
-    if (*v == '+')
-        v++;
-
-    while (*v>='0' && *v<='9') {
-        int digit = *v++ - '0';
-        n = n*10 + digit;
-    }
-    *rv = (char *)v;
-    return n;
-}
-
-static inline unsigned int parse_sam_flag(char *v, char **rv) {
+static inline unsigned int parse_sam_flag(char *v, char **rv, int *overflow) {
     if (*v >= '1' && *v <= '9') {
-        return STRTOUL64(v, rv, 10);
+        return hts_str2uint(v, rv, 16, overflow);
     }
     else if (*v == '0') {
         // handle single-digit "0" directly; otherwise it's hex or octal
         if (v[1] == '\t') { *rv = v+1; return 0; }
-        else return strtoul(v, rv, 0);
+        else {
+            unsigned long val = strtoul(v, rv, 0);
+            if (val > 65535) { *overflow = 1; return 65535; }
+            return val;
+        }
     }
     else {
         // TODO implement symbolic flag letters
@@ -1814,7 +1909,7 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
     uint8_t *t;
 
     char *p = s->s, *q;
-    int i;
+    int i, overflow = 0;
     bam1_core_t *c = &b->core;
 
     b->l_data = 0;
@@ -1836,7 +1931,7 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
     c->l_qname = p - q + c->l_extranul;
 
     // flag
-    c->flag = parse_sam_flag(p, &p);
+    c->flag = parse_sam_flag(p, &p, &overflow);
     if (*p++ != '\t') goto err_ret; // malformated flag
 
     // chr
@@ -1849,7 +1944,7 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
     } else c->tid = -1;
 
     // pos
-    c->pos = STRTOL64(p, &p, 10) - 1;
+    c->pos = hts_str2uint(p, &p, 63, &overflow) - 1;
     if (*p++ != '\t') goto err_ret;
     if (c->pos < 0 && c->tid >= 0) {
         _parse_warn(1, "mapped query cannot have zero coordinate; treated as unmapped");
@@ -1858,7 +1953,7 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
     if (c->tid < 0) c->flag |= BAM_FUNMAP;
 
     // mapq
-    c->qual = STRTOL64(p, &p, 10);
+    c->qual = hts_str2uint(p, &p, 8, &overflow);
     if (*p++ != '\t') goto err_ret;
     // cigar
     if (*p != '*') {
@@ -1873,7 +1968,7 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
         _get_mem(uint32_t, &cigar, b, c->n_cigar * sizeof(uint32_t));
         for (i = 0; i < c->n_cigar; ++i) {
             int op;
-            cigar[i] = STRTOL64(q, &q, 10)<<BAM_CIGAR_SHIFT;
+            cigar[i] = hts_str2uint(q, &q, 28, &overflow)<<BAM_CIGAR_SHIFT;
             op = bam_cigar_table[(unsigned char)*q++];
             _parse_err(op < 0, "unrecognized CIGAR operator");
             cigar[i] |= op;
@@ -1899,14 +1994,14 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
         _parse_warn(c->mtid < 0, "urecognized mate reference name; treated as unmapped");
     }
     // mpos
-    c->mpos = STRTOL64(p, &p, 10) - 1;
+    c->mpos = hts_str2uint(p, &p, 63, &overflow) - 1;
     if (*p++ != '\t') goto err_ret;
     if (c->mpos < 0 && c->mtid >= 0) {
         _parse_warn(1, "mapped mate cannot have zero coordinate; treated as unmapped");
         c->mtid = -1;
     }
     // tlen
-    c->isize = STRTOL64(p, &p, 10);
+    c->isize = hts_str2int(p, &p, 64, &overflow);
     if (*p++ != '\t') goto err_ret;
     // seq
     q = _read_token(p);
@@ -1960,7 +2055,7 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
             b->data[b->l_data++] = *q++;
         } else if (type == 'i' || type == 'I') {
             if (*q == '-') {
-                long x = STRTOL64(q, &q, 10);
+                int32_t x = hts_str2int(q, &q, 32, &overflow);
                 if (x >= INT8_MIN) {
                     b->data[b->l_data++] = 'c';
                     b->data[b->l_data++] = x;
@@ -1974,7 +2069,7 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
                     b->l_data += 4;
                 }
             } else {
-                unsigned long x = STRTOUL64(q, &q, 10);
+                uint32_t x = hts_str2uint(q, &q, 32, &overflow);
                 if (x <= UINT8_MAX) {
                     b->data[b->l_data++] = 'C';
                     b->data[b->l_data++] = x;
@@ -2008,48 +2103,25 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
             b->data[b->l_data++] = '\0';
             q = end;
         } else if (type == 'B') {
-            int32_t n, size;
-            size_t bytes;
+            uint32_t n;
             char *r;
             type = *q++; // q points to the first ',' following the typing byte
-            size = aux_type2size(type);
-            _parse_err_param(size <= 0 || size > 4,
-                             "unrecognized type B:%c", type);
             _parse_err(*q && *q != ',' && *q != '\t',
                        "B aux field type not followed by ','");
 
             for (r = q, n = 0; *r > '\t'; ++r)
                 if (*r == ',') ++n;
 
-            // Ensure space for type + values
-            bytes = (size_t) n * (size_t) size;
-            _parse_err(bytes / size != n
-                       || possibly_expand_bam_data(b, bytes + 2 + sizeof(uint32_t)) < 0,
-                       "out of memory");
-            b->data[b->l_data++] = 'B';
-            b->data[b->l_data++] = type;
-            i32_to_le(n, b->data + b->l_data);
-            b->l_data += sizeof(uint32_t);
-
-            // This ensures that q always ends up at the next comma after
-            // reading a number even if it's followed by junk.  It
-            // prevents the possibility of trying to read more than n items.
-#define skip_to_comma_(q) do { while (*(q) > '\t' && *(q) != ',') (q)++; } while (0)
-            if (type == 'c')      while (q < r) { *(b->data + b->l_data) = STRTOL64(q + 1, &q, 0); b->l_data++; skip_to_comma_(q); }
-            else if (type == 'C') while (q < r) { *(b->data + b->l_data) = STRTOUL64(q + 1, &q, 0); b->l_data++; skip_to_comma_(q); }
-            else if (type == 's') while (q < r) { i16_to_le(STRTOL64(q + 1, &q, 0), b->data + b->l_data); b->l_data += 2; skip_to_comma_(q); }
-            else if (type == 'S') while (q < r) { u16_to_le(STRTOUL64(q + 1, &q, 0), b->data + b->l_data); b->l_data += 2; skip_to_comma_(q); }
-            else if (type == 'i') while (q < r) { i32_to_le(STRTOL64(q + 1, &q, 0), b->data + b->l_data); b->l_data += 4; skip_to_comma_(q); }
-            else if (type == 'I') while (q < r) { u32_to_le(STRTOUL64(q + 1, &q, 0), b->data + b->l_data); b->l_data += 4; skip_to_comma_(q); }
-            else if (type == 'f') while (q < r) { float_to_le(strtod(q + 1, &q), b->data + b->l_data); b->l_data += 4; skip_to_comma_(q); }
-            else _parse_err_param(1, "unrecognized type B:%c", type);
-#undef skip_to_comma_
-
+            if (sam_parse_B_vals(type, n, q, &q, r, b) < 0)
+                goto err_ret;
         } else _parse_err_param(1, "unrecognized type %c", type);
 
         while (*q > '\t') { q++; } // Skip any junk to next tab
         q++;
     }
+
+    _parse_err(overflow != 0, "numeric value out of allowed range");
+
     if (bam_tag2cigar(b, 1, 1) < 0)
         return -2;
     return 0;

--- a/test/test_str2int.c
+++ b/test/test_str2int.c
@@ -1,0 +1,155 @@
+/* test_parse_int.c -- Test integer string conversion
+
+   Copyright (C) 2019 Genome Research Ltd.
+
+   Author: Rob Davies <rmd@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+
+#include <config.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include "textutils_internal.h"
+
+// Test hts_str2int() and hts_str2uint() on various values around the
+// maximum (or minimum for negative numbers) allowed for the given
+// number of bits.  Ensures that the failed flag is set when the output
+// isn't going to fit, that the correct value is returned and that
+// 'end' points to the character following the number.
+static int check_str2int(int verbose) {
+    char buffer[64], *end;
+    int64_t val;
+    uint64_t num, uval;
+    int failed = 0, efail, i, offset;
+    const char sentinal = '#';
+
+    // Positive value (unsigned)
+    for (i = 1; i < 64; i++) {
+        num = (1ULL << i) - 1;
+        for (offset = i < 5 ? -(1LL << (i - 1)) : -16; offset <= 30; offset++) {
+            efail = (offset > 0);
+            snprintf(buffer, sizeof(buffer), "%" PRIu64 "%c",
+                     num + offset, sentinal);
+
+            uval = hts_str2uint(buffer, &end, i, &failed);
+            if (failed != efail || uval != (!efail ? num + offset : num)
+                || *end != sentinal) {
+                fprintf(stderr, "hts_str2uint failed: %d bit "
+                        "%s %"PRIu64" '%c' %d (%d)\n",
+                        i, buffer, uval, *end, failed, efail);
+                return -1;
+            } else if (verbose) {
+                fprintf(stderr, "hts_str2uint OK: %d bit "
+                        "%s %"PRIu64" '%c' %d (%d)\n",
+                        i, buffer, uval, *end, failed, efail);
+            }
+            failed = 0;
+        }
+
+        // Positive value (signed)
+        for (offset = i < 5 ? -(1LL << (i - 1)) : -16; offset <= 30; offset++) {
+            efail = (offset > 0);
+            snprintf(buffer, sizeof(buffer), "%" PRIu64 "%c",
+                     num + offset, sentinal);
+
+            val = hts_str2int(buffer, &end, i + 1, &failed);
+            if (failed != efail || val != (!efail ? num + offset : num)
+                || *end != sentinal) {
+                fprintf(stderr,
+                        "hts_str2int  failed: %d bit "
+                        "%s %"PRId64" '%c' %d (%d)\n",
+                        i + 1, buffer, val, *end, failed, efail);
+                return -1;
+            } else if (verbose) {
+                fprintf(stderr, "hts_str2int  OK: %d bit "
+                        "%s %"PRId64" '%c' %d (%d)\n",
+                        i + 1, buffer, val, *end, failed, efail);
+            }
+            failed = 0;
+        }
+
+        // Negative value (signed)
+        for (offset = i < 5 ? -(1LL << (i - 1)) : -16; offset <= 30; offset++) {
+            efail = (offset > 0);
+            snprintf(buffer, sizeof(buffer), "-%" PRIu64 "%c",
+                     num + offset + 1, sentinal);
+
+            val = hts_str2int(buffer, &end, i + 1, &failed);
+            // Cast of val to unsigned in this comparison avoids undefined
+            // behaviour when checking INT64_MIN.
+            if (failed != efail
+                || -((uint64_t) val) != (!efail ? num + offset + 1 : num + 1)
+                || *end != sentinal) {
+                fprintf(stderr,
+                        "hts_str2int  failed: %d bit "
+                        "%s %"PRId64" '%c' %d (%d)\n",
+                        i + 1, buffer, val, *end, failed, efail);
+                return -1;
+            } else if (verbose) {
+                fprintf(stderr, "hts_str2int  OK: %d bit "
+                        "%s %"PRId64" '%c' %d (%d)\n",
+                        i + 1, buffer, val, *end, failed, efail);
+            }
+            failed = 0;
+        }
+    }
+
+    // Special case for UINT64_MAX
+    for (offset = 0; offset <= 999; offset++) {
+        efail = offset > 615;
+        snprintf(buffer, sizeof(buffer), "18446744073709551%03d%c",
+                 offset, sentinal);
+        uval = hts_str2uint(buffer, &end, 64, &failed);
+        if (failed != efail
+            || uval != (efail ? UINT64_MAX : 18446744073709551000ULL + offset)
+            || *end != sentinal) {
+            fprintf(stderr, "hts_str2uint failed: 64 bit %s "
+                    "%"PRIu64" '%c' %d (%d)\n",
+                    buffer, uval, *end, failed, efail);
+            return -1;
+        } else if (verbose) {
+            fprintf(stderr, "hts_str2uint OK: 64 bit "
+                    "%s %"PRIu64" '%c' %d (%d)\n",
+                    buffer, uval, *end, failed, efail);
+        }
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    int verbose = 0, opt, res;
+
+    while ((opt = getopt(argc, argv, "v")) != -1) {
+        switch (opt) {
+        case 'v':
+            verbose = 1;
+            break;
+        default:
+            fprintf(stderr, "Usage: %s [-v]\n", argv[0]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    res = check_str2int(verbose);
+    return res ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
Replace STRTOL64() and STRTOUL64() functions with versions that can detect when the parsed value will not fit into the destination.  The new functions are called hts_str2int() and hts_str2uint() as the
interface has changed somewhat from that of strtol().  The new functions have been put in textutils_internal.h so that they can be used by other parsers (notably vcf) in future updates.

Add tests for the new hts_str2int() and hts_str2uint() functions.

Update sam_parse1() to use these functions and report an error if a number was too large.  The B array code is pulled out into its own function.  The new function includes code to fix up B arrays where the subtype code was set incorrectly (at the cost of a couple of extra scans through the data).

This has been designed to have minimal impact on the speed of the SAM parser.  If fact it may even be faster as the compiler (notably clang) can see that the "fast" loop is bounded in size and decides to unroll it.

Credit to OSS-Fuzz
Fixes oss-fuzz 18142
