### PR TITLE
Fixes to pass cppcheck-1.90 warnings

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -2176,6 +2176,7 @@ int cram_codec_decoder2encoder(cram_fd *fd, cram_codec *c) {
         // FIXME: we huffman and e_huffman structs amended, we could
         // unify this.
         cram_codec *t = malloc(sizeof(*t));
+        if (!t) return -1;
         t->codec = E_HUFFMAN;
         t->free = cram_huffman_encode_free;
         t->store = cram_huffman_encode_store;
@@ -2224,6 +2225,7 @@ int cram_codec_decoder2encoder(cram_fd *fd, cram_codec *c) {
 
     case E_BYTE_ARRAY_LEN: {
         cram_codec *t = malloc(sizeof(*t));
+        if (!t) return -1;
         t->codec = E_BYTE_ARRAY_LEN;
         t->free   = cram_byte_array_len_encode_free;
         t->store  = cram_byte_array_len_encode_store;
@@ -2239,7 +2241,6 @@ int cram_codec_decoder2encoder(cram_fd *fd, cram_codec *c) {
         // {len,val}_{encoding,dat} are undefined, but unused.
         // Leaving them unset here means we can test that assertion.
         *c = *t;
-        free(t);
         break;
     }
 

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1145,7 +1145,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 
         if (ncigar+2 >= cigar_alloc) {
             cigar_alloc = cigar_alloc ? cigar_alloc*2 : 1024;
-            if (!(cigar = realloc(cigar, cigar_alloc * sizeof(*cigar))))
+            if (!(cigar = realloc(s->cigar, cigar_alloc * sizeof(*cigar))))
                 return -1;
             s->cigar = cigar;
         }
@@ -1724,7 +1724,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 
         if (ncigar+1 >= cigar_alloc) {
             cigar_alloc = cigar_alloc ? cigar_alloc*2 : 1024;
-            if (!(cigar = realloc(cigar, cigar_alloc * sizeof(*cigar))))
+            if (!(cigar = realloc(s->cigar, cigar_alloc * sizeof(*cigar))))
                 return -1;
             s->cigar = cigar;
         }
@@ -1754,7 +1754,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
     if (cig_len) {
         if (ncigar >= cigar_alloc) {
             cigar_alloc = cigar_alloc ? cigar_alloc*2 : 1024;
-            if (!(cigar = realloc(cigar, cigar_alloc * sizeof(*cigar))))
+            if (!(cigar = realloc(s->cigar, cigar_alloc * sizeof(*cigar))))
                 return -1;
             s->cigar = cigar;
         }
@@ -1876,9 +1876,8 @@ static int cram_decode_aux_1_0(cram_container *c, cram_slice *s,
         r |= c->comp_hdr->codecs[DS_TN]->decode(s, c->comp_hdr->codecs[DS_TN],
                                                 blk, (char *)&id, &out_sz);
         if (out_sz == 3) {
-            tag_data[0] = ((char *)&id)[0];
-            tag_data[1] = ((char *)&id)[1];
-            tag_data[2] = ((char *)&id)[2];
+            // Tag name stored as 3 chars instead of an int?
+            memcpy(tag_data, &id, 3);
         } else {
             tag_data[0] = (id>>16) & 0xff;
             tag_data[1] = (id>>8)  & 0xff;

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1779,12 +1779,10 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
     if ((ds & CRAM_QS) && (cf & CRAM_FLAG_PRESERVE_QUAL_SCORES)) {
         int32_t out_sz2 = cr->len;
 
-        if (ds & CRAM_QS) {
-            if (!c->comp_hdr->codecs[DS_QS]) return -1;
-            r |= c->comp_hdr->codecs[DS_QS]
-                            ->decode(s, c->comp_hdr->codecs[DS_QS], blk,
-                                     qual, &out_sz2);
-        }
+        if (!c->comp_hdr->codecs[DS_QS]) return -1;
+        r |= c->comp_hdr->codecs[DS_QS]
+            ->decode(s, c->comp_hdr->codecs[DS_QS], blk,
+                     qual, &out_sz2);
     }
 
     s->cigar = cigar;

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -547,7 +547,8 @@ cram_block *cram_encode_slice_header(cram_fd *fd, cram_slice *s) {
     if (!b)
         return NULL;
 
-    if (NULL == (cp = buf = malloc(16+5*(8+s->hdr->num_blocks)))) {
+    cp = buf = malloc(16+5*(8+s->hdr->num_blocks));
+    if (NULL == buf) {
         cram_free_block(b);
         return NULL;
     }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2938,7 +2938,7 @@ cram_container *cram_new_container(int nrec, int nslice) {
 
     c->bams = NULL;
 
-    if (!(c->slices = (cram_slice **)calloc(nslice, sizeof(cram_slice *))))
+    if (!(c->slices = calloc(nslice != 0 ? nslice : 1, sizeof(cram_slice *))))
         goto err;
     c->slice = NULL;
 

--- a/cram/cram_stats.c
+++ b/cram/cram_stats.c
@@ -145,13 +145,15 @@ enum cram_encoding cram_stats_encoding(cram_fd *fd, cram_stats *st) {
             continue;
         if (nvals >= vals_alloc) {
             vals_alloc = vals_alloc ? vals_alloc*2 : 1024;
-            vals  = realloc(vals,  vals_alloc * sizeof(int));
-            freqs = realloc(freqs, vals_alloc * sizeof(int));
-            if (!vals || !freqs) {
+            int *vals_tmp  = realloc(vals,  vals_alloc * sizeof(int));
+            int *freqs_tmp = realloc(freqs, vals_alloc * sizeof(int));
+            if (!vals_tmp || !freqs_tmp) {
                 if (vals)  free(vals);
                 if (freqs) free(freqs);
                 return E_HUFFMAN; // Cannot do much else atm
             }
+            vals = vals_tmp;
+            freqs = freqs_tmp;
         }
         vals[nvals] = i;
         freqs[nvals] = st->freqs[i];
@@ -170,10 +172,15 @@ enum cram_encoding cram_stats_encoding(cram_fd *fd, cram_stats *st) {
 
             if (nvals >= vals_alloc) {
                 vals_alloc = vals_alloc ? vals_alloc*2 : 1024;
-                vals  = realloc(vals,  vals_alloc * sizeof(int));
-                freqs = realloc(freqs, vals_alloc * sizeof(int));
-                if (!vals || !freqs)
+                int *vals_tmp  = realloc(vals,  vals_alloc * sizeof(int));
+                int *freqs_tmp = realloc(freqs, vals_alloc * sizeof(int));
+                if (!vals_tmp || !freqs_tmp) {
+                    if (vals)  free(vals);
+                    if (freqs) free(freqs);
                     return E_HUFFMAN; // Cannot do much else atm
+                }
+                vals = vals_tmp;
+                freqs = freqs_tmp;
             }
             i = kh_key(st->h, k);
             vals[nvals]=i;

--- a/cram/pooled_alloc.c
+++ b/cram/pooled_alloc.c
@@ -199,6 +199,7 @@ int main(void) {
         pool_free(p, item);
     }
 
+    free(items);
     return 0;
 }
 #endif

--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -842,6 +842,7 @@ int main(int argc, char **argv) {
     if (optind < argc) {
         if (!(outfp = fopen(argv[optind], "wb"))) {
             perror(argv[optind]);
+            fclose(infp);
             return 1;
         }
         optind++;
@@ -899,6 +900,10 @@ int main(int argc, char **argv) {
             tv2.tv_usec - tv1.tv_usec,
             (double)bytes / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
                              tv2.tv_usec - tv1.tv_usec));
+
+    if (infp  != stdin)  fclose(infp);
+    if (outfp != stdout) fclose(outfp);
+
     return 0;
 }
 #endif

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -890,19 +890,19 @@ static int query_cmp(const void *p1, const void *p2) {
 /* Query strings must be in alphabetical order for authorisation */
 
 static int order_query_string(kstring_t *qs) {
-    int *query_offset;
+    int *query_offset = NULL;
     int num_queries, i;
-    char **queries;
+    char **queries = NULL;
     kstring_t ordered = {0, 0, NULL};
-    char *escaped;
+    char *escaped = NULL;
+    int ret = -1;
 
     if ((query_offset = ksplit(qs, '&', &num_queries)) == NULL) {
         return -1;
     }
 
-    if ((queries = malloc(num_queries * sizeof(char*))) == NULL) {
-        return -1;
-    }
+    if ((queries = malloc(num_queries * sizeof(char*))) == NULL)
+        goto err;
 
     for (i = 0; i < num_queries; i++) {
         queries[i] = qs->s + query_offset[i];
@@ -918,19 +918,20 @@ static int order_query_string(kstring_t *qs) {
         kputs(queries[i], &ordered);
     }
 
-    if ((escaped = escape_query(ordered.s)) == NULL) {
-        return -1;
-    }
+    if ((escaped = escape_query(ordered.s)) == NULL)
+        goto err;
 
     qs->l = 0;
     kputs(escaped, qs);
 
+    ret = 0;
+ err:
     free(ordered.s);
     free(queries);
     free(query_offset);
     free(escaped);
 
-    return 0;
+    return ret;
 }
 
 

--- a/hts.c
+++ b/hts.c
@@ -2062,6 +2062,7 @@ static int hts_idx_save_core(const hts_idx_t *idx, BGZF *fp, int fmt)
 int hts_idx_save(const hts_idx_t *idx, const char *fn, int fmt)
 {
     int ret, save;
+    if (idx == NULL || fn == NULL) { errno = EINVAL; return -1; }
     char *fnidx = (char*)calloc(1, strlen(fn) + 5);
     if (fnidx == NULL) return -1;
 

--- a/hts.c
+++ b/hts.c
@@ -1396,8 +1396,8 @@ int hts_getline(htsFile *fp, int delimiter, kstring_t *str)
 
 char **hts_readlist(const char *string, int is_file, int *_n)
 {
-    int m = 0, n = 0;
-    char **s = 0;
+    unsigned int m = 0, n = 0;
+    char **s = 0, **s_new;
     if ( is_file )
     {
         BGZF *fp = bgzf_open(string, "r");
@@ -1408,9 +1408,12 @@ char **hts_readlist(const char *string, int is_file, int *_n)
         while (bgzf_getline(fp, '\n', &str) >= 0)
         {
             if (str.l == 0) continue;
+            if (hts_resize(char*, n + 1, &m, &s, 0) < 0)
+                goto err;
+            s[n] = strdup(str.s);
+            if (!s[n])
+                goto err;
             n++;
-            hts_expand(char*,n,m,s);
-            s[n-1] = strdup(str.s);
         }
         bgzf_close(fp);
         free(str.s);
@@ -1422,57 +1425,83 @@ char **hts_readlist(const char *string, int is_file, int *_n)
         {
             if (*p == ',' || *p == 0)
             {
-                n++;
-                hts_expand(char*,n,m,s);
-                s[n-1] = (char*)calloc(p - q + 1, 1);
-                strncpy(s[n-1], q, p - q);
+                if (hts_resize(char*, n + 1, &m, &s, 0) < 0)
+                    goto err;
+                s[n] = (char*)calloc(p - q + 1, 1);
+                if (!s[n])
+                    goto err;
+                strncpy(s[n++], q, p - q);
                 q = p + 1;
             }
             if ( !*p ) break;
             p++;
         }
     }
-    s = (char**)realloc(s, n * sizeof(char*));
+    // Try to shrink s to the minimum size needed
+    s_new = (char**)realloc(s, n * sizeof(char*));
+    if (!s_new)
+        goto err;
+
+    s = s_new;
+    assert(n < INT_MAX); // hts_resize() should ensure this
     *_n = n;
     return s;
+
+ err:
+    for (m = 0; m < n; m++)
+        free(s[m]);
+    free(s);
+    return NULL;
 }
 
 char **hts_readlines(const char *fn, int *_n)
 {
-    int m = 0, n = 0;
-    char **s = 0;
+    unsigned int m = 0, n = 0;
+    char **s = 0, **s_new;
     BGZF *fp = bgzf_open(fn, "r");
     if ( fp ) { // read from file
         kstring_t str;
         str.s = 0; str.l = str.m = 0;
         while (bgzf_getline(fp, '\n', &str) >= 0) {
             if (str.l == 0) continue;
-            if (m == n) {
-                m = m? m<<1 : 16;
-                s = (char**)realloc(s, m * sizeof(char*));
-            }
-            s[n++] = strdup(str.s);
+            if (hts_resize(char *, n + 1, &m, &s, 0) < 0)
+                goto err;
+            s[n] = strdup(str.s);
+            if (!s[n])
+                goto err;
+            n++;
         }
         bgzf_close(fp);
-        s = (char**)realloc(s, n * sizeof(char*));
         free(str.s);
     } else if (*fn == ':') { // read from string
         const char *q, *p;
         for (q = p = fn + 1;; ++p)
             if (*p == ',' || *p == 0) {
-                if (m == n) {
-                    m = m? m<<1 : 16;
-                    s = (char**)realloc(s, m * sizeof(char*));
-                }
+                if (hts_resize(char *, n + 1, &m, &s, 0) < 0)
+                    goto err;
                 s[n] = (char*)calloc(p - q + 1, 1);
+                if (!s[n])
+                    goto err;
                 strncpy(s[n++], q, p - q);
                 q = p + 1;
                 if (*p == 0) break;
             }
     } else return 0;
-    s = (char**)realloc(s, n * sizeof(char*));
+    // Try to shrink s to the minimum size needed
+    s_new = (char**)realloc(s, n * sizeof(char*));
+    if (!s_new)
+        goto err;
+
+    s = s_new;
+    assert(n < INT_MAX); // hts_resize() should ensure this
     *_n = n;
     return s;
+
+ err:
+    for (m = 0; m < n; m++)
+        free(s[m]);
+    free(s);
+    return NULL;
 }
 
 // DEPRECATED: To be removed in a future HTSlib release
@@ -2675,7 +2704,7 @@ int hts_itr_multi_cram(const hts_idx_t *idx, hts_itr_t *iter)
     hts_pos_t beg, end;
     hts_reglist_t *curr_reg;
     hts_pair32_t *curr_intv;
-    hts_pair64_max_t *off = NULL;
+    hts_pair64_max_t *off = NULL, *tmp;
     cram_index *e = NULL;
 
     if (!cidx || !iter || !iter->multi)
@@ -2694,9 +2723,11 @@ int hts_itr_multi_cram(const hts_idx_t *idx, hts_itr_t *iter)
         tid = curr_reg->tid;
 
         if (tid >= 0) {
-            off = (hts_pair64_max_t*)realloc(off, (n_off + curr_reg->count) * sizeof(hts_pair64_max_t));
-            if (!off)
-                return -1;
+            tmp = (hts_pair64_max_t*)realloc(off, (n_off + curr_reg->count)
+                                             * sizeof(hts_pair64_max_t));
+            if (!tmp)
+                goto err;
+            off = tmp;
 
             for (j=0; j < curr_reg->count; j++) {
                 curr_intv = &curr_reg->intervals[j];
@@ -2747,7 +2778,10 @@ int hts_itr_multi_cram(const hts_idx_t *idx, hts_itr_t *iter)
                     e = cram_index_query(cidx->cram, tid, 1, NULL);
                     if (e) {
                         iter->read_rest = 1;
-                        off = (hts_pair64_max_t*)realloc(off, sizeof(hts_pair64_max_t));
+                        tmp = (hts_pair64_max_t*)realloc(off, sizeof(hts_pair64_max_t));
+                        if (!tmp)
+                            goto err;
+                        off = tmp;
                         off[0].u = e->offset;
                         off[0].v = 0;
                         off[0].max = 0;
@@ -2796,6 +2830,10 @@ int hts_itr_multi_cram(const hts_idx_t *idx, hts_itr_t *iter)
         iter->finished = 1;
 
     return 0;
+
+ err:
+    free(off);
+    return -1;
 }
 
 void hts_itr_destroy(hts_itr_t *iter)

--- a/htslib/kbitset.h
+++ b/htslib/kbitset.h
@@ -104,7 +104,7 @@ static inline int kbs_resize2(kbitset_t **bsp, size_t ni_new, int fill)
 	size_t n_new = (ni_new + KBS_ELTBITS-1) / KBS_ELTBITS;
 	if (bs == NULL || n_new > bs->n_max) {
 		bs = (kbitset_t *)
-			realloc(bs, sizeof(kbitset_t) + n_new * sizeof(unsigned long));
+			realloc(*bsp, sizeof(kbitset_t) + n_new * sizeof(unsigned long));
 		if (bs == NULL) return -1;
 
 		bs->n_max = n_new;

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -1060,7 +1060,7 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     #define bcf_hdr_id2number(hdr,type,int_id)  ((hdr)->id[BCF_DT_ID][int_id].val->info[type]>>12)
     #define bcf_hdr_id2type(hdr,type,int_id)    (uint32_t)((hdr)->id[BCF_DT_ID][int_id].val->info[type]>>4 & 0xf)
     #define bcf_hdr_id2coltype(hdr,type,int_id) (uint32_t)((hdr)->id[BCF_DT_ID][int_id].val->info[type] & 0xf)
-    #define bcf_hdr_idinfo_exists(hdr,type,int_id)  ((int_id<0 || bcf_hdr_id2coltype(hdr,type,int_id)==0xf) ? 0 : 1)
+    #define bcf_hdr_idinfo_exists(hdr,type,int_id)  ((int_id)>=0 && bcf_hdr_id2coltype((hdr),(type),(int_id))!=0xf)
     #define bcf_hdr_id2hrec(hdr,dict_type,col_type,int_id)    ((hdr)->id[(dict_type)==BCF_DT_CTG?BCF_DT_CTG:BCF_DT_ID][int_id].val->hrec[(dict_type)==BCF_DT_CTG?0:(col_type)])
     /// Convert BCF FORMAT data to string form
     /**

--- a/sam.c
+++ b/sam.c
@@ -2451,7 +2451,7 @@ static void *sam_parse_worker(void *arg) {
         // However this is an API change so for now we copy.
 
         char *nl = strchr(cp, '\n');
-        nl = nl ? nl : cp_end;
+        if (!nl)  nl = cp_end;
         if (*nl) *nl++ = '\0';
         kstring_t ks = {nl-cp, gl->alloc, cp};
         if (sam_parse1(&ks, fd->h, &b[i]) < 0) {

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -128,7 +128,10 @@ static int *init_filters(bcf_hdr_t *hdr, const char *filters, int *nfilters)
     {
         if ( *tmp==',' || !*tmp )
         {
-            out = (int*) realloc(out, (nout+1)*sizeof(int));
+            int *otmp = (int*) realloc(out, (nout+1)*sizeof(int));
+            if (!otmp)
+                goto err;
+            out = otmp;
             if ( tmp-prev==1 && *prev=='.' )
             {
                 out[nout] = -1;
@@ -149,6 +152,11 @@ static int *init_filters(bcf_hdr_t *hdr, const char *filters, int *nfilters)
     if ( str.m ) free(str.s);
     *nfilters = nout;
     return out;
+
+ err:
+    if (str.m) free(str.s);
+    free(out);
+    return NULL;
 }
 
 int bcf_sr_set_regions(bcf_srs_t *readers, const char *regions, int is_file)

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -321,7 +321,7 @@ int bcf_sr_add_reader(bcf_srs_t *files, const char *fname)
     // Update list of chromosomes
     if ( !files->explicit_regs && !files->streaming )
     {
-        int n,i;
+        int n = 0, i;
         const char **names = reader->tbx_idx ? tbx_seqnames(reader->tbx_idx, &n) : bcf_hdr_seqnames(reader->header, &n);
         for (i=0; i<n; i++)
         {

--- a/tabix.c
+++ b/tabix.c
@@ -176,6 +176,7 @@ static int query_regions(args_t *args, char *fname, char **regs, int nregs, int 
             if ( bcf_hdr_write(out,hdr)!=0 ) error("Failed to write to %s\n", fname);
         if ( !args->header_only )
         {
+            assert(regs != NULL);
             bcf1_t *rec = bcf_init();
             for (i=0; i<nregs; i++)
             {

--- a/test/hfile.c
+++ b/test/hfile.c
@@ -180,6 +180,8 @@ int main(void)
         text = slurp(buffer);
         if (strcmp(original, text) != 0) {
             fprintf(stderr, "%s differs from vcf.c\n", buffer);
+            free(text);
+            free(original);
             return EXIT_FAILURE;
         }
         free(text);

--- a/test/sam.c
+++ b/test/sam.c
@@ -1551,7 +1551,7 @@ static int generator(const char *name)
     }
 
     if (fputs("@HD\tVN:1.4\n", f) < 0) goto cleanup;
-    if (fprintf(f, "@SQ\tSN:ref1\tLN:%u\n", MAX_RECS + SEQ_LEN) < 0)
+    if (fprintf(f, "@SQ\tSN:ref1\tLN:%d\n", MAX_RECS + SEQ_LEN) < 0)
         goto cleanup;
     for (i = 0; i < MAX_RECS; i++) {
         if (fprintf(f, "read%zu\t0\tref1\t%zu\t64\t100M\t*\t0\t0\t%.*s\t%.*s\n",

--- a/test/test_bgzf.c
+++ b/test/test_bgzf.c
@@ -378,7 +378,7 @@ static int setup(const char *src, Files *f) {
         perror(__func__);
         goto fail;
     }
-    for (i = 0; i < max; i++) snprintf(text + i*8, text_sz - i*8, "%07d\n", i);
+    for (i = 0; i < max; i++) snprintf(text + i*8, text_sz - i*8, "%07u\n", i);
     f->text = (unsigned char *) text;
     f->ltext = text_sz - 1;
 

--- a/test/test_kstring.c
+++ b/test/test_kstring.c
@@ -120,7 +120,7 @@ static int test_kputw_from_to(kstring_t *str, int s, int e) {
         }
         if (i != strtol(str->s, NULL, 10)) {
             fprintf(stderr,
-                    "kputw wrote the wrong value, expected %u, got %s\n",
+                    "kputw wrote the wrong value, expected %d, got %s\n",
                     i, str->s);
             return -1;
         }

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -617,6 +617,7 @@ static void *tpool_worker(void *arg) {
 }
 
 static void wake_next_worker(hts_tpool_process *q, int locked) {
+    if (!q) return;
     hts_tpool *p = q->p;
     if (!locked)
         pthread_mutex_lock(&p->pool_m);
@@ -641,7 +642,7 @@ static void wake_next_worker(hts_tpool_process *q, int locked) {
 
     int running = p->tsize - p->nwaiting;
     int sig = p->t_stack_top >= 0 && p->njobs > p->tsize - p->nwaiting
-        && (!q || q->n_processing < q->qsize - q->n_output);
+        && (q->n_processing < q->qsize - q->n_output);
 
 //#define AVG_USAGE
 #ifdef AVG_USAGE

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -57,10 +57,11 @@ static int worker_id(hts_tpool *p) {
     return -1;
 }
 
-int DBG_OUT(FILE *fp, char *fmt, ...) {
+void DBG_OUT(FILE *fp, char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    return vfprintf(fp, fmt, args);
+    vfprintf(fp, fmt, args);
+    va_end(args);
 }
 #else
 #define DBG_OUT(...) do{}while(0)

--- a/vcf.c
+++ b/vcf.c
@@ -3600,6 +3600,7 @@ bcf_hdr_t *bcf_hdr_subset(const bcf_hdr_t *h0, int n, char *const* samples, int 
     bcf_hdr_t *h = bcf_hdr_init("w");
     if (!h) {
         hts_log_error("Failed to allocate bcf header");
+        khash_str2int_destroy(names_hash);
         return NULL;
     }
     bcf_hdr_format(h0, 1, &htxt);


### PR DESCRIPTION
Command ran: cppcheck --inline-suppr  --enable=warning -q -f --language=c .

This is a mix of silencing false positives, rewriting code to be less confusing to cppcheck (and sometimes to us), and genuine minor issues around handling running out of memory.

In some cases I've added inline suppressions, eg

    // cppcheck-suppress objectIndex

This isn't ideal, but I personally think it's worth having a little annotation in order to make detection of future buglets easier to find.

Fixes #995

Propose merging immediately *after* 1.10 release as there are no serious bugs fixed.

Note cppcheck 1.72 still finds some false positives, but I don't propose silencing them.  1.90 is the latest version at time of PR.