### PR TITLE
Changed int64_t to hts_pos_t for *_parse_region API

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -744,7 +744,7 @@ static int fai_get_val(const faidx_t *fai, const char *str,
     khiter_t iter;
     khash_t(s) *h;
     int id;
-    int64_t beg, end;
+    hts_pos_t beg, end;
 
     if (!fai_parse_region(fai, str, &id, &beg, &end, 0)) {
         hts_log_warning("Reference %s not found in FASTA file, returning empty sequence", str);
@@ -913,7 +913,8 @@ int faidx_has_seq(const faidx_t *fai, const char *seq)
 }
 
 const char *fai_parse_region(const faidx_t *fai, const char *s,
-                             int *tid, int64_t *beg, int64_t *end, int flags)
+                             int *tid, hts_pos_t *beg, hts_pos_t *end,
+                             int flags)
 {
     return hts_parse_region(s, tid, beg, end, (hts_name2id_f)fai_name2id, (void *)fai, flags);
 }

--- a/hts.c
+++ b/hts.c
@@ -2916,8 +2916,9 @@ static void *hts_memrchr(const void *s, int c, size_t n) {
  *            beg & end will be set.
  * On failure NULL is returned.
  */
-const char *hts_parse_region(const char *s, int *tid, int64_t *beg, int64_t *end,
-                             hts_name2id_f getid, void *hdr, int flags)
+const char *hts_parse_region(const char *s, int *tid, hts_pos_t *beg,
+                             hts_pos_t *end, hts_name2id_f getid, void *hdr,
+                             int flags)
 {
     if (!s || !tid || !beg || !end || !getid)
         return NULL;
@@ -3094,7 +3095,7 @@ const char *hts_parse_reg64(const char *s, hts_pos_t *beg, hts_pos_t *end)
 
 const char *hts_parse_reg(const char *s, int *beg, int *end)
 {
-    int64_t beg64 = 0, end64 = 0;
+    hts_pos_t beg64 = 0, end64 = 0;
     const char *colon = hts_parse_reg64(s, &beg64, &end64);
     if (beg64 > INT_MAX) {
         hts_log_error("Position %"PRId64" too large", beg64);

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -294,7 +294,9 @@ int faidx_seq_len(const faidx_t *fai, const char *seq);
     Thus "{chr1}:100-200" and "{chr1:100-200}" disambiguate the above example.
 */
 HTSLIB_EXPORT
-const char *fai_parse_region(const faidx_t *fai, const char *s, int *tid, int64_t *beg, int64_t *end, int flags);
+const char *fai_parse_region(const faidx_t *fai, const char *s,
+                             int *tid, hts_pos_t *beg, hts_pos_t *end,
+                             int flags);
 
 #ifdef __cplusplus
 }

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -925,6 +925,9 @@ typedef const char *(*hts_id2name_f)(void*, int);
     @param end  Set on return to the 1-based end of the region
     @return  Pointer to the colon or '\0' after the reference sequence name,
              or NULL if @a str could not be parsed.
+
+    NOTE: For compatibility with hts_parse_reg only.
+    Please use hts_parse_region instead.
 */
 HTSLIB_EXPORT
 const char *hts_parse_reg64(const char *str, hts_pos_t *beg, hts_pos_t *end);
@@ -1001,8 +1004,9 @@ const char *hts_parse_reg(const char *str, int *beg, int *end);
         >= 0 The specified range in @p str could not be parsed
 */
 HTSLIB_EXPORT
-const char *hts_parse_region(const char *str, int *tid, int64_t *beg, int64_t *end,
-                             hts_name2id_f getid, void *hdr, int flags);
+const char *hts_parse_region(const char *s, int *tid, hts_pos_t *beg,
+                             hts_pos_t *end, hts_name2id_f getid, void *hdr,
+                             int flags);
 
 
 ///////////////////////////////////////////////////////////

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1272,7 +1272,8 @@ static inline int sam_itr_next(htsFile *htsfp, hts_itr_t *itr, bam1_t *r) {
 #define sam_itr_multi_next(htsfp, itr, r) sam_itr_next(htsfp, itr, r)
 
 HTSLIB_EXPORT
-const char *sam_parse_region(sam_hdr_t *h, const char *s, int *tid, int64_t *beg, int64_t *end, int flags);
+const char *sam_parse_region(sam_hdr_t *h, const char *s, int *tid,
+                             hts_pos_t *beg, hts_pos_t *end, int flags);
 
     /***************
      *** SAM I/O ***

--- a/sam.c
+++ b/sam.c
@@ -361,7 +361,8 @@ int bam_hdr_write(BGZF *fp, const sam_hdr_t *h)
     return 0;
 }
 
-const char *sam_parse_region(sam_hdr_t *h, const char *s, int *tid, int64_t *beg, int64_t *end, int flags) {
+const char *sam_parse_region(sam_hdr_t *h, const char *s, int *tid,
+                             hts_pos_t *beg, hts_pos_t *end, int flags) {
     return hts_parse_region(s, tid, beg, end, (hts_name2id_f)bam_name2id, h, flags);
 }
 

--- a/test/test-parse-reg.c
+++ b/test/test-parse-reg.c
@@ -47,15 +47,11 @@
 #include <htslib/hts.h>
 #include <htslib/sam.h>
 
-#ifndef INT64_32_MAX
-#define INT64_32_MAX ((((int64_t)INT_MAX)<<32)|INT_MAX)
-#endif
-
 void reg_expected(sam_hdr_t *hdr, const char *reg, int flags,
-                 char *reg_exp, int tid_exp, int64_t beg_exp, int64_t end_exp) {
+                 char *reg_exp, int tid_exp, hts_pos_t beg_exp, hts_pos_t end_exp) {
     const char *reg_out;
     int tid_out = -1;
-    int64_t beg_out = -1, end_out = -1;
+    hts_pos_t beg_out = -1, end_out = -1;
 
     reg_out = sam_parse_region(hdr, reg, &tid_out, &beg_out, &end_out, flags);
 
@@ -64,8 +60,8 @@ void reg_expected(sam_hdr_t *hdr, const char *reg, int flags,
         (reg_exp && tid_out != tid_exp) ||
         (reg_exp && beg_out != beg_exp) ||
         (reg_exp && end_out != end_exp)) {
-        fprintf(stderr, "Parsing \"%s\" expected return \"%s\", %d:%"PRId64"-%"PRId64", "
-                "but got \"%s\", %d:%"PRId64"-%"PRId64"\n",
+        fprintf(stderr, "Parsing \"%s\" expected return \"%s\", %d:%"PRIhts_pos"-%"PRIhts_pos", "
+                "but got \"%s\", %d:%"PRIhts_pos"-%"PRIhts_pos"\n",
                 reg,
                 reg_exp?reg_exp:"(null)", tid_exp, beg_exp, end_exp,
                 reg_out?reg_out:"(null)", tid_out, beg_out, end_out);
@@ -91,26 +87,26 @@ int reg_test(char *fn) {
     // 5 chr1,chr3
 
     // Check range extensions.
-    reg_expected(hdr, "chr1", 0, "",  0, 0, INT64_32_MAX);
-    reg_expected(hdr, "chr1:50", 0, "",  0, 49, INT64_32_MAX);
+    reg_expected(hdr, "chr1", 0, "",  0, 0, HTS_POS_MAX);
+    reg_expected(hdr, "chr1:50", 0, "",  0, 49, HTS_POS_MAX);
     reg_expected(hdr, "chr1:50", HTS_PARSE_ONE_COORD, "",  0, 49, 50);
     reg_expected(hdr, "chr1:50-100", 0, "",  0, 49, 100);
-    reg_expected(hdr, "chr1:50-", 0, "",  0, 49, INT64_32_MAX);
+    reg_expected(hdr, "chr1:50-", 0, "",  0, 49, HTS_POS_MAX);
     reg_expected(hdr, "chr1:-50", 0, "",  0, 0, 50);
 
     // Check quoting
     fprintf(stderr, "Expected error: ");
     reg_expected(hdr, "chr1:100-200", 0, NULL,  0, 0, 0); // ambiguous
     reg_expected(hdr, "{chr1}:100-200", 0, "",  0, 99, 200);
-    reg_expected(hdr, "{chr1:100-200}", 0, "",  2, 0, INT64_32_MAX);
+    reg_expected(hdr, "{chr1:100-200}", 0, "",  2, 0, HTS_POS_MAX);
     reg_expected(hdr, "{chr1:100-200}:100-200", 0, "",  2, 99, 200);
     reg_expected(hdr, "{chr2:100-200}:100-200", 0, "",  3, 99, 200);
     reg_expected(hdr, "chr2:100-200:100-200", 0, "",  3, 99, 200);
-    reg_expected(hdr, "chr2:100-200", 0, "",  3, 0, INT64_32_MAX);
+    reg_expected(hdr, "chr2:100-200", 0, "",  3, 0, HTS_POS_MAX);
 
     // Check numerics
-    reg_expected(hdr, "chr3", 0, "",  4, 0, INT64_32_MAX);
-    reg_expected(hdr, "chr3:", 0, "",  4, 0, INT64_32_MAX);
+    reg_expected(hdr, "chr3", 0, "",  4, 0, HTS_POS_MAX);
+    reg_expected(hdr, "chr3:", 0, "",  4, 0, HTS_POS_MAX);
     reg_expected(hdr, "chr3:1000-1500", 0, "",  4, 999, 1500);
     reg_expected(hdr, "chr3:1,000-1,500", 0, "",  4, 999, 1500);
     reg_expected(hdr, "chr3:1k-1.5K", 0, "",  4, 999, 1500);
@@ -118,11 +114,11 @@ int reg_test(char *fn) {
     reg_expected(hdr, "chr3:1e3-15e2", 0, "",  4, 999, 1500);
 
     // Check list mode
-    reg_expected(hdr, "chr1,chr3", HTS_PARSE_LIST, "chr3", 0, 0, INT64_32_MAX);
+    reg_expected(hdr, "chr1,chr3", HTS_PARSE_LIST, "chr3", 0, 0, HTS_POS_MAX);
     fprintf(stderr, "Expected error: ");
     reg_expected(hdr, "chr1:100-200,chr3", HTS_PARSE_LIST, NULL,  0, 0, 0); // ambiguous
-    reg_expected(hdr, "{chr1,chr3}", HTS_PARSE_LIST, "", 5, 0, INT64_32_MAX);
-    reg_expected(hdr, "{chr1,chr3},chr1", HTS_PARSE_LIST, "chr1", 5, 0, INT64_32_MAX);
+    reg_expected(hdr, "{chr1,chr3}", HTS_PARSE_LIST, "", 5, 0, HTS_POS_MAX);
+    reg_expected(hdr, "{chr1,chr3},chr1", HTS_PARSE_LIST, "chr1", 5, 0, HTS_POS_MAX);
     // incorrect usage; first reg is valid (but not what user expects).
     reg_expected(hdr, "chr3:1,000-1,500", HTS_PARSE_LIST | HTS_PARSE_ONE_COORD, "000-1,500",  4, 0, 1);
 
@@ -190,13 +186,13 @@ int main(int argc, char **argv) {
     const char *reg = argv[2];
     while (*reg) {
         int tid;
-        int64_t beg, end;
+        hts_pos_t beg, end;
         reg = sam_parse_region(hdr, reg, &tid, &beg, &end, flags);
         if (!reg) {
             fprintf(stderr, "Failed to parse region\n");
             exit(1);
         }
-        printf("%-20s %12"PRId64" %12"PRId64"\n",
+        printf("%-20s %12"PRIhts_pos" %12"PRIhts_pos"\n",
                tid == -1 ? "*" : hdr->target_name[tid],
                beg, end);
     }


### PR DESCRIPTION
Also fixed a few other assumptions of hts_pos_t equalling int64_t.

Updated the test-parse-reg to use hts_pos_t as well.

Added a comment to hts_parse_reg64 indicating that it is not our
preferred API.  It was added in a separate commit for ease of API
migration from hts_parse_reg, but was added only because the
hts_parse_region code hadn't been accepted.  This is now the correct
interface.

---

Note the name of hts_parse_reg64 is mildly annoying.  When Linux switched from fseek taking long to taking off_t it didn't use fseek64, but fseeko.  It's largely irrelevant though as both hts_parse_reg and hts_parse_reg64 should be considered deprecated.