### PR TITLE
Move <zlib.h> include out of the public bgzf.h header

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -34,6 +34,7 @@
 #include <pthread.h>
 #include <sys/types.h>
 #include <inttypes.h>
+#include <zlib.h>
 
 #ifdef HAVE_LIBDEFLATE
 #include <libdeflate.h>

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -32,7 +32,6 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <zlib.h>
 #include <sys/types.h>
 
 #include "hts_defs.h"
@@ -57,6 +56,7 @@ struct kstring_t;
 struct bgzf_mtaux_t;
 typedef struct __bgzidx_t bgzidx_t;
 typedef struct bgzf_cache_t bgzf_cache_t;
+struct z_stream_s;
 
 struct BGZF {
     // Reserved bits should be written as 0; read as "don't care"
@@ -72,7 +72,7 @@ struct BGZF {
     struct bgzf_mtaux_t *mt; // only used for multi-threading
     bgzidx_t *idx;      // BGZF index
     int idx_build_otf;  // build index on the fly, set by bgzf_index_build_init()
-    z_stream *gz_stream;// for gzip-compressed files
+    struct z_stream_s *gz_stream; // for gzip-compressed files
     int64_t seeked;     // virtual offset of last seek
 };
 #ifndef HTS_BGZF_TYPEDEF

--- a/test/test_bgzf.c
+++ b/test/test_bgzf.c
@@ -33,6 +33,7 @@ DEALINGS IN THE SOFTWARE.
 #include <sys/stat.h>
 #include <inttypes.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include "htslib/bgzf.h"
 #include "htslib/hfile.h"
 #include "hfile_internal.h"


### PR DESCRIPTION
Move `#include <zlib.h>` from _htslib/bgzf.h_ to _bgzf.c_, as callers of BGZF functions don't need zlib declarations. This was the only non-system #include in the public HTSlib headers (apart from inclusion of other HTSlib headers, of course).

This is something I've had lying around for a long time, but hadn't previously looked at how long the `z_stream_s` tag has been stable in zlib — happily the answer is decades and it is used in other zlib language bindings too so won't be changing.

This could cause minor breakage to third-party code itself using zlib functions but only #including `<htslib/bgzf.h>`. I've verified that samtools and bcftools both 1.9 and **develop** compile fine with this change. The possibility of breakage for other third-party code remains, but there's enough 64-bit-types-related and other changes in this upcoming release that IMHO this wouldn't add much additional risk of breakage.

The proximate cause for making this change now (besides collecting it with the other ABI-breakers etc in the upcoming release) is that Fedora is finally making an effort to package modern samtools/htslib/bcftools (see [RH #1759940](https://bugzilla.redhat.com/show_bug.cgi?id=1759940)). As they do not ship a static _libhts.a_, if this `#include` were removed from the public headers, their _htslib-devel_ package would not need to depend on _zlib-devel_.

Also there is a small compilation speed increase for code using BGZF.