### PR TITLE
Fix possible undefined shift in cram_byte_array_stop_decode_init()

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1922,7 +1922,7 @@ cram_codec *cram_byte_array_stop_decode_init(char *data, int size,
     c->u.byte_array_stop.stop = *cp++;
     if (CRAM_MAJOR_VERS(version) == 1) {
         c->u.byte_array_stop.content_id = cp[0] + (cp[1]<<8) + (cp[2]<<16)
-            + (cp[3]<<24);
+            + ((unsigned int) cp[3]<<24);
         cp += 4;
     } else {
         cp += safe_itf8_get((char *) cp, data + size,


### PR DESCRIPTION
Only happens if high bit of last external block content_id byte is set.  This is unlikely in real data, but turned up in fuzz testing.