### PR TITLE
Added bam_set_seqi function.

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -312,6 +312,13 @@ typedef struct {
  @return    4-bit integer representing the base.
  */
 #define bam_seqi(s, i) ((s)[(i)>>1] >> ((~(i)&1)<<2) & 0xf)
+/*!
+ @abstract  Modifies a single base in the bam structure.
+ @param s   Query sequence returned by bam_get_seq()
+ @param i   The i-th position, 0-based
+ @param b   Base in nt16 nomenclature (see seq_nt16_table)
+*/
+#define bam_set_seqi(s,i,b) ((s)[(i)>>1] = ((s)[(i)>>1] & (0xf0 >> ((~(i)&1)<<2))) | ((b)<<((~(i)&1)<<2)))
 
 /**************************
  *** Exported functions ***


### PR DESCRIPTION
This has been copied over from the samtools sort_minimiser PR.
For now this is a macro to keep the code style consistent with all the
other bam_* macros.

Ideally we'd use a static inline, but if so I think this is a second
PR (or second commit) that rewrites all these macro-functions so we
have some level of consistency in code style.