### PR TITLE
Add more error checking to the tabix application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ tabix: tabix.o libhts.a
 
 bgzip.o: bgzip.c config.h $(htslib_bgzf_h) $(htslib_hts_h)
 htsfile.o: htsfile.c config.h $(htslib_hfile_h) $(htslib_hts_h) $(htslib_sam_h) $(htslib_vcf_h)
-tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_regidx_h)
+tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_regidx_h) $(htslib_hts_defs_h)
 
 # Maintainer source code checks
 # - copyright boilerplate presence

--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,7 @@ tabix: tabix.o libhts.a
 
 bgzip.o: bgzip.c config.h $(htslib_bgzf_h) $(htslib_hts_h)
 htsfile.o: htsfile.c config.h $(htslib_hfile_h) $(htslib_hts_h) $(htslib_sam_h) $(htslib_vcf_h)
-tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_regidx_h) $(htslib_hts_defs_h)
+tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_regidx_h) $(htslib_hts_defs_h) $(htslib_hts_log_h)
 
 # Maintainer source code checks
 # - copyright boilerplate presence

--- a/tabix.1
+++ b/tabix.1
@@ -138,6 +138,13 @@ but the entire input will be read sequentially and regions not listed in FILE wi
 .TP
 .BI "-D "
 Do not download the index file before opening it. Valid for remote files only.
+.TP
+.BI "--verbosity " INT
+Set verbosity of logging messages printed to stderr.
+The default is 3, which turns on error and warning messages;
+2 reduces warning messages;
+1 prints only error messages and 0 is mostly silent.
+Values higher than 3 produce additional informational and debugging messages.
 .PP
 .SH EXAMPLE
 (grep ^"#" in.gff; grep -v ^"#" in.gff | sort -k1,1 -k4,4n) | bgzip > sorted.gff.gz;

--- a/tabix.c
+++ b/tabix.c
@@ -42,6 +42,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/hts.h"
 #include "htslib/regidx.h"
 #include "htslib/hts_defs.h"
+#include "htslib/hts_log.h"
 
 typedef struct
 {
@@ -455,6 +456,7 @@ static int usage(FILE *fp, int status)
     fprintf(fp, "   -R, --regions FILE         restrict to regions listed in the file\n");
     fprintf(fp, "   -T, --targets FILE         similar to -R but streams rather than index-jumps\n");
     fprintf(fp, "   -D                         do not download the index file\n");
+    fprintf(fp, "       --verbosity INT        set verbosity [3]\n");
     fprintf(fp, "\n");
     return status;
 }
@@ -487,6 +489,7 @@ int main(int argc, char *argv[])
         {"list-chroms", no_argument, NULL, 'l'},
         {"reheader", required_argument, NULL, 'r'},
         {"version", no_argument, NULL, 1},
+        {"verbosity", required_argument, NULL, 3},
         {NULL, 0, NULL, 0}
     };
 
@@ -549,6 +552,12 @@ int main(int argc, char *argv[])
                 return EXIT_SUCCESS;
             case 2:
                 return usage(stdout, EXIT_SUCCESS);
+            case 3: {
+                int v = atoi(optarg);
+                if (v < 0) v = 0;
+                hts_set_log_level(v);
+                break;
+            }
             default: return usage(stderr, EXIT_FAILURE);
         }
     }


### PR DESCRIPTION
Check for error returns from bcf_itr_next(), hts_getline() and tbx_itr_next() so failures can be reported properly.

Add checks in other places that could fail, mostly memory allocations and writes to the output file.

Note that bcf_itr_querys() and tbx_itr_querys() return NULL for both general failures and those caused by the requested region not being present.  As tabix silently skips missing regions, it is currently not possible to detect errors in these functions.