### PR TITLE
Prevent a double free in case of failure

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -3441,7 +3441,6 @@ static int idx_test_and_fetch(const char *fn, const char **local_fn, int *local_
 {
     hFILE *remote_hfp;
     FILE *local_fp = NULL;
-    uint8_t *buf = NULL;
     int save_errno;
     htsFormat fmt;
     kstring_t s = KS_INITIALIZE;
@@ -3490,7 +3489,7 @@ static int idx_test_and_fetch(const char *fn, const char **local_fn, int *local_
                 goto fail;
             }
             hts_log_info("Downloading file %s to local directory", fn);
-            buf = (uint8_t*)calloc(buf_size, 1);
+            uint8_t *buf = (uint8_t*)calloc(buf_size, 1);
             if (!buf) {
                 hts_log_error("%s", strerror(errno));
                 goto fail;
@@ -3540,7 +3539,6 @@ static int idx_test_and_fetch(const char *fn, const char **local_fn, int *local_
     save_errno = errno;
     hclose_abruptly(remote_hfp);
     if (local_fp) fclose(local_fp);
-    free(buf);
     free(s.s);
     errno = save_errno;
     return -2;


### PR DESCRIPTION
Move the `free` call after the error checking.

Fixes #1033 