### PR TITLE
Removed some CRAM pre-1.0 legacies.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -208,10 +208,6 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
     }
 
     /* Initialise defaults for preservation map */
-    hdr->mapped_qs_included = 0;
-    hdr->unmapped_qs_included = 0;
-    hdr->unmapped_placed = 0;
-    hdr->qs_included = 0;
     hdr->read_names_included = 0;
     hdr->AP_delta = 1;
     memcpy(hdr->substitution_matrix, "CGTNAGTNACTNACGNACGT", 20);
@@ -230,40 +226,10 @@ cram_block_compression_hdr *cram_decode_compression_header(cram_fd *fd,
         }
         cp += 2;
         switch(CRAM_KEY(cp[-2],cp[-1])) {
-        case CRAM_KEY('M','I'):
+        case CRAM_KEY('M','I'): // was mapped QS included in V1.0
+        case CRAM_KEY('U','I'): // was unmapped QS included in V1.0
+        case CRAM_KEY('P','I'): // was unmapped placed in V1.0
             hd.i = *cp++;
-            k = kh_put(map, hdr->preservation_map, "MI", &r);
-            if (-1 == r) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
-
-            kh_val(hdr->preservation_map, k) = hd;
-            hdr->mapped_qs_included = hd.i;
-            break;
-
-        case CRAM_KEY('U','I'):
-            hd.i = *cp++;
-            k = kh_put(map, hdr->preservation_map, "UI", &r);
-            if (-1 == r) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
-
-            kh_val(hdr->preservation_map, k) = hd;
-            hdr->unmapped_qs_included = hd.i;
-            break;
-
-        case CRAM_KEY('P','I'):
-            hd.i = *cp++;
-            k = kh_put(map, hdr->preservation_map, "PI", &r);
-            if (-1 == r) {
-                cram_free_compression_header(hdr);
-                return NULL;
-            }
-
-            kh_val(hdr->preservation_map, k) = hd;
-            hdr->unmapped_placed = hd.i;
             break;
 
         case CRAM_KEY('R','N'):

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1774,11 +1774,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
         h->ref_seq_start = c->ref_seq_start;
         h->ref_seq_span  = c->ref_seq_span;
         h->num_records   = c->num_records;
-
-        h->mapped_qs_included = 0;   // fixme
-        h->unmapped_qs_included = 0; // fixme
         h->AP_delta = c->pos_sorted;
-        // h->...  fixme
         memcpy(h->substitution_matrix, CRAM_SUBST_MATRIX, 20);
 
         if (!(c_hdr = cram_encode_compression_header(fd, c, h)))

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -288,10 +288,6 @@ typedef struct cram_block_compression_hdr {
     int32_t *landmark;
 
     /* Flags from preservation map */
-    int mapped_qs_included;
-    int unmapped_qs_included;
-    int unmapped_placed;
-    int qs_included;
     int read_names_included;
     int AP_delta;
     // indexed by ref-base and subst. code


### PR DESCRIPTION
The preservation map for 1.0 defines MI, UI and PI keys, which in turn
set a bunch of variables related to how quality scores are stored.
The 1.0 spec required this, but even in the official 1.0 cramtools-jar
completely ignored them.

They appear in this C code as I added them while writing io_lib's
implementation from the 1.0 specification, but the variables are never
accessed as that was the only way to get parity with cramtools.jar.

This patch keeps the keys so a 1.0 file doesn't whinge (cramtools did
write those fields out, even if it never did anything with them), but
they are now silently skipped.

[TODO:  ditch 1.0 entirely!  I'm not convinced it works in any
meaningful way, given the specification and Java implementation
differed greatly. CRAM 2.0 was born from this - unifying code and
spec - and IMO should be considered the first workable version.]