### PR TITLE
Improve SAM writing speed by ~30%

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -45,6 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cram/cram.h"
 #include "cram/os.h"
+#include "sam_internal.h" // for nibble2base
 #include "htslib/hts.h"
 #include "htslib/hts_endian.h"
 
@@ -2679,44 +2680,6 @@ static cram_container *cram_next_container(cram_fd *fd, bam_seq_t *b) {
     c->n_mapped = 0;
 
     return c;
-}
-
-/*
- * Convert a nibble encoded BAM sequence to a string of bases.
- *
- * We do this 2 bp at a time for speed. Equiv to:
- *
- * for (i = 0; i < len; i++)
- *    seq[i] = seq_nt16_str[bam_seqi(nib, i)];
- */
-static void nibble2base(uint8_t *nib, char *seq, int len) {
-    static const char code2base[512] =
-        "===A=C=M=G=R=S=V=T=W=Y=H=K=D=B=N"
-        "A=AAACAMAGARASAVATAWAYAHAKADABAN"
-        "C=CACCCMCGCRCSCVCTCWCYCHCKCDCBCN"
-        "M=MAMCMMMGMRMSMVMTMWMYMHMKMDMBMN"
-        "G=GAGCGMGGGRGSGVGTGWGYGHGKGDGBGN"
-        "R=RARCRMRGRRRSRVRTRWRYRHRKRDRBRN"
-        "S=SASCSMSGSRSSSVSTSWSYSHSKSDSBSN"
-        "V=VAVCVMVGVRVSVVVTVWVYVHVKVDVBVN"
-        "T=TATCTMTGTRTSTVTTTWTYTHTKTDTBTN"
-        "W=WAWCWMWGWRWSWVWTWWWYWHWKWDWBWN"
-        "Y=YAYCYMYGYRYSYVYTYWYYYHYKYDYBYN"
-        "H=HAHCHMHGHRHSHVHTHWHYHHHKHDHBHN"
-        "K=KAKCKMKGKRKSKVKTKWKYKHKKKDKBKN"
-        "D=DADCDMDGDRDSDVDTDWDYDHDKDDDBDN"
-        "B=BABCBMBGBRBSBVBTBWBYBHBKBDBBBN"
-        "N=NANCNMNGNRNSNVNTNWNYNHNKNDNBNN";
-
-    int i, len2 = len/2;
-    seq[0] = 0;
-
-    for (i = 0; i < len2; i++)
-        // Note size_t cast helps gcc optimiser.
-        memcpy(&seq[i*2], &code2base[(size_t)nib[i]*2], 2);
-
-    if ((i *= 2) < len)
-        seq[i] = seq_nt16_str[bam_seqi(nib, i)];
 }
 
 /*


### PR DESCRIPTION
1. Use the same two bytes at a time approach (seq2nibble) already used
   in CRAM for sequence.

2. Ensure the quality c = s+33 statement doesn't trigger any type
   aliasing rules, permitting SIMD usage.

Benchmarks on 10 million NovaSeq records, reading from uncompressed
BAM (bgzf wrapped):

```
Read only: ./test/test_view -B /tmp/u.bam
        8993715174      cycles                    #    3.541 GHz
       18985281221      instructions              #    2.11  insn per cycle
       2.540721616 seconds time elapsed

Read + write SAM (develop):
       21910087899      cycles                    #    3.566 GHz
       55089448827      instructions              #    2.51  insn per cycle
       6.144628857 seconds time elapsed

Read + write SAM (this commit):
       18882595700      cycles                    #    3.558 GHz
       42301339830      instructions              #    2.24  insn per cycle
       5.308875782 seconds time elapsed
```