### PR TITLE
Use srand48_deterministic() on platforms that have it

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 Noteworthy changes in release a.b
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* hts_srand48() now seeds the same POSIX-standard sequences of pseudo-random
+  numbers regardless of platform, including on OpenBSD where plain srand48()
+  produces a different cryptographically-strong non-deterministic sequence.
+
+
 Noteworthy changes in release 1.10.2 (19th December 2019)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/configure.ac
+++ b/configure.ac
@@ -173,7 +173,7 @@ HTS_HIDE_DYNAMIC_SYMBOLS
 
 dnl FIXME This pulls in dozens of standard header checks
 AC_FUNC_MMAP
-AC_CHECK_FUNCS([gmtime_r fsync drand48])
+AC_CHECK_FUNCS([gmtime_r fsync drand48 srand48_deterministic])
 
 # Darwin has a dubious fdatasync() symbol, but no declaration in <unistd.h>
 AC_CHECK_DECL([fdatasync(int)], [AC_CHECK_FUNCS(fdatasync)])

--- a/hts_os.c
+++ b/hts_os.c
@@ -33,7 +33,14 @@ DEALINGS IN THE SOFTWARE.  */
 #else
 #include <stdlib.h>
 HTSLIB_EXPORT
-void hts_srand48(long seed) { srand48(seed); }
+void hts_srand48(long seed)
+{
+#ifdef HAVE_SRAND48_DETERMINISTIC
+    srand48_deterministic(seed);
+#else
+    srand48(seed);
+#endif
+}
 
 HTSLIB_EXPORT
 double hts_erand48(unsigned short xseed[3]) { return erand48(xseed); }

--- a/htslib/hts_os.h
+++ b/htslib/hts_os.h
@@ -32,6 +32,11 @@ DEALINGS IN THE SOFTWARE.  */
 extern "C" {
 #endif
 
+/* This is srand48_deterministic() on platforms that provide it, or srand48()
+   otherwise (or our own POSIX srand48() on platforms that provide neither).
+   Hence calling hts_srand48() will always set up the same POSIX-determined
+   sequence of pseudo-random numbers on any platform, while calling srand48()
+   may (e.g., on OpenBSD) set up a different non-deterministic sequence. */
 HTSLIB_EXPORT
 void hts_srand48(long seed);
 


### PR DESCRIPTION
This is a prerequisite for an upcoming samtools PR to make the test suite work on OpenBSD, where there are test suite failures testing `samtools merge -c -p` because OpenBSD produces a different random number sequence and so the renamed reference sequences are different from the tests' expected output.

This could be fixed in samtools, but as _hts_os.h_ collects together platform-specific `srand48()/drand48()/etc` foibles, it seems better to fix it here. Typically for HTSlib clients, cross-platform repeatability seems more important than unneeded  cryptographic secureness on one platform.

It would be possible to `#define srand48(S) hts_srand48((S))` on OpenBSD to get the standard sequence whichever of the two functions were used, but (1) this is very fragile as it is impossible to ensure that no system headers are ever #included **after** _htslib/hts_os.h_ (and such a `#define` could wreak havoc on a system header) and (2) it seems better to give client programs the choice.