### PR TITLE
Add crypt4gh file detection

### DIFF
--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -204,6 +204,7 @@ enum htsExactFormat {
     json HTS_DEPRECATED_ENUM("Use htsExactFormat 'htsget' instead") = htsget,
     empty_format,  // File is empty (or empty after decompression)
     fasta_format, fastq_format, fai_format, fqi_format,
+    hts_crypt4gh_format,
     format_maximum = 32767
 };
 


### PR DESCRIPTION
Adds format detection for crypt4gh files (see https://samtools.github.io/hts-specs/crypt4gh.pdf).

If hts_hopen() finds a crypt4gh file, it will try to re-open it via the hfile_crypt4gh() plug-in.  Detection occurs at the same point as htsget, so it does both in a loop to allow for crypt4gh served via htsget.

Actual decryption of the file requires an external plug-in, available from [samtools/htslib-crypt4gh](https://github.com/samtools/htslib-crypt4gh). As this may not be present, a dummy handler is included that prints an error message indicating that it is needed.  This is overridden by the real one when it is available.