### PR TITLE
Fix missing return parameter value

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -3416,7 +3416,7 @@ static int idx_test_and_fetch(const char *fn, const char **local_fn, int *local_
         }
 
         if (download) {
-            if ((local_fp = fopen(s.s, "w")) == 0) {
+            if ((local_fp = fopen(s.s, "wb")) == 0) {
                 hts_log_error("Failed to create file %s in the working directory", p);
                 goto fail;
             }
@@ -3641,7 +3641,7 @@ static hts_idx_t *idx_find_and_load(const char *fn, int fmt, int flags)
         }
         fn2[fnidx - fn] = '\0';
         fnidx += strlen(HTS_IDX_DELIM);
-        idx = hts_idx_load2(fn2, fnidx);
+        idx = hts_idx_load3(fn2, fnidx, fmt, flags);
         free(fn2);
         return idx;
     }

--- a/hts.c
+++ b/hts.c
@@ -3395,6 +3395,7 @@ static int idx_test_and_fetch(const char *fn, const char **local_fn, int *local_
             fclose(local_fp);
             free(s.s);
             *local_fn = p;
+            *local_len = e-p;
             return 0;
         }
 


### PR DESCRIPTION
Bug visible when trying to run `bcftools view "https://url1.gvcf.gz##idx##https://url2.gvcf.gz.tbi" 1:10000-10010`
The calling function `idx_filename` was receiving ret=0, but `local_len` wasn't set. As it was never initialized it randomly failed at the `memmove` operation.