### PR TITLE
Write index fix

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -226,6 +226,40 @@ int bgzf_idx_push(BGZF *fp, hts_idx_t *hidx, int tid, hts_pos_t beg, hts_pos_t e
     return 0;
 }
 
+/*
+ * bgzf analogue to hts_idx_amend_last.
+ *
+ * This is needed when multi-threading and writing indices on the fly.
+ * At the point of writing a record we know the virtual offset for start
+ * and end, but that end virtual offset may be the end of the current
+ * block.  In standard indexing our end virtual offset becomes the start
+ * of the next block.  Thus to ensure bit for bit compatibility we
+ * detect this boundary case and fix it up here.
+ *
+ * In theory this has no behavioural change, but it also works around
+ * a bug elsewhere which causes bgzf_read to return 0 when our offset
+ * is the end of a block rather than the start of the next.
+ */
+void bgzf_idx_amend_last(BGZF *fp, hts_idx_t *hidx, uint64_t offset) {
+    mtaux_t *mt = fp->mt;
+    if (!mt) {
+        hts_idx_amend_last(hidx, offset);
+        return;
+    }
+
+    pthread_mutex_lock(&mt->idx_m);
+    hts_idx_cache_t *ic = &mt->idx_cache;
+    if (ic->nentries > 0) {
+        hts_idx_cache_entry *e = &ic->e[ic->nentries-1];
+        if ((offset & 0xffff) == 0 && e->offset != 0) {
+            // bumped to next block number
+            e->offset = 0;
+            e->block_number++;
+        }
+    }
+    pthread_mutex_unlock(&mt->idx_m);
+}
+
 static int bgzf_idx_flush(BGZF *fp) {
     mtaux_t *mt = fp->mt;
 

--- a/hts_internal.h
+++ b/hts_internal.h
@@ -108,6 +108,18 @@ void close_plugin(void *plugin);
  */
 int bgzf_idx_push(BGZF *fp, hts_idx_t *hidx, int tid, hts_pos_t beg, hts_pos_t end, uint64_t offset, int is_mapped);
 
+/*
+ * bgzf analogue to hts_idx_amend_last.
+ *
+ * This is needed when multi-threading and writing indices on the fly.
+ * At the point of writing a record we know the virtual offset for start
+ * and end, but that end virtual offset may be the end of the current
+ * block.  In standard indexing our end virtual offset becomes the start
+ * of the next block.  Thus to ensure bit for bit compatibility we
+ * detect this boundary case and fix it up here.
+ */
+void bgzf_idx_amend_last(BGZF *fp, hts_idx_t *hidx, uint64_t offset);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sam.c
+++ b/sam.c
@@ -740,6 +740,8 @@ static int bam_write_idx1(htsFile *fp, const sam_hdr_t *h, const bam1_t *b) {
         return -1;
     if (!bfp->mt)
         hts_idx_amend_last(fp->idx, bgzf_tell(bfp));
+    else
+        bgzf_idx_amend_last(bfp, fp->idx, bgzf_tell(bfp));
 
     int ret = bam_write1(bfp, b);
     if (ret < 0)


### PR DESCRIPTION
Fixes samtools/samtools#1197

Fixes the bug which caused the auto-indexing (--write-index) code to produce different output when multi-threaded.  The difference being whether a BGZF virtual offset is the first byte of the next block or points to the end of the previous block.  Hence we'll no longer produce indices like this which gives data compatibility with older samtools releases.

Also fixed the bug which caused usual offsets pointing to the end of a block to be misinterpreted as hitting EOF in the bgzf file.  This gives compatibility with reading indices produced using multi-threaded auto-indexing using samtools 1.10.