### PR TITLE
Search for a local .crai index first

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -1085,7 +1085,8 @@ char *haddextension(struct kstring_t *buffer, const char *filename,
 
     if (find_scheme_handler(filename)) {
         // URL, so alter extensions before any trailing query or fragment parts
-        trailing = filename + strcspn(filename, "?#");
+        // Allow # symbols in s3 URLs
+        trailing = filename + ((strncmp(filename, "s3://", 5) && strncmp(filename, "s3+http://", 10) && strncmp(filename, "s3+https://", 11))  ? strcspn(filename, "?#") : strcspn(filename, "?"));
     }
     else {
         // Local path, so alter extensions at the end of the filename

--- a/hts.c
+++ b/hts.c
@@ -3370,8 +3370,8 @@ static int idx_test_and_fetch(const char *fn, const char **local_fn, int *local_
         const int buf_size = 1 * 1024 * 1024;
         int l;
         const char *p, *e;
-        // Ignore ?# params: eg any file.fmt?param=val
-        e = fn + strcspn(fn, "?#");
+        // Ignore ?# params: eg any file.fmt?param=val, except for S3 URLs
+        e = fn + ((strncmp(fn, "s3://", 5) && strncmp(fn, "s3+http://", 10) && strncmp(fn, "s3+https://", 11)) ? strcspn(fn, "?#") : strcspn(fn, "?"));
         // Find the previous slash from there.
         p = e;
         while (p > fn && *p != '/') p--;

--- a/hts_internal.h
+++ b/hts_internal.h
@@ -46,6 +46,15 @@ struct hts_json_token {
 
 struct cram_fd;
 
+/*
+ * Check the existence of a local index file using part of the alignment file name.
+ * The order is alignment.bam.csi, alignment.csi, alignment.bam.bai, alignment.bai
+ * @param fn    - pointer to the file name
+ * @param fnidx - pointer to the index file name placeholder
+ * @return        1 for success, 0 for failure
+ */
+int hts_idx_check_local(const char *fn, int fmt, char **fnidx);
+
 // Retrieve the name of the index file and also download it, if it is remote
 char *hts_idx_getfn(const char *fn, const char *ext);
 


### PR DESCRIPTION
When doing a indexed search in a CRAM file, look first for a local CRAI index file in the current folder. If unsuccessful and the CRAM file is remote (e.g. S3, HTTP, FTP), go to the same remote location and try to fetch it from there.

Fixes https://github.com/samtools/samtools/issues/1132
Improves https://github.com/samtools/htslib/pull/870