### PR TITLE
[fuzz] Free allocated SN strings when encountering an error

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -1345,7 +1345,7 @@ static sam_hdr_t *sam_hdr_create(htsFile* fp) {
                     }
                     sn = (char*)calloc(r - q + 1, 1);
                     if (!sn)
-                    goto error;
+                        goto error;
 
                     strncpy(sn, q, r - q);
                     q = r;
@@ -1532,6 +1532,10 @@ static sam_hdr_t *sam_hdr_create(htsFile* fp) {
     return fp->bam_header;
 
  error:
+    if (h && d && (!h->target_name || !h->target_len)) {
+        for (k = kh_begin(d); k != kh_end(d); ++k)
+            if (kh_exist(d, k)) free((void *)kh_key(d, k));
+    }
     sam_hdr_destroy(h);
     ks_free(&str);
     kh_destroy(s2i, d);


### PR DESCRIPTION
Upon successful completion of `sam_hdr_create`, ownership of the newly created **SN** strings is given to `sam_hdr_t::target_name`, which takes care of freeing them at the end. But if an error occurs, the handover might fail and the allocated strings are missed by the clean-up routines. 

Credit to OSS-Fuzz
Fixes oss-fuzz 20888