### PR TITLE
Add missing Makefile dependencies and ignored test executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ shlib-exports-*.txt
 /test/test-parse-reg
 /test/test_realn
 /test/test-regidx
+/test/test_str2int
 /test/test-vcf-api
 /test/test-vcf-sweep
 /test/test_view

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ header_h = header.h cram/string_alloc.h cram/pooled_alloc.h $(htslib_khash_h) $(
 hfile_internal_h = hfile_internal.h $(htslib_hts_defs_h) $(htslib_hfile_h) $(textutils_internal_h)
 hts_internal_h = hts_internal.h $(htslib_hts_h) $(textutils_internal_h)
 sam_internal_h = sam_internal.h $(htslib_sam_h)
-textutils_internal_h = textutils_internal.h $(htslib_kstring_h) $(htslib_sam_h)
+textutils_internal_h = textutils_internal.h $(htslib_kstring_h)
 thread_pool_internal_h = thread_pool_internal.h $(htslib_thread_pool_h)
 
 
@@ -329,7 +329,7 @@ hfile_net.o hfile_net.pico: hfile_net.c config.h $(hfile_internal_h) $(htslib_kn
 hfile_s3_write.o hfile_s3_write.pico: hfile_s3_write.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
 hts.o hts.pico: hts.c config.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_hts_endian_h) version.h $(hts_internal_h) $(hfile_internal_h) $(sam_internal_h) $(htslib_hts_os_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h) $(htslib_tbx_h)
-hts_os.o hts_os.pico: hts_os.c config.h os/rand.c
+hts_os.o hts_os.pico: hts_os.c config.h $(htslib_hts_defs_h) os/rand.c
 vcf.o vcf.pico: vcf.c config.h $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_hfile_h) $(hts_internal_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_sam_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_hts_endian_h)
 sam.o sam.pico: sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_bgzf_h) $(cram_h) $(hts_internal_h) $(sam_internal_h) $(htslib_hfile_h) $(htslib_hts_endian_h) $(header_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_kstring_h)
 tbx.o tbx.pico: tbx.c config.h $(htslib_tbx_h) $(htslib_bgzf_h) $(htslib_hts_endian_h) $(hts_internal_h) $(htslib_khash_h)
@@ -346,7 +346,7 @@ multipart.o multipart.pico: multipart.c config.h $(htslib_kstring_h) $(hts_inter
 plugin.o plugin.pico: plugin.c config.h $(hts_internal_h) $(htslib_kstring_h)
 probaln.o probaln.pico: probaln.c config.h $(htslib_hts_h)
 realn.o realn.pico: realn.c config.h $(htslib_hts_h) $(htslib_sam_h)
-textutils.o textutils.pico: textutils.c config.h $(htslib_hfile_h) $(htslib_kstring_h) $(hts_internal_h)
+textutils.o textutils.pico: textutils.c config.h $(htslib_hfile_h) $(htslib_kstring_h) $(htslib_sam_h) $(hts_internal_h)
 
 cram/cram_codecs.o cram/cram_codecs.pico: cram/cram_codecs.c config.h $(cram_h)
 cram/cram_decode.o cram/cram_decode.pico: cram/cram_decode.c config.h $(cram_h) $(cram_os_h) $(htslib_hts_h)
@@ -462,7 +462,7 @@ test/fuzz/hts_open_fuzzer.o: test/fuzz/hts_open_fuzzer.c config.h $(htslib_hfile
 test/fieldarith.o: test/fieldarith.c config.h $(htslib_sam_h)
 test/hfile.o: test/hfile.c config.h $(htslib_hfile_h) $(htslib_hts_defs_h) $(htslib_kstring_h)
 test/pileup.o: test/pileup.c config.h $(htslib_sam_h) $(htslib_kstring_h)
-test/sam.o: test/sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h) $(htslib_hts_log_h)
+test/sam.o: test/sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_hts_log_h)
 test/test_bgzf.o: test/test_bgzf.c config.h $(htslib_bgzf_h) $(htslib_hfile_h) $(hfile_internal_h)
 test/test_kstring.o: test/test_kstring.c config.h $(htslib_kstring_h)
 test/test-parse-reg.o: test/test-parse-reg.c config.h $(htslib_hts_h) $(htslib_sam_h)

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -30,6 +30,7 @@
 #define HTSLIB_FAIDX_H
 
 #include <stdint.h>
+#include "hts_defs.h"
 #include "hts.h"
 
 #ifdef __cplusplus

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -32,6 +32,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdint.h>
 #include <inttypes.h>
 
+#include "hts_defs.h"
 #include "hts_log.h"
 
 #ifdef __cplusplus

--- a/htslib_vars.mk
+++ b/htslib_vars.mk
@@ -27,7 +27,7 @@
 
 htslib_bgzf_h = $(HTSPREFIX)htslib/bgzf.h $(htslib_hts_defs_h)
 htslib_cram_h = $(HTSPREFIX)htslib/cram.h $(htslib_hts_defs_h) $(htslib_hts_h) $(htslib_sam_h)
-htslib_faidx_h = $(HTSPREFIX)htslib/faidx.h $(htslib_hts_defs_h)
+htslib_faidx_h = $(HTSPREFIX)htslib/faidx.h $(htslib_hts_defs_h) $(htslib_hts_h)
 htslib_hfile_h = $(HTSPREFIX)htslib/hfile.h $(htslib_hts_defs_h)
 htslib_hts_h = $(HTSPREFIX)htslib/hts.h $(htslib_hts_defs_h) $(htslib_hts_log_h)
 htslib_hts_defs_h = $(HTSPREFIX)htslib/hts_defs.h

--- a/textutils.c
+++ b/textutils.c
@@ -30,7 +30,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "htslib/hfile.h"
 #include "htslib/kstring.h"
-#include "htslib/sam.h"
+#include "htslib/sam.h"  // For stringify_argv() declaration
 
 #include "hts_internal.h"
 


### PR DESCRIPTION
Another round of updating dependencies to correspond to `#include` updates in recent PRs.

It has occurred to me (and it seems obvious in retrospect!) that I could add a version of my dependency checking script to `make maintainer-check` so these would be caught immediately. (You could even use it as a pre-commit hook if you wanted to.) Could do this after the dust has settled on the current release activities.