### PR TITLE
Mark new internal synced_bcf_reader.c functions as static

### DIFF
--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -817,7 +817,7 @@ static int _regions_add(bcf_sr_regions_t *reg, const char *chr, hts_pos_t start,
     return 0; // FIXME: check for errs in this function
 }
 
-int _regions_cmp(const void *aptr, const void *bptr)
+static int regions_cmp(const void *aptr, const void *bptr)
 {
     region1_t *a = (region1_t*)aptr;
     region1_t *b = (region1_t*)bptr;
@@ -827,7 +827,7 @@ int _regions_cmp(const void *aptr, const void *bptr)
     if ( a->end > b->end ) return 1;
     return 0;
 }
-void _regions_merge(region_t *reg)
+static void regions_merge(region_t *reg)
 {
     int i = 0, j;
     while ( i<reg->nregs )
@@ -849,8 +849,8 @@ void _regions_sort_and_merge(bcf_sr_regions_t *reg)
     int i;
     for (i=0; i<reg->nseqs; i++)
     {
-        qsort(reg->regs[i].regs, reg->regs[i].nregs, sizeof(*reg->regs[i].regs), _regions_cmp);
-        _regions_merge(&reg->regs[i]);
+        qsort(reg->regs[i].regs, reg->regs[i].nregs, sizeof(*reg->regs[i].regs), regions_cmp);
+        regions_merge(&reg->regs[i]);
     }
 }
 
@@ -1096,7 +1096,7 @@ int bcf_sr_regions_seek(bcf_sr_regions_t *reg, const char *seq)
 }
 
 // Returns 0 on success, -1 when done
-int advance_creg(region_t *reg)
+static int advance_creg(region_t *reg)
 {
     int i = reg->creg + 1;
     while ( i<reg->nregs && reg->regs[i].start > reg->regs[i].end ) i++;    // regions with start>end are marked to skip by merge_regions()


### PR DESCRIPTION
Ensuring properly-prefixed functions (whose names start with `hts_`, `sam_`, or whatever) are `static` where possible is less necessary now that visibility control has been merged. However it is still important (at least for static linking against _libhts.a_) for functions that would otherwise pollute the user's namespace. Also remove the leading underscore from the new identifiers, as that is reserved to the compiler.

(These functions appeared in db90fb58b06d6f3b27b5b873588da7c77844da22 which was not done via a pull request, so was not reviewed.)

(Also a recent addition and a function that could be `static` is `sam_hdr_dup_sdict()`, but as that is properly prefixed there's no need to address it.)