### PR TITLE
Adds linear index support

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -464,6 +464,26 @@ cram_index *cram_index_last(cram_fd *fd, int refid, cram_index *from) {
     return &from->e[slice];
 }
 
+cram_index *cram_index_query_last(cram_fd *fd, int refid, hts_pos_t end) {
+    cram_index *first = cram_index_query(fd, refid, end, NULL);
+    cram_index *last =  cram_index_last(fd, refid, NULL);
+    if (!first || !last)
+        return NULL;
+
+    while (first < last && (first+1)->start <= end)
+        first++;
+
+    while (first->e) {
+        int count = 0;
+        int nslices = first->nslice;
+        first = first->e;
+        while (++count < nslices && (first+1)->start <= end)
+            first++;
+    }
+
+    return first;
+}
+
 /*
  * Skips to a container overlapping the start coordinate listed in
  * cram_range.

--- a/cram/cram_index.h
+++ b/cram/cram_index.h
@@ -53,6 +53,7 @@ void cram_index_free(cram_fd *fd);
  */
 cram_index *cram_index_query(cram_fd *fd, int refid, hts_pos_t pos, cram_index *frm);
 cram_index *cram_index_last(cram_fd *fd, int refid, cram_index *from);
+cram_index *cram_index_query_last(cram_fd *fd, int refid, hts_pos_t end);
 
 /*
  * Skips to a container overlapping the start coordinate listed in

--- a/hts.c
+++ b/hts.c
@@ -2746,7 +2746,7 @@ int hts_itr_multi_cram(const hts_idx_t *idx, hts_itr_t *iter)
                     if (end >= HTS_POS_MAX) {
                        e = cram_index_last(cidx->cram, tid, NULL);
                     } else {
-                       e = cram_index_query(cidx->cram, tid, end+1, NULL);
+                       e = cram_index_query_last(cidx->cram, tid, end+1);
                     }
 
                     if (e) {

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -678,7 +678,7 @@ typedef struct {
     int curr_tid, curr_reg, curr_intv;
     hts_pos_t curr_beg, curr_end;
     uint64_t curr_off, nocoor_off;
-    hts_pair64_t *off;
+    hts_pair64_max_t *off;
     hts_readrec_func *readrec;
     hts_seek_func *seek;
     hts_tell_func *tell;


### PR DESCRIPTION
- Adds BAI linear index support for standard iterators.  This uses a bit more memory as it doesn't discard the BAI linear index, but permits it to be used for optimising range queries.  The effect is minimal on deep data, but profound on shallow.

- Also adds BAI linear index support for multi-region iterators.  This is harder and requires some rather ghastly hacks to avoid changing the ABI.  It's possible there are better methods using the off[] array, but this is rather complex and therefore liable to be error prone given the substantial disconnect between intervals and offsets, which can be many to many and also include partial overlaps - not to mention also being in potentially different orders.

- Finally fixes a pre-existing bug on multi-region iterators for CRAM where it could terminate early and omit records.

Benchmarks, from the first commit message for normal iterator:

    Indexer     Branch   Time(s) BAM I/O(Mb)  Idx I/O(Mb)
    -----------------------------------------------------
    htslib-BAI  develop  1.488   164.1        2.43
    htsjdk-BAI  develop  0.502    53.6        8.27
    htslib-BAI  this     0.498    53.5        2.43
    htsjdk-BAI  this     0.530    53.3        8.27
    htslib-CSI  this     1.532   163.3        0.49

For multi-region iterator (NB many more regions included in this test):

    Indexer     Branch   Time(s) BAM I/O(Mb)  Idx I/O(Mb)
    -----------------------------------------------------
    htslib-BAI  develop  15.184  1397.0       2.43
    htslib-BAI  this      2.991   305.2       2.43

It looks stark, but remember this is due to shallow data - around 2x coverage.  For deep data the difference is minimal.
