### PR TITLE
Change signature of kgets_func2() to be more like hgetln()

### DIFF
--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -130,7 +130,8 @@ extern "C" {
     HTSLIB_EXPORT
 	int kgetline(kstring_t *s, kgets_func *fgets, void *fp);
 
-	typedef ssize_t kgets_func2(char *, int, void *);
+    // This matches the signature of hgetln(), apart from the last pointer
+	typedef ssize_t kgets_func2(char *, size_t, void *);
     HTSLIB_EXPORT
 	int kgetline2(kstring_t *s, kgets_func2 *fgets, void *fp);
 


### PR DESCRIPTION
In particular the second parameter should be `size_t`, not `int`.
The incorrect version worked when using `hgetln()`, mainly because the ABI passes arguments in registers.  This ensures it will work because the types match instead of due to a happy accident.

Presumably the original version was trying to match `fgets()`, but there's not much point in that as the return value is different.

Thanks to @jmarshall  for spotting this.