### PR TITLE
Fix crash when loading external plug-ins into Windows executables that statically link HTSlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ test/test_bgzf.o: test/test_bgzf.c config.h $(htslib_bgzf_h) $(htslib_hfile_h) $
 test/test_kstring.o: test/test_kstring.c config.h $(htslib_kstring_h)
 test/test-parse-reg.o: test/test-parse-reg.c config.h $(htslib_hts_h) $(htslib_sam_h)
 test/test_realn.o: test/test_realn.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h)
-test/test-regidx.o: test/test-regidx.c config.h $(htslib_kstring_h) $(htslib_regidx_h) $(htslib_hts_defs_h)
+test/test-regidx.o: test/test-regidx.c config.h $(htslib_kstring_h) $(htslib_regidx_h) $(htslib_hts_defs_h) $(textutils_internal_h)
 test/test_str2int.o: test/test_str2int.c config.h $(textutils_internal_h)
 test/test_view.o: test/test_view.c config.h $(cram_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_hts_log_h)
 test/test_index.o: test/test_index.c config.h $(htslib_sam_h) $(htslib_vcf_h)

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ cram/cram_io.o cram/cram_io.pico: cram/cram_io.c config.h os/lzma_stub.h $(cram_
 cram/cram_samtools.o cram/cram_samtools.pico: cram/cram_samtools.c config.h $(cram_h) $(htslib_sam_h) $(sam_internal_h)
 cram/cram_stats.o cram/cram_stats.pico: cram/cram_stats.c config.h $(cram_h) $(cram_os_h)
 cram/mFILE.o cram/mFILE.pico: cram/mFILE.c config.h $(htslib_hts_log_h) $(cram_os_h) cram/mFILE.h
-cram/open_trace_file.o cram/open_trace_file.pico: cram/open_trace_file.c config.h $(cram_os_h) $(cram_open_trace_file_h) $(cram_misc_h) $(htslib_hfile_h) $(htslib_hts_log_h)
+cram/open_trace_file.o cram/open_trace_file.pico: cram/open_trace_file.c config.h $(cram_os_h) $(cram_open_trace_file_h) $(cram_misc_h) $(htslib_hfile_h) $(htslib_hts_log_h) $(htslib_hts_h)
 cram/pooled_alloc.o cram/pooled_alloc.pico: cram/pooled_alloc.c config.h cram/pooled_alloc.h $(cram_misc_h)
 cram/rANS_static.o cram/rANS_static.pico: cram/rANS_static.c config.h cram/rANS_static.h cram/rANS_byte.h
 cram/string_alloc.o cram/string_alloc.pico: cram/string_alloc.c config.h cram/string_alloc.h

--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ libhts.dylib: $(LIBHTS_OBJS)
 	$(CC) -dynamiclib -install_name $(libdir)/libhts.$(LIBHTS_SOVERSION).dylib -current_version $(NUMERIC_VERSION) -compatibility_version $(MACH_O_COMPATIBILITY_VERSION) $(LDFLAGS) -o $@ $(LIBHTS_OBJS) $(LIBS)
 	ln -sf $@ libhts.$(LIBHTS_SOVERSION).dylib
 
-cyghts-$(LIBHTS_SOVERSION).dll: $(LIBHTS_OBJS)
+cyghts-$(LIBHTS_SOVERSION).dll libhts.dll.a: $(LIBHTS_OBJS)
 	$(CC) -shared -Wl,--out-implib=libhts.dll.a -Wl,--enable-auto-import $(LDFLAGS) -o $@ -Wl,--whole-archive $(LIBHTS_OBJS) -Wl,--no-whole-archive $(LIBS) -lpthread
 
 hts-$(LIBHTS_SOVERSION).dll hts.dll.a: $(LIBHTS_OBJS)
@@ -310,10 +310,10 @@ hts-object-files: $(LIBHTS_OBJS)
 .o.bundle:
 	$(CC) -bundle -Wl,-undefined,dynamic_lookup $(LDFLAGS) -o $@ $< $(LIBS)
 
-.o.cygdll:
+%.cygdll: %.o libhts.dll.a
 	$(CC) -shared $(LDFLAGS) -o $@ $< libhts.dll.a $(LIBS)
 
-.o.dll:
+%.dll: %.o hts.dll.a
 	$(CC) -shared $(LDFLAGS) -o $@ $< hts.dll.a $(LIBS)
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -184,9 +184,12 @@ if test $enable_plugins != no; then
 
 Plugin support requires dynamic linking facilities from the operating system.
 Either configure with --disable-plugins or resolve this error to build HTSlib.])])
+  # Check if the compiler understands -rdynamic 
   # TODO Test whether this is required and/or needs tweaking per-platform
-  LDFLAGS="$LDFLAGS -rdynamic"
-  static_LDFLAGS="$static_LDFLAGS -rdynamic"
+  HTS_TEST_CC_C_LD_FLAG([-rdynamic],[rdynamic_flag])
+  AS_IF([test x"$rdynamic_flag" != "xno"],
+    [LDFLAGS="$LDFLAGS $rdynamic_flag"
+     static_LDFLAGS="$static_LDFLAGS $rdynamic_flag"])
   case "$ac_cv_search_dlopen" in
     -l*) static_LIBS="$static_LIBS $ac_cv_search_dlopen" ;;
   esac

--- a/cram/open_trace_file.c
+++ b/cram/open_trace_file.c
@@ -81,6 +81,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cram/misc.h"
 #include "htslib/hfile.h"
 #include "htslib/hts_log.h"
+#include "htslib/hts.h"
 
 /*
  * Returns whether the path refers to a regular file.
@@ -107,11 +108,7 @@ char *tokenise_search_path(const char *searchpath) {
     char *newsearch;
     unsigned int i, j;
     size_t len;
-#if defined(_WIN32) || defined(__MSYS__)
-    char path_sep = ';';
-#else
-    char path_sep = ':';
-#endif
+    char path_sep = HTS_PATH_SEPARATOR_CHAR;
 
     if (!searchpath)
         searchpath="";

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -432,7 +432,7 @@ static int is_escaped(const char *str) {
 
     while (*c != '\0') {
         if (*c == '%' && c[1] != '\0' && c[2] != '\0') {
-            if (isxdigit(c[1]) && isxdigit(c[2])) {
+            if (isxdigit_c(c[1]) && isxdigit_c(c[2])) {
                 escaped = 1;
                 c += 3;
                 continue;
@@ -465,7 +465,7 @@ static int redirect_endpoint_callback(void *auth, long response,
         new_region += strlen("x-amz-bucket-region: ");
         end = new_region;
 
-        while (isalnum(*end) || ispunct(*end)) end++;
+        while (isalnum_c(*end) || ispunct_c(*end)) end++;
 
         *end = 0;
 

--- a/hts.c
+++ b/hts.c
@@ -3037,7 +3037,7 @@ const char *hts_parse_region(const char *s, int *tid, hts_pos_t *beg,
     char *hyphen;
     *beg = hts_parse_decimal(colon+1, &hyphen, flags) - 1;
     if (*beg < 0) {
-        if (isdigit(*hyphen) || *hyphen == '\0' || *hyphen == ',') {
+        if (isdigit_c(*hyphen) || *hyphen == '\0' || *hyphen == ',') {
             // interpret chr:-100 as chr:1-100
             *end = *beg==-1 ? HTS_POS_MAX : -(*beg+1);
             *beg = 0;

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -38,6 +38,15 @@ DEALINGS IN THE SOFTWARE.  */
 extern "C" {
 #endif
 
+// Separator used to split HTS_PATH (for plugins); REF_PATH (cram references)
+#if defined(_WIN32) || defined(__MSYS__)
+#define HTS_PATH_SEPARATOR_CHAR ';'
+#define HTS_PATH_SEPARATOR_STR  ";"
+#else
+#define HTS_PATH_SEPARATOR_CHAR ':'
+#define HTS_PATH_SEPARATOR_STR  ":"
+#endif
+
 #ifndef HTS_BGZF_TYPEDEF
 typedef struct BGZF BGZF;
 #define HTS_BGZF_TYPEDEF

--- a/plugin.c
+++ b/plugin.c
@@ -44,7 +44,7 @@ static DIR *open_nextdir(struct hts_path_itr *itr)
     DIR *dir;
 
     while (1) {
-        const char *colon = strchr(itr->pathdir, ':');
+        const char *colon = strchr(itr->pathdir, HTS_PATH_SEPARATOR_CHAR);
         if (colon == NULL) return NULL;
 
         itr->entry.l = 0;
@@ -86,13 +86,13 @@ void hts_path_itr_setup(struct hts_path_itr *itr, const char *path,
     }
 
     while (1) {
-        size_t len = strcspn(path, ":");
+        size_t len = strcspn(path, HTS_PATH_SEPARATOR_STR);
         if (len == 0) kputs(builtin_path, &itr->path);
         else kputsn(path, len, &itr->path);
-        kputc(':', &itr->path);
+        kputc(HTS_PATH_SEPARATOR_CHAR, &itr->path);
 
         path += len;
-        if (*path == ':') path++;
+        if (*path == HTS_PATH_SEPARATOR_CHAR) path++;
         else break;
     }
 

--- a/test/test-regidx.c
+++ b/test/test-regidx.c
@@ -36,6 +36,7 @@
 #include "htslib/kstring.h"
 #include "htslib/regidx.h"
 #include "htslib/hts_defs.h"
+#include "textutils_internal.h"
 
 static int verbose = 0;
 
@@ -77,18 +78,18 @@ int custom_parse(const char *line, char **chr_beg, char **chr_end, hts_pos_t *be
 
     // Skip the fields that were parsed above
     char *ss = (char*) line;
-    while ( *ss && isspace(*ss) ) ss++;
+    while ( *ss && isspace_c(*ss) ) ss++;
     for (i=0; i<3; i++)
     {
-        while ( *ss && !isspace(*ss) ) ss++;
+        while ( *ss && !isspace_c(*ss) ) ss++;
         if ( !*ss ) return -2;  // wrong number of fields
-        while ( *ss && isspace(*ss) ) ss++;
+        while ( *ss && isspace_c(*ss) ) ss++;
     }
     if ( !*ss ) return -2;
 
     // Parse the payload
     char *se = ss;
-    while ( *se && !isspace(*se) ) se++;
+    while ( *se && !isspace_c(*se) ) se++;
     char **dat = (char**) payload;
     *dat = (char*) malloc(se-ss+1);
     memcpy(*dat,ss,se-ss+1);

--- a/textutils_internal.h
+++ b/textutils_internal.h
@@ -164,8 +164,10 @@ static inline int isdigit_c(char c) { return isdigit((unsigned char) c); }
 static inline int isgraph_c(char c) { return isgraph((unsigned char) c); }
 static inline int islower_c(char c) { return islower((unsigned char) c); }
 static inline int isprint_c(char c) { return isprint((unsigned char) c); }
+static inline int ispunct_c(char c) { return ispunct((unsigned char) c); }
 static inline int isspace_c(char c) { return isspace((unsigned char) c); }
 static inline int isupper_c(char c) { return isupper((unsigned char) c); }
+static inline int isxdigit_c(char c) { return isxdigit((unsigned char) c); }
 static inline char tolower_c(char c) { return tolower((unsigned char) c); }
 static inline char toupper_c(char c) { return toupper((unsigned char) c); }
 


### PR DESCRIPTION
Works around the plug-in's insistence on linking against and using the shared hts.dll by spotting when this causes a problem and using `dlopen()` /  `dlsym()` to find `hfile_add_scheme_handler()` in the executable and call that instead.  This ensures the plug-in is registered in the correct place.  It's not elegant but it works.

Additional bonus fixes:
- A missing dependencies on hts.dll.a which could result in the plug-in dlls trying to build before the shared library was available.
- Some char-subscripts warnings due to use of `ctype` functions with `char` types.  These don't appear to trigger warnings in our CI builds (including Appveyor) but did when I made a MinGW build by hand.

Fixes #964 
