### PR TITLE
Removed gcc9 warning in kroundup.

### DIFF
--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -38,18 +38,30 @@
 #include "hts_defs.h"
 
 #ifndef kroundup32
-#define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x),(x)=(x)?(x):(uint32_t)-1)
+#define kroundup32(x) ((x)<INT_MAX                                      \
+  ? (--(x),                                                             \
+     (x)|=(x)>>1,                                                       \
+     (x)|=(x)>>2,                                                       \
+     (x)|=(x)>>4,                                                       \
+     (x)|=(x)>>8,                                                       \
+     (x)|=(x)>>16,                                                      \
+     ++(x))                                                             \
+  : ((x)=UINT_MAX))
 #endif
 
 #ifndef kroundup_size_t
-#define kroundup_size_t(x) (--(x),                                       \
-                            (x)|=(x)>>(sizeof(size_t)/8), /*  0 or  1 */ \
-                            (x)|=(x)>>(sizeof(size_t)/4), /*  1 or  2 */ \
-                            (x)|=(x)>>(sizeof(size_t)/2), /*  2 or  4 */ \
-                            (x)|=(x)>>(sizeof(size_t)),   /*  4 or  8 */ \
-                            (x)|=(x)>>(sizeof(size_t)*2), /*  8 or 16 */ \
-                            (x)|=(x)>>(sizeof(size_t)*4), /* 16 or 32 */ \
-                            ++(x),(x)=(x)?(x):(size_t)-1)
+// Equiv to SSIZE_MAX
+#define SIZE_OVERFLOW (((size_t)-1)   - (((size_t)-1)>>1))
+
+#define kroundup_size_t(x) (((x) < SIZE_OVERFLOW)                       \
+    ? (--(x),                                                           \
+       (x)|=(x)>>(sizeof(size_t)/8), /*  0 or  1 */                     \
+       (x)|=(x)>>(sizeof(size_t)/4), /*  1 or  2 */                     \
+       (x)|=(x)>>(sizeof(size_t)/2), /*  2 or  4 */                     \
+       (x)|=(x)>>(sizeof(size_t)),   /*  4 or  8 */                     \
+       (x)|=(x)>>(sizeof(size_t)*2), /*  8 or 16 */                     \
+       (x)|=(x)>>(sizeof(size_t)*4), /* 16 or 32 */                     \
+       ++(x)) : (x) /*don't round up*/)
 #endif
 
 #if defined __GNUC__ && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4))


### PR DESCRIPTION
The (size_t)-1 cap to avoid roundup overflows sometimes triggers a new gcc warning (eg in samtools bam_fastq.c).  Given getting to this point is almost always an error somewhere else, we take the alternative strategy of not rounding up instead.

This said, I believe the roundup strategy is fundamentally poor anyway.  Rather than doubling we'd be better off with a lower power, eg roundup(x) being (x+10)*1.5  or similar, with appropriate bracketing and bounds checks etc.  This is almost certainly less code, more frugal on memory, and realistically not going to be a major issue for memory pools either as the number of reallocs and memmoves still isn't vast.  (It's ~70% more, but probably more of those will be the same pointer instead of a new alloc and move.)