### PR TITLE
Add support for remote reference files

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -3449,7 +3449,7 @@ static int idx_test_and_fetch(const char *fn, const char **local_fn, int *local_
             goto fail;
         }
         if (fmt.category != index_file || (fmt.format != bai &&  fmt.format != csi && fmt.format != tbi
-                && fmt.format != crai)) {
+                && fmt.format != crai && fmt.format != fai_format)) {
             hts_log_error("Format of index file '%s' is not supported", fn);
             goto fail;
         }
@@ -3531,6 +3531,7 @@ int hts_idx_check_local(const char *fn, int fmt, char **fnidx) {
     char *bai_ext = ".bai";
     char *tbi_ext = ".tbi";
     char *crai_ext = ".crai";
+    char *fai_ext = ".fai";
 
     if (!fn)
         return 0;
@@ -3626,6 +3627,13 @@ int hts_idx_check_local(const char *fn, int fmt, char **fnidx) {
                     break;
                 }
         }
+    } else if (fmt == HTS_FMT_FAI) { // Or .fai
+        strcpy(fnidx_tmp, fn_tmp); strcpy(fnidx_tmp + l_fn, fai_ext);
+        *fnidx = fnidx_tmp;
+        if(stat(fnidx_tmp, &sbuf) == 0)
+            return 1;
+        else
+            return 0;
     }
 
     free(fnidx_tmp);
@@ -3664,7 +3672,12 @@ static char *idx_filename(const char *fn, const char *ext, int download) {
 
 char *hts_idx_getfn(const char *fn, const char *ext)
 {
-    return idx_filename(fn, ext, 1);
+    return idx_filename(fn, ext, HTS_IDX_SAVE_REMOTE);
+}
+
+char *hts_idx_locatefn(const char *fn, const char *ext)
+{
+    return idx_filename(fn, ext, 0);
 }
 
 static hts_idx_t *idx_find_and_load(const char *fn, int fmt, int flags)

--- a/hts_internal.h
+++ b/hts_internal.h
@@ -58,6 +58,9 @@ int hts_idx_check_local(const char *fn, int fmt, char **fnidx);
 // Retrieve the name of the index file and also download it, if it is remote
 char *hts_idx_getfn(const char *fn, const char *ext);
 
+// Retrieve the name of the index file, but do not download it, if it is remote
+char *hts_idx_locatefn(const char *fn, const char *ext);
+
 // Used for on-the-fly indexing.  See the comments in hts.c.
 void hts_idx_amend_last(hts_idx_t *idx, uint64_t offset);
 

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -294,7 +294,7 @@ int faidx_seq_len(const faidx_t *fai, const char *seq);
     @param  beg   Returns the start of the region (0 based)
     @param  end   Returns the one past last of the region (0 based)
     @param  flags Parsing method, see HTS_PARSE_* in hts.h.
-    @return      pointer to end of parsed s if successs, NULL if not.
+    @return      pointer to end of parsed s if success, NULL if not.
 
     To work around ambiguous parsing issues, eg both "chr1" and "chr1:100-200"
     are reference names, quote using curly braces.
@@ -312,6 +312,19 @@ const char *fai_parse_region(const faidx_t *fai, const char *s,
 HTSLIB_EXPORT
 void fai_set_cache_size(faidx_t *fai, int cache_size);
 
+/// Determines the path to the reference index file
+/** @param  fa    String with the path to the reference file
+ *  @return       String with the path to the reference index file, or NULL on failure
+
+    If the reference path has the format reference.fa##idx##index.fa.fai,
+    the index path is taken directly from it as index.fa.fai.
+    If the reference file is local and the index file cannot be found, it
+    will be created alongside the reference file.
+    If the reference file is remote and the index file cannot be found,
+    the method returns NULL.
+
+    The returned string has to be freed by the user at the end of its scope.
+ */
 HTSLIB_EXPORT
 char *fai_path(const char *fa);
 #ifdef __cplusplus

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -312,6 +312,8 @@ const char *fai_parse_region(const faidx_t *fai, const char *s,
 HTSLIB_EXPORT
 void fai_set_cache_size(faidx_t *fai, int cache_size);
 
+HTSLIB_EXPORT
+char *fai_path(const char *fa);
 #ifdef __cplusplus
 }
 #endif

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -623,6 +623,7 @@ When REST or NONE is used, idx is also ignored and may be NULL.
 #define HTS_FMT_BAI 1
 #define HTS_FMT_TBI 2
 #define HTS_FMT_CRAI 3
+#define HTS_FMT_FAI 4
 
 // Almost INT64_MAX, but when cast into a 32-bit int it's
 // also INT_MAX instead of -1.  This avoids bugs with old code

--- a/sam.c
+++ b/sam.c
@@ -1420,7 +1420,14 @@ static sam_hdr_t *sam_hdr_create(htsFile* fp) {
 
     if (!has_SQ && fp->fn_aux) {
         kstring_t line = { 0, 0, NULL };
-        hFILE* f = hopen(fp->fn_aux, "r");
+
+        /* The reference index (.fai) is actually needed here */
+        char *fai_fn = fp->fn_aux;
+        char *fn_delim = strstr(fp->fn_aux, HTS_IDX_DELIM);
+        if (fn_delim)
+            fai_fn = fn_delim + strlen(HTS_IDX_DELIM);
+
+        hFILE* f = hopen(fai_fn, "r");
         int e = 0, absent;
         if (f == NULL)
             goto error;
@@ -1479,7 +1486,7 @@ static sam_hdr_t *sam_hdr_create(htsFile* fp) {
 
         ks_free(&line);
         if (hclose(f) != 0) {
-            hts_log_error("Error on closing %s", fp->fn_aux);
+            hts_log_error("Error on closing %s", fai_fn);
             e = 1;
         }
         if (e)


### PR DESCRIPTION
1. The new method `fai_path` takes the full path to a reference file (e.g. _prot://path/to/ref.fa_) and returns the path to a corresponding index file (e.g. _prot://path/to/ref.fa.fai_). 

    - If the index file is missing and the reference file is local, the index file is generated locally, in the same location as the reference.
    - If the reference file or index file is remote, neither will be downloaded locally.
    - If the reference file is remote and an index file cannot be located, **NULL** is returned and the user will see an error message.

2. The method `refs_load_fai` can now handle remote files, via `hFILE` pointers, and only tries to infer the name of the reference file starting from the index file, if a previous reference has not been provided (e.g. via `sam_open_format`).

3. **UR** tags in `@SQ` lines can now be set to remote URIs.

4. The reference file and the index file can now be provided as a single string argument, using the format **reference.fa##idx##index.fa.fai**. 