### PR TITLE
Minor improvements and public header cleansing

### DIFF
--- a/bcf_sr_sort.c
+++ b/bcf_sr_sort.c
@@ -25,6 +25,7 @@
 #define HTS_BUILDING_LIBRARY // Enables HTSLIB_EXPORT, see htslib/hts_defs.h
 #include <config.h>
 
+#include <assert.h>
 #include <strings.h>
 
 #include "bcf_sr_sort.h"

--- a/bgzf.c
+++ b/bgzf.c
@@ -2186,11 +2186,7 @@ int bgzf_getline(BGZF *fp, int delim, kstring_t *str)
         for (l = fp->block_offset; l < fp->block_length && buf[l] != delim; ++l);
         if (l < fp->block_length) state = 1;
         l -= fp->block_offset;
-        if (str->l + l + 1 >= str->m) {
-            str->m = str->l + l + 2;
-            kroundup32(str->m);
-            str->s = (char*)realloc(str->s, str->m);
-        }
+        if (ks_expand(str, l + 2) < 0) { state = -3; break; }
         memcpy(str->s + str->l, buf + fp->block_offset, l);
         str->l += l;
         fp->block_offset += l + 1;

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -31,7 +31,6 @@
 #define HTSLIB_BGZF_H
 
 #include <stdint.h>
-#include <stdio.h>
 #include <sys/types.h>
 
 #include "hts_defs.h"

--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -25,7 +25,9 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef HTSLIB_HTS_DEFS_H
 #define HTSLIB_HTS_DEFS_H
 
+#if defined __MINGW32__
 #include <stdio.h>     // For __MINGW_PRINTF_FORMAT macro
+#endif
 
 #ifdef __clang__
 #ifdef __has_attribute

--- a/htslib/kseq.h
+++ b/htslib/kseq.h
@@ -119,11 +119,7 @@
 				for (i = ks->begin; i < ks->end; ++i) \
 					if (isspace(ks->buf[i]) && ks->buf[i] != ' ') break;  \
 			} else i = 0; /* never come to here! */ \
-			if (str->m - str->l < (size_t)(i - ks->begin + 1)) { \
-				str->m = str->l + (i - ks->begin) + 1; \
-				kroundup32(str->m); \
-				str->s = (char*)realloc(str->s, str->m); \
-			} \
+			(void) ks_expand(str, i - ks->begin + 1); \
             seek_pos += i - ks->begin; if ( i < ks->end ) seek_pos++; \
 			gotany = 1; \
 			memcpy(str->s + str->l, ks->buf + ks->begin, i - ks->begin);  \

--- a/htslib/regidx.h
+++ b/htslib/regidx.h
@@ -64,8 +64,6 @@
 #ifndef HTSLIB_REGIDX_H
 #define HTSLIB_REGIDX_H
 
-#include <stdio.h>
-#include <inttypes.h>
 #include "hts.h"
 
 #ifdef __cplusplus

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -35,7 +35,6 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <stdint.h>
 #include <limits.h>
-#include <assert.h>
 #include <errno.h>
 #include "hts.h"
 #include "kstring.h"

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_BUILDING_LIBRARY // Enables HTSLIB_EXPORT, see htslib/hts_defs.h
 #include <config.h>
 
+#include <assert.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <string.h>

--- a/tabix.c
+++ b/tabix.c
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <config.h>
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/vcf_sweep.c
+++ b/vcf_sweep.c
@@ -25,6 +25,8 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_BUILDING_LIBRARY // Enables HTSLIB_EXPORT, see htslib/hts_defs.h
 #include <config.h>
 
+#include <assert.h>
+
 #include "htslib/vcf_sweep.h"
 #include "htslib/bgzf.h"
 


### PR DESCRIPTION
A couple of stacked up trivialities:

* Use the newly-available `ks_expand()` to avoid kstring-related explicit `kroundup32+realloc` calls

* Tidy up inclusions of standard C headers from the public _htslib/*.h_ headers — in particular don't include `<assert.h>` from any public headers. (Verified that current samtools and bcftools still build after this change.)