### PR TITLE
[new method] fai_set_cache_size

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -917,3 +917,7 @@ const char *fai_parse_region(const faidx_t *fai, const char *s,
 {
     return hts_parse_region(s, tid, beg, end, (hts_name2id_f)fai_name2id, (void *)fai, flags);
 }
+
+void fai_set_cache_size(faidx_t *fai, int cache_size) {
+    bgzf_set_cache_size(fai->bgzf, cache_size);
+}

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -296,6 +296,13 @@ int faidx_seq_len(const faidx_t *fai, const char *seq);
 HTSLIB_EXPORT
 const char *fai_parse_region(const faidx_t *fai, const char *s, int *tid, int64_t *beg, int64_t *end, int flags);
 
+/// Sets the cache size of the underlying BGZF compressed file
+/** @param  fai         Pointer to the faidx_t struct
+ *  @param  cache_size  Selected cache size in bytes
+ */
+HTSLIB_EXPORT
+void fai_set_cache_size(faidx_t *fai, int cache_size);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Exposes `fai_set_cache_size` for setting the cache of BGZF based faidx files.

Fixes #913 