### PR TITLE
Make the iterator work with 64 bit positions

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -361,7 +361,7 @@ void cram_index_free(cram_fd *fd) {
  * Returns the cram_index pointer on success
  *         NULL on failure
  */
-cram_index *cram_index_query(cram_fd *fd, int refid, int pos,
+cram_index *cram_index_query(cram_fd *fd, int refid, hts_pos_t pos,
                              cram_index *from) {
     int i, j, k;
     cram_index *e;

--- a/cram/cram_index.h
+++ b/cram/cram_index.h
@@ -51,7 +51,7 @@ void cram_index_free(cram_fd *fd);
  * Returns the cram_index pointer on sucess
  *         NULL on failure
  */
-cram_index *cram_index_query(cram_fd *fd, int refid, int pos, cram_index *frm);
+cram_index *cram_index_query(cram_fd *fd, int refid, hts_pos_t pos, cram_index *frm);
 cram_index *cram_index_last(cram_fd *fd, int refid, cram_index *from);
 
 /*

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -675,7 +675,7 @@ typedef struct {
     int curr_tid, curr_reg, curr_intv;
     hts_pos_t curr_beg, curr_end;
     uint64_t curr_off, nocoor_off;
-    hts_pair64_max_t *off;
+    hts_pair64_t *off;
     hts_readrec_func *readrec;
     hts_seek_func *seek;
     hts_tell_func *tell;


### PR DESCRIPTION
Remove the usage of `hts_pair64_max_t::max`, as the same value is already contained in `hts_reglist_t::max_end`.
Remove references to `hts_pair64_max_t` type.