### PR TITLE
Add tabix --cache option; make bgzf cache work better with hfile_libcurl

### DIFF
--- a/tabix.1
+++ b/tabix.1
@@ -139,6 +139,14 @@ but the entire input will be read sequentially and regions not listed in FILE wi
 .BI "-D "
 Do not download the index file before opening it. Valid for remote files only.
 .TP
+.BI "--cache " INT
+Set the BGZF block cache size to INT megabytes. [10]
+
+This is of most benefit when the
+.B -R
+option is used, which can cause blocks to be read more than once.
+Setting the size to 0 will disable the cache.
+.TP
 .BI "--verbosity " INT
 Set verbosity of logging messages printed to stderr.
 The default is 3, which turns on error and warning messages;


### PR DESCRIPTION
First commit adds a `--cache` option to tabix, set by default to a reasonably modest value (10 Megs; enough for at least 160 BGZF blocks).  This will mainly have an effect with the `-R` option, which can cause blocks to be accessed repeatedly, especially when the requested regions are close together.

The second attempts to reduce the number of backward seeks made by `hfile_libcurl` when the cache is in use.  Each seek causes a new web request to start, so they can be quite expensive and are best avoided.  Commit ad2e24f was an earlier fix that stopped a new request from happening on every single BGZF cache hit, however it wasn't a complete fix as `hseek()` [can discard a small amount of data](https://github.com/samtools/htslib/blob/0bff7c1/hfile.c#L472) from the hFILE buffer.  If this data is needed later, `hfile_libcurl` is forced to request it from the server again.

The solution to the backward seeks is to make `libcurl_seek()` store a copy of the data that would otherwise be lost.  Should the data be needed again, `libcurl_read()` can provide it from the copy without needing to contact the server.  Once the cached data has been used up, the original web connection can carry on providing data from where it was before the first `hseek()`.

(I do have another version of this that uses the data stored in the existing hFILE buffer instead of copying it.  While it avoids the need to copy the data to a new location, it relies on `hfile_libcurl` knowing quite a lot about the internal operations of `hFILE`.  The solution here seemed rather less fragile, and is less likely to cause problems if we want to make changes to `hFILE` in the future).