### PR TITLE
Add items to `make all`; fix some warnings in header.c [minor]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ BUILT_THRASH_PROGRAMS = \
 	test/thrash_threads6 \
 	test/thrash_threads7
 
-all: lib-static lib-shared $(BUILT_PROGRAMS) plugins $(BUILT_TEST_PROGRAMS)
+all: lib-static lib-shared $(BUILT_PROGRAMS) plugins $(BUILT_TEST_PROGRAMS) \
+     htslib_static.mk htslib-uninstalled.pc
 
 HTSPREFIX =
 include htslib_vars.mk
@@ -494,8 +495,10 @@ test/thrash_threads5: test/thrash_threads5.o libhts.a
 
 test/thrash_threads6: test/thrash_threads6.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads6.o libhts.a -lz $(LIBS) -lpthread
+
 test/thrash_threads7: test/thrash_threads7.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/thrash_threads7.o libhts.a -lz $(LIBS) -lpthread
+
 test_thrash: $(BUILT_THRASH_PROGRAMS)
 
 # Test to ensure the functions in the header files are exported by the shared
@@ -620,8 +623,9 @@ force:
 
 .PHONY: all check clean distclean distdir force
 .PHONY: install install-pkgconfig installdirs lib-shared lib-static
-.PHONY: maintainer-clean mostlyclean plugins print-config print-version
-.PHONY: show-version tags test testclean
+.PHONY: maintainer-check maintainer-clean mostlyclean plugins
+.PHONY: print-config print-version show-version tags
+.PHONY: test test-shlib-exports test_thrash testclean
 .PHONY: clean-so install-so
 .PHONY: clean-cygdll install-cygdll
 .PHONY: clean-dll install-dll

--- a/Makefile
+++ b/Makefile
@@ -437,8 +437,8 @@ test/test-regidx: test/test-regidx.o libhts.a
 test/test-parse-reg: test/test-parse-reg.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test-parse-reg.o libhts.a $(LIBS) -lpthread
 
-test/test_str2int: test/test_str2int.o
-	$(CC) $(LDFLAGS) -o $@ test/test_str2int.o
+test/test_str2int: test/test_str2int.o libhts.a
+	$(CC) $(LDFLAGS) -o $@ test/test_str2int.o libhts.a $(LIBS) -lpthread
 
 test/test_view: test/test_view.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_view.o libhts.a $(LIBS) -lpthread

--- a/header.h
+++ b/header.h
@@ -53,7 +53,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern "C" {
 #endif
 
-#define TYPEKEY(a) (((a)[0]<<8)|((a)[1]))
+/*! Make a single integer out of a two-letter type code */
+static inline khint32_t TYPEKEY(const char *type) {
+    unsigned int u0 = (unsigned char) type[0];
+    unsigned int u1 = (unsigned char) type[1];
+    return (u0 << 8) | u1;
+}
 
 /*
  * Proposed new SAM header parsing

--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -245,7 +245,7 @@ HTSLIB_EXPORT
 int bcf_sr_next_line(bcf_srs_t *readers);
 
 #define bcf_sr_has_line(readers, i) (readers)->has_line[i]
-#define bcf_sr_get_line(_readers, i) ((_readers)->has_line[i] ? ((_readers)->readers[i].buffer[0]) : NULL)
+#define bcf_sr_get_line(_readers, i) ((_readers)->has_line[i] ? ((_readers)->readers[i].buffer[0]) : (bcf1_t *) NULL)
 #define bcf_sr_swap_line(_readers, i, lieu) { bcf1_t *tmp = lieu; lieu = (_readers)->readers[i].buffer[0]; (_readers)->readers[i].buffer[0] = tmp; }
 #define bcf_sr_region_done(_readers,i) (!(_readers)->has_line[i] && !(_readers)->readers[i].nbuffer ? 1 : 0)
 #define bcf_sr_get_header(_readers, i) (_readers)->readers[i].header


### PR DESCRIPTION
Another collection of minor miscellanea:

* Add a couple of minor makefile targets to `make all`. While converting lofreq to use HTSlib directly, I wanted to use _htslib_static.mk_ to get `$(HTSLIB_static_LIBS)` but didn't want to use _htslib.mk_'s dependency infrastructure. This meant that e.g. https://github.com/CSB5/lofreq/pull/86/files#diff-354f30a63fb0907d4ad57269548329e3 couldn't just use `make all` but had to list `htslib_static.mk` as an explicit target. Adding it to HTSlib's `all` would remove this need.

* Fix the semi-theoretical sign-extension bugs in `TYPEKEY()` and use it throughout _header.c_. This replaces a bunch of bit-shifting on plain maybe-signed `chars` and makes for (to my eye) clearer code. Also prevents some `-Wextra` and cppcheck warnings.

* In the same source file, trivially rename a `sam_hdr_remove_lines()` parameter to prevent another cppcheck warning.