### PR TITLE
Fix htslib.mk parallel build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ hfile_*.cygdll
 hfile_*.dll
 hfile_*.so
 
+hts-object-files
 htslib_static.mk
 
 cyg*.dll

--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,10 @@ cyghts-$(LIBHTS_SOVERSION).dll: $(LIBHTS_OBJS)
 hts-$(LIBHTS_SOVERSION).dll hts.dll.a: $(LIBHTS_OBJS)
 	$(CC) -shared -Wl,--out-implib=hts.dll.a -Wl,--enable-auto-import -Wl,--exclude-all-symbols $(LDFLAGS) -o $@ -Wl,--whole-archive $(LIBHTS_OBJS) -Wl,--no-whole-archive $(LIBS) -lpthread
 
+# Target to allow htslib.mk to build all the object files before it
+# links the shared and static libraries.
+hts-object-files: $(LIBHTS_OBJS)
+	touch $@
 
 .pico.so:
 	$(CC) -shared -Wl,-E $(LDFLAGS) -o $@ $< $(LIBS) -lpthread
@@ -572,6 +576,7 @@ testclean:
 
 mostlyclean: testclean
 	-rm -f *.o *.pico cram/*.o cram/*.pico test/*.o test/*.dSYM version.h
+	-rm -f hts-object-files
 
 clean: mostlyclean clean-$(SHLIB_FLAVOUR)
 	-rm -f libhts.a $(BUILT_PROGRAMS) $(BUILT_PLUGINS) $(BUILT_TEST_PROGRAMS) $(BUILT_THRASH_PROGRAMS)

--- a/htslib.mk
+++ b/htslib.mk
@@ -82,6 +82,7 @@ HTSLIB_ALL = \
 	$(HTSDIR)/config.h \
 	$(HTSDIR)/errmod.c \
 	$(HTSDIR)/faidx.c \
+	$(HTSDIR)/header.c \
 	$(HTSDIR)/header.h \
 	$(HTSDIR)/hfile_internal.h \
 	$(HTSDIR)/hfile.c \
@@ -89,6 +90,7 @@ HTSLIB_ALL = \
 	$(HTSDIR)/hfile_libcurl.c \
 	$(HTSDIR)/hfile_net.c \
 	$(HTSDIR)/hfile_s3.c \
+	$(HTSDIR)/hfile_s3_write.c \
 	$(HTSDIR)/hts.c \
 	$(HTSDIR)/hts_internal.h \
 	$(HTSDIR)/hts_os.c \
@@ -103,6 +105,7 @@ HTSLIB_ALL = \
 	$(HTSDIR)/regidx.c \
 	$(HTSDIR)/region.c \
 	$(HTSDIR)/sam.c \
+	$(HTSDIR)/sam_internal.h \
 	$(HTSDIR)/synced_bcf_reader.c \
 	$(HTSDIR)/tbx.c \
 	$(HTSDIR)/textutils.c \
@@ -148,19 +151,27 @@ HTSLIB_ALL = \
 $(HTSDIR)/config.h:
 	+cd $(HTSDIR) && $(MAKE) config.h
 
-$(HTSDIR)/libhts.a: $(HTSLIB_ALL)
+$(HTSDIR)/hts-object-files : $(HTSLIB_ALL)
+	+cd $(HTSDIR) && $(MAKE) hts-object-files
+
+$(HTSDIR)/libhts.a: $(HTSDIR)/hts-object-files
 	+cd $(HTSDIR) && $(MAKE) lib-static
 
-$(HTSDIR)/libhts.so $(HTSDIR)/libhts.dylib $(HTSDIR)/libhts.dll.a $(HTSDIR)/hts.dll.a: $(HTSLIB_ALL)
+$(HTSDIR)/libhts.so: $(HTSLIB_ALL)
 	+cd $(HTSDIR) && $(MAKE) lib-shared
 
-$(HTSDIR)/bgzip: $(HTSDIR)/bgzip.c $(HTSLIB_PUBLIC_HEADERS)
+$(HTSDIR)/libhts.dylib $(HTSDIR)/libhts.dll.a $(HTSDIR)/hts.dll.a: $(HTSDIR)/hts-object-files
+	+cd $(HTSDIR) && $(MAKE) lib-shared
+
+$(HTSDIR)/bgzip: $(HTSDIR)/bgzip.c $(HTSLIB_PUBLIC_HEADERS) $(HTSDIR)/libhts.a
 	+cd $(HTSDIR) && $(MAKE) bgzip
 
-$(HTSDIR)/htsfile: $(HTSDIR)/htsfile.c $(HTSLIB_PUBLIC_HEADERS)
+$(HTSDIR)/htsfile: $(HTSDIR)/htsfile.c $(HTSLIB_PUBLIC_HEADERS) $(HTSDIR)/libhts.a
+
 	+cd $(HTSDIR) && $(MAKE) htsfile
 
-$(HTSDIR)/tabix: $(HTSDIR)/tabix.c $(HTSLIB_PUBLIC_HEADERS)
+$(HTSDIR)/tabix: $(HTSDIR)/tabix.c $(HTSLIB_PUBLIC_HEADERS) $(HTSDIR)/libhts.a
+
 	+cd $(HTSDIR) && $(MAKE) tabix
 
 $(HTSDIR)/htslib_static.mk: $(HTSDIR)/htslib.pc.tmp


### PR DESCRIPTION
Fixes a missing shared dependency on the HTSlib object files for the (Windows and Mac) shared and static library targets in `htslib.mk`.  This was causing random [build failures](https://ci.appveyor.com/project/samtools/bcftools/builds/28720476) for BCFtools on Appveyor because it was trying to build both the shared and static libraries at the same time, resulting in the `.o` files being built twice and one of the libraries to become corrupt because one of the object files being included got rebuilt as it was added.

The fix creates an empty file target file `hts-object-files` in HTSlib's Makefile which `htslib.mk` uses to track the shared dependency for the libraries.  While adding an empty target isn't ideal (for example it won't notice missing `.o` files if the `.c` file is unchanged), it seems to be the best solution given that `htslib.mk` doesn't keep track of HTSlib's configure options, so it can't easily work out which object files are going into the libraries.