### PR TITLE
Fix sam_hdr_dup to cope with long refs.

### DIFF
--- a/test/test.pl
+++ b/test/test.pl
@@ -645,6 +645,12 @@ sub test_view
     testv $opts, "./test_view $tv_args -p longrefs/longref.tmp.sam_ longrefs/longref.tmp.sam.gz";
     testv $opts, "./compare_sam.pl longrefs/longref.sam longrefs/longref.tmp.sam_";
 
+    # CRAM disabled for now as the positions cannot be 32-bit.  (These tests are useful for
+    # checking SQ headers only.)
+    # testv $opts, "./test_view $tv_args -C -o no_ref -p longrefs/longref.tmp.cram longrefs/longref.sam";
+    # testv $opts, "./test_view $tv_args -p longrefs/longref.tmp.sam_ longrefs/longref.tmp.cram";
+    # testv $opts, "./compare_sam.pl longrefs/longref.sam longrefs/longref.tmp.sam_";
+
     # Build index and compare with on-the-fly one made earlier.
     test_compare $opts, "$$opts{path}/test_index -c longrefs/longref.tmp.sam.gz", "longrefs/longref.tmp.sam.gz.csi.otf", "longrefs/longref.tmp.sam.gz.csi", gz=>1;
 


### PR DESCRIPTION
This is a simplified version of the `sam_hdr_dup` fix from PR #976 split out into its own pull request.

If the source header has not been parsed yet (i.e. `sam_hdr_t::hrecs` is NULL) it just copies any entries in `sam_hdr_t::sdict`.  If it has been parsed, `sam_hdr_t::sdict` entries are added in `sam_hdr_update_target_arrays` where necessary.

`sam_hdr_update_target_arrays` will now also remove `sam_hdr_t::sdict` entries if they are no longer needed.  This fixes a bug where dangling pointers could be left in `sdict` if any target names have been removed.

Adds some `sam_hdr_dup` tests in `test/sam.c` `check_big_ref()`.