### PR TITLE
Define HTSLIB_EXPORT without using a helper macro

### DIFF
--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -97,18 +97,16 @@ DEALINGS IN THE SOFTWARE.  */
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #if defined(HTS_BUILDING_LIBRARY)
-#define HTS_DLL_EXPORT __declspec(dllexport)
+#define HTSLIB_EXPORT __declspec(dllexport)
 #else
-#define HTS_DLL_EXPORT
+#define HTSLIB_EXPORT
 #endif
 #elif HTS_COMPILER_HAS(__visibility__) || HTS_GCC_AT_LEAST(4,0)
-#define HTS_DLL_EXPORT __attribute__((__visibility__("default")))
+#define HTSLIB_EXPORT __attribute__((__visibility__("default")))
 #elif defined(__SUNPRO_C) && __SUNPRO_C >= 0x550
-#define HTS_DLL_EXPORT __global
+#define HTSLIB_EXPORT __global
 #else
-#define HTS_DLL_EXPORT
+#define HTSLIB_EXPORT
 #endif
-
-#define HTSLIB_EXPORT HTS_DLL_EXPORT
 
 #endif

--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -96,7 +96,11 @@ DEALINGS IN THE SOFTWARE.  */
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(HTS_BUILDING_LIBRARY)
 #define HTS_DLL_EXPORT __declspec(dllexport)
+#else
+#define HTS_DLL_EXPORT
+#endif
 #elif HTS_COMPILER_HAS(__visibility__) || HTS_GCC_AT_LEAST(4,0)
 #define HTS_DLL_EXPORT __attribute__((__visibility__("default")))
 #elif defined(__SUNPRO_C) && __SUNPRO_C >= 0x550
@@ -105,10 +109,6 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_DLL_EXPORT
 #endif
 
-#if !(defined(_WIN32) || defined(__CYGWIN__)) || defined(HTS_BUILDING_LIBRARY)
 #define HTSLIB_EXPORT HTS_DLL_EXPORT
-#else
-#define HTSLIB_EXPORT
-#endif
 
 #endif


### PR DESCRIPTION
Assuming that it's not the intention for `HTS_DLL_EXPORT` to be independently useful, this PR removes it and defines `HTSLIB_EXPORT` directly instead. This improves #1013 a bit, as there's only one macro to print out spuriously rather than two — see the discussion on that issue.

You may wish to squash this when merging, but it's presented as two commits because the individual diffs are understandable but the combined diff less so.