### PR TITLE
Prevent negative rlen on erroneous INFO/END when reading BCF

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -789,6 +789,14 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
      *  The @p string in bcf_update_info_flag() is optional,
      *  @p n indicates whether the flag is set or removed.
      *
+     *  Note that updating an END info tag will cause line->rlen to be
+     *  updated as a side-effect (removing the tag will set it to the
+     *  string length of the REF allele). If line->pos is being changed as
+     *  well, it is important that this is done before calling
+     *  bcf_update_info_int32() to update the END tag, otherwise rlen will be
+     *  set incorrectly.  If the new END value is less than or equal to
+     *  line->pos, a warning will be printed and line->rlen will be set to
+     *  the length of the REF allele.
      */
     #define bcf_update_info_int32(hdr,line,key,values,n)   bcf_update_info((hdr),(line),(key),(values),(n),BCF_HT_INT)
     #define bcf_update_info_float(hdr,line,key,values,n)   bcf_update_info((hdr),(line),(key),(values),(n),BCF_HT_REAL)

--- a/tbx.c
+++ b/tbx.c
@@ -141,7 +141,24 @@ int tbx_parse1(const tbx_conf_t *conf, int len, char *line, tbx_intv_t *intv)
                             s = strstr(line + b, ";END=");
                             if (s) s += 5;
                         }
-                        if (s) intv->end = strtoll(s, &s, 0);
+                        if (s && *s != '.') {
+                            long long end = strtoll(s, &s, 0);
+                            if (end <= intv->beg) {
+                                static int reported = 0;
+                                if (!reported) {
+                                    int l = intv->ss ? (int) (intv->se - intv->ss) : 0;
+                                    hts_log_warning("VCF INFO/END=%lld is smaller than POS at %.*s:%"PRIhts_pos"\n"
+                                                    "This tag will be ignored. "
+                                                    "Note: only one invalid END tag will be reported.",
+                                                    end, l >= 0 ? l : 0,
+                                                    intv->ss ? intv->ss : "",
+                                                    intv->beg);
+                                    reported = 1;
+                                }
+                            } else {
+                                intv->end = end;
+                            }
+                        }
                         line[i] = c;
                     }
                 }


### PR DESCRIPTION
This is an extension of ea879e19b8 which added checks for reading
VCF.

Resolves https://github.com/samtools/bcftools/issues/1154