### PR TITLE
Delay CRAM crc32 checks to block decompression step.

### DIFF
--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -275,6 +275,9 @@ struct cram_block {
 
     // To aid compression
     cram_metrics *m; // used to track aux block compression only
+
+    int crc32_checked;
+    uint32_t crc_part;
 };
 
 struct cram_codec; /* defined in cram_codecs.h */


### PR DESCRIPTION
This means we don't validate the CRC until we have a need to use that
data.  Thus we don't pay the price when doing sub-queries such as
samtools index and samtools flagstats.

This brings htslib into line with io_lib's implementation which has
done this for some time.

Some benchmarks below on 1 million PacBio reads, which show this problem up more than most files due to the small nature of flags vs long sequence & quality blocks:

This branch:
```
time MALLOC_TOP_PAD_=1000000000 ./samtools flagstat /tmp/_1m.cram
real 0m0.523s
user 0m0.332s
sys  0m0.184s

time MALLOC_TOP_PAD_=1000000000 ./samtools index /tmp/_1m.cram
real 0m0.221s
user 0m0.024s
sys  0m0.196s

time MALLOC_TOP_PAD_=1000000000 ./samtools view -c /tmp/_1m.cram
real 0m30.824s
user 0m30.426s
sys  0m0.324s
```
Dev branch:
```
time MALLOC_TOP_PAD_=1000000000 samtools flagstat /tmp/_1m.cram
real 0m1.317s
user 0m1.048s
sys  0m0.260s

time MALLOC_TOP_PAD_=1000000000 samtools index /tmp/_1m.cram
real 0m1.029s
user 0m0.816s
sys  0m0.212s

time MALLOC_TOP_PAD_=1000000000 samtools view -c /tmp/_1m.cram
real 0m31.412s
user 0m30.894s
sys  0m0.452s
```
Note this is with libdeflate's fast CRC.  Zlib's shows an even larger
discrepancy.

PS.  For the curious, the MALLOC_TOP_PAD_=1000000000 is to work around
deficiency of GNU's libc malloc implementation.  Without it (but with
this patch) we have excessive system call time due to wasted time
spent zeroing pages of memory that we keep repeatedly giving back:
```
# This branch
time ./samtools flagstat /tmp/_1m.cram
real 0m1.328s
user 0m0.280s
sys  0m1.044s

# Dev branch
real  0m2.110s
user  0m1.104s
sys   0m0.996s
```
Also, as a demonstration of CRAM vs BAM, this is the BAM equivalent:
```
-rw-r--r-- 1 jkb team117 2160547816 Nov 25 15:30 /tmp/_1m.bam
-rw-r--r-- 1 jkb team117 1303241699 Nov 25 15:05 /tmp/_1m.cram

time MALLOC_TOP_PAD_=1000000000 ./samtools index /tmp/_1m.bam
real	0m20.564s
user	0m19.953s
sys	0m0.572s

time MALLOC_TOP_PAD_=1000000000 ./samtools view -c /tmp/_1m.bam
real	0m19.663s
user	0m19.257s
sys	0m0.372s
```