### PR TITLE
Report more BGZF errors

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -958,6 +958,9 @@ int bgzf_read_block(BGZF *fp)
 
         if (j->errcode) {
             fp->errcode = j->errcode;
+            hts_log_error("BGZF decode jobs returned error %d "
+                          "for block offset %"PRId64,
+                          j->errcode, j->block_address);
             return -1;
         }
 
@@ -1025,6 +1028,9 @@ int bgzf_read_block(BGZF *fp)
         count = hread(fp->fp, fp->uncompressed_block, BGZF_MAX_BLOCK_SIZE);
         if (count < 0)  // Error
         {
+            hts_log_error("Failed to read uncompressed data "
+                          "at offset %"PRId64"%s%s",
+                          block_address, errno ? ": " : "", strerror(errno));
             fp->errcode |= BGZF_ERR_IO;
             return -1;
         }
@@ -1045,6 +1051,8 @@ int bgzf_read_block(BGZF *fp)
         count = inflate_gzip_block(fp);
         if ( count<0 )
         {
+            hts_log_error("Reading GZIP stream failed at offset %"PRId64,
+                          block_address);
             fp->errcode |= BGZF_ERR_ZLIB;
             return -1;
         }
@@ -1066,10 +1074,13 @@ int bgzf_read_block(BGZF *fp)
             fp->block_length = 0;
             return 0;
         }
-        int ret;
+        int ret = 0;
         if ( count != sizeof(header) || (ret=check_header(header))==-2 )
         {
             fp->errcode |= BGZF_ERR_HEADER;
+            hts_log_error("%s BGZF header at offset %"PRId64,
+                          ret ? "Invalid" : "Failed to read",
+                          block_address);
             return -1;
         }
         if ( ret==-1 )
@@ -1094,6 +1105,8 @@ int bgzf_read_block(BGZF *fp)
             count = inflate_gzip_block(fp);
             if ( count<0 )
             {
+                hts_log_error("Reading GZIP stream failed at offset %"PRId64,
+                              block_address);
                 fp->errcode |= BGZF_ERR_ZLIB;
                 return -1;
             }
@@ -1106,6 +1119,8 @@ int bgzf_read_block(BGZF *fp)
         block_length = unpackInt16((uint8_t*)&header[16]) + 1; // +1 because when writing this number, we used "-1"
         if (block_length < BLOCK_HEADER_LENGTH)
         {
+            hts_log_error("Invalid BGZF block length at offset %"PRId64,
+                          block_address);
             fp->errcode |= BGZF_ERR_HEADER;
             return -1;
         }
@@ -1114,17 +1129,23 @@ int bgzf_read_block(BGZF *fp)
         remaining = block_length - BLOCK_HEADER_LENGTH;
         count = hread(fp->fp, &compressed_block[BLOCK_HEADER_LENGTH], remaining);
         if (count != remaining) {
+            hts_log_error("Failed to read BGZF block data at offset %"PRId64
+                          " expected %d bytes; hread returned %d",
+                          block_address, remaining, count);
             fp->errcode |= BGZF_ERR_IO;
             return -1;
         }
         size += count;
         if ((count = inflate_block(fp, block_length)) < 0) {
-            hts_log_debug("Inflate block operation failed: %s", bgzf_zerr(count, NULL));
+            hts_log_debug("Inflate block operation failed for "
+                          "block at offset %"PRId64": %s",
+                          block_address, bgzf_zerr(count, NULL));
             fp->errcode |= BGZF_ERR_ZLIB;
             return -1;
         }
         fp->last_block_eof = (count == 0);
         if ( count ) break;     // otherwise an empty bgzf block
+        block_address = bgzf_htell(fp); // update for new block start
     }
     if (fp->block_length != 0) fp->block_offset = 0; // Do not reset offset if this read follows a seek.
     fp->block_address = block_address;

--- a/tabix.c
+++ b/tabix.c
@@ -74,6 +74,8 @@ HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) static void error_errno(const char *format, ...
     }
     if (eno) {
         fprintf(stderr, "%s%s\n", format ? ": " : "", strerror(eno));
+    } else {
+        fprintf(stderr, "\n");
     }
     fflush(stderr);
     exit(EXIT_FAILURE);


### PR DESCRIPTION
* Make `bgzf_read_block()` print more error messages, including the offset of the BGZF block where it failed.

Note that this introduces a small change of behaviour as block_address is now updated after an empty block has been read.  This may change the location stored in indexes of files with empty blocks.

* Make `hts_itr_next()` return an error on seek failure.

The return code needs to be less that -1, or the caller will incorrectly interpret it as end of data, causing it to silently finish too early.

* Fix missing newline in tabix error messages.