### PR TITLE
Silence gcc warnings

### DIFF
--- a/hfile_s3_write.c
+++ b/hfile_s3_write.c
@@ -171,13 +171,12 @@ static int get_entry(char *in, char *start_tag, char *end_tag, kstring_t *out) {
     }
 
     start = strstr(in, start_tag);
+    if (!start) return EOF;
 
-    if (start) {
-        start += strlen(start_tag);
-        end = strstr(start, end_tag);
-    }
+    start += strlen(start_tag);
+    end = strstr(start, end_tag);
 
-    if (!start || !end) return EOF;
+    if (!end) return EOF;
 
     return kputsn(start, end - start, out);
 }


### PR DESCRIPTION
For some optimisation levels, gcc would report a format-truncation warning for the line that measured how much memory was needed to store the header string.  Silence it by supplying a reasonably big buffer, which has the added bonus that the malloc and second call to vsnprintf can be avoided completely in most cases.
