### PR TITLE
Fix integer overflow in cram_read_slice

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3852,9 +3852,9 @@ cram_slice *cram_read_slice(cram_fd *fd) {
     for (i = 0; i < n; i++) {
         if (s->block[i]->content_type != EXTERNAL)
             continue;
-        int v = s->block[i]->content_id;
-        if (v < 0 || v >= 256)
-            v = 256 + (v > 0 ? v % 251 : (-v) % 251);
+        uint32_t v = s->block[i]->content_id;
+        if (v >= 256)
+            v = 256 + v % 251;
         s->block_by_id[v] = s->block[i];
     }
 

--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -477,10 +477,11 @@ char *cram_content_type2str(enum cram_content_type t);
 
 static inline cram_block *cram_get_block_by_id(cram_slice *slice, int id) {
   //fprintf(stderr, "%d\t%p\n", id, slice->block_by_id);
-    if (slice->block_by_id && id >= 0 && id < 256) {
-        return slice->block_by_id[id];
+    uint32_t v = id;
+    if (slice->block_by_id && v < 256) {
+        return slice->block_by_id[v];
     } else {
-        int v = 256 + (id > 0 ? id % 251 : (-id) % 251);
+        v = 256 + v % 251;
         if (slice->block_by_id &&
             slice->block_by_id[v] &&
             slice->block_by_id[v]->content_id == id)


### PR DESCRIPTION
Occurs when block content_id is INT_MIN, which cannot be negated in an int.

Casting to uint32_t fixes the problem and allows checks for negative values to be eliminated.  Blocks with negative content_id will end up in different hash buckets, but that shouldn't matter as long as cram_get_block_by_id() is consistent with cram_read_slice().

Credit to OSS-Fuzz
Fixes oss-fuzz 20102