### PR TITLE
Return lengths from bam_cigar2rqlens as hts_pos_t and make it static

### DIFF
--- a/README.large_positions.md
+++ b/README.large_positions.md
@@ -201,6 +201,7 @@ File htslib/regidx.h:
 File htslib/sam.h:
 
    [new]        sam_hdr_tid2len()
+   [return]     bam_cigar2qlen()
    [return]     bam_cigar2rlen()
    [return]     bam_endpos()
    [parameters] bam_itr_queryi()

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -947,8 +947,14 @@ bam1_t *bam_dup1(const bam1_t *bsrc);
    This function returns the sum of the lengths of the M, I, S, = and X
    operations in @p cigar (these are the operations that "consume" query
    bases).  All other operations (including invalid ones) are ignored.
+
+   @note This return type of this function is hts_pos_t so that it can
+   correctly return the length of CIGAR sequences including many long
+   operations without overflow. However, other restrictions (notably the sizes
+   of bam1_core_t::l_qseq and bam1_t::data) limit the maximum query sequence
+   length supported by HTSlib to fewer than INT_MAX bases.
  */
-int bam_cigar2qlen(int n_cigar, const uint32_t *cigar);
+hts_pos_t bam_cigar2qlen(int n_cigar, const uint32_t *cigar);
 
 /// Calculate reference length from CIGAR data
 /**

--- a/sam.c
+++ b/sam.c
@@ -450,7 +450,7 @@ static void bam_cigar2rqlens(int n_cigar, const uint32_t *cigar,
     }
 }
 
-int bam_cigar2qlen(int n_cigar, const uint32_t *cigar)
+hts_pos_t bam_cigar2qlen(int n_cigar, const uint32_t *cigar)
 {
     int k, l;
     for (k = l = 0; k < n_cigar; ++k)
@@ -1914,8 +1914,8 @@ int sam_parse1(kstring_t *s, sam_hdr_t *h, bam1_t *b)
     if (strcmp(q, "*")) {
         _parse_err(p - q - 1 > INT32_MAX, "read sequence is too long");
         c->l_qseq = p - q - 1;
-        i = bam_cigar2qlen(c->n_cigar, (uint32_t*)(b->data + c->l_qname));
-        _parse_err(c->n_cigar && i != c->l_qseq, "CIGAR and query sequence are of different length");
+        hts_pos_t ql = bam_cigar2qlen(c->n_cigar, (uint32_t*)(b->data + c->l_qname));
+        _parse_err(c->n_cigar && ql != c->l_qseq, "CIGAR and query sequence are of different length");
         i = (c->l_qseq + 1) >> 1;
         _get_mem(uint8_t, &t, b, i);
 

--- a/sam.c
+++ b/sam.c
@@ -437,7 +437,8 @@ bam1_t *bam_dup1(const bam1_t *bsrc)
     return bdst;
 }
 
-void bam_cigar2rqlens(int n_cigar, const uint32_t *cigar, int *rlen, int *qlen)
+static void bam_cigar2rqlens(int n_cigar, const uint32_t *cigar,
+                             hts_pos_t *rlen, hts_pos_t *qlen)
 {
     int k;
     *rlen = *qlen = 0;
@@ -607,7 +608,7 @@ int bam_read1(BGZF *fp, bam1_t *b)
         return -4;
 
     if (c->n_cigar > 0) { // recompute "bin" and check CIGAR-qlen consistency
-        int rlen, qlen;
+        hts_pos_t rlen, qlen;
         bam_cigar2rqlens(c->n_cigar, bam_get_cigar(b), &rlen, &qlen);
         if ((b->core.flag & BAM_FUNMAP)) rlen=1;
         b->core.bin = hts_reg2bin(b->core.pos, b->core.pos + rlen, 14, 5);


### PR DESCRIPTION
A bit of left-over 64 bit work, discovered by oss-fuzz.

While it's unlikely that a single CIGAR could cover over 4 Gbases of reference, I wouldn't like to guarantee that someone won't try to make one so we may as well support it.
