### PR TITLE
Cram unmapped reset

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -894,10 +894,9 @@ static int cram_compress_slice(cram_fd *fd, cram_container *c, cram_slice *s) {
     }
 
     // NAME: best is generally xz, bzip2, zlib then rans1
-    // It benefits well from a little bit extra compression level.
     if (cram_compress_block(fd, s->block[DS_RN], fd->m[DS_RN],
                             method & ~(1<<RANS0 | 1<<GZIP_RLE),
-                            MIN(9,level)))
+                            level))
         return -1;
 
     // NS shows strong local correlation as rearrangements are localised

--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -203,7 +203,7 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
 
     // Uncompress if required
     if (kstr.s[0] == 31 && (uc)kstr.s[1] == 139) {
-        size_t l;
+        size_t l = 0;
         char *s = zlib_mem_inflate(kstr.s, kstr.l, &l);
         if (!s)
             goto fail;

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -411,6 +411,8 @@ struct cram_container {
     uint32_t crc32;       // CRC32
 
     uint64_t s_num_bases; // number of bases in this slice
+
+    uint32_t n_mapped;    // Number of mapped reads
 };
 
 /*
@@ -746,6 +748,7 @@ struct cram_fd {
     int multi_seq;                      // -1 is auto, 0 is one ref per container, 1 is multi...
     int multi_seq_user;                 // Original user setting (CRAM_OPT_MULTI_SEQ_PER_SLICE)
     int unsorted;
+    int last_mapped;                    // number of mapped reads in last container
     int empty_container;                // Marker for EOF block
 
     // thread pool


### PR DESCRIPTION
For transition from mapped to unmapped the types of codec to use in CRAM can change, particularly for the BA data series (used for unmapped sequence bases).

The data that is unmapped but placed along side the mapped, is often fairly random looking and entropy encoding does well.  The pure unmapped data is also usually fairly random looking, but with "samtools sort -M" can have strong similarities with previous reads making gzip or lzma a good tool.

As a demonstration on SRR1770413 (bwa aligned, sort -M).  Current htslib gives BA at 12.5Mb (larger with big slice sizes as it doesn't get time to restart the compression trials).  With this patch it's 6.6Mb for the same data (5.0Mb with lzma).


The second commit enables libdeflate usage within CRAM.  Previously we only used this for BAM and for CRCs in CRAM, but it's now available as an alternative to zlib for actual gzip compressed blocks.

One reason we didn't do this in the past was because enabling libdeflate doesn't save a great deal of time in CRAM - it mostly spends time on non-deflate things - and also because it was giving poorer compression ratios.  We've worked around this latter case so may as well take the small speed wins.  A small test set:

```
       	   Decode(s)		Encode(s)		Size(Mb)
       	   LibD	  Zlib		LibD   Zlib		LibD	Zlib
HiSeq      2.16	  2.20		5.36   5.65		59.03	59.02
HiSeqX     1.37	  1.43		3.72   3.78		17.48	17.78
NovaSeq	   1.93	  2.00		4.68   4.83		22.46   22.46
```

This paves the way to permitting higher compression ratios now as libdeflate's max compression is considerably higher than zlib's, albeit at a CPU cost:

```
       	   Decode(s)		Encode(s)		Size(Mb)
       	   LibD	  Zlib		LibD   Zlib		LibD	Zlib
HiSeq      ?	  ?		16.5   10.0		58.41	58.69
HiSeqX     ?	  ?		21.0   10.4		16.65	16.90
NovaSeq	   ?	  ?		20.2   12.1		22.01   22.26
```

Marginal I guess.