### PR TITLE
Add big-endian case (arch: s390x) as allow_failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,24 @@ matrix:
     os: linux
     env: CFLAGS="-std=c99 -pedantic" USE_CONFIG=yes
 
+  # Big-endian
+  - compiler: gcc
+    arch: s390x
+    os: linux
+    env: USE_CONFIG=yes
+    addons:
+      apt:
+        packages:
+          - libbz2-dev
+          - liblzma-dev
+
+  allow_failures:
+  # The build is failed in big-endian environment (arch: s390x).
+  # BCF header code makes no attempt to account for endianness
+  # https://github.com/samtools/htslib/issues/355
+  - arch: s390x
+  fast_finish: true
+
 # For MacOSX systems
 before_install:
   - |


### PR DESCRIPTION
It is related to https://github.com/samtools/htslib/issues/355 .

https://github.com/samtools/htslib/issues/355#issuecomment-553415546
> It won't break the amd64 test cases, but it will break the build as a whole. Once the remaining issues have been tracked down and fixed it will be useful to turn this on so that they don't regress, but it would be rather distracting at the moment.

This PR is to add s390x case as `allow_failures` with `fast_finish: true` option.

`allow_failures` is to ignore the result of the test case that is set as "allow_failures".
As a result, as Travis is green (succeeded) even when the `s390x` case is failed, "it will not break the build as a whole".

`fast_finish: true` option is return the entire result without waiting the test case that is set as "allow_failures". As a result, we are not disturbed by the case.

Here is my forked repository's result.
https://travis-ci.org/junaruga/htslib/builds/611619509

I admit that the s390x case is slow at the moment.
But we can see the useful result.

https://travis-ci.org/junaruga/htslib/jobs/611619519#L335

```
Unexpected failures: 4
```
