### PR TITLE
[header API] Link a new PG line only to valid chains

### DIFF
--- a/header.c
+++ b/header.c
@@ -2049,7 +2049,7 @@ static int sam_hdr_link_pg(sam_hdr_t *bh) {
         hrecs = bh->hrecs;
     }
 
-    if (!hrecs->pgs_changed)
+    if (!hrecs->pgs_changed || !hrecs->npg)
         return 0;
 
     hrecs->npg_end_alloc = hrecs->npg;
@@ -2057,6 +2057,9 @@ static int sam_hdr_link_pg(sam_hdr_t *bh) {
     if (!new_pg_end)
         return -1;
     hrecs->pg_end = new_pg_end;
+    int *chain_size = calloc(hrecs->npg, sizeof(int));
+    if (!chain_size)
+        return -1;
 
     for (i = 0; i < hrecs->npg; i++)
         hrecs->pg_end[i] = i;
@@ -2084,18 +2087,26 @@ static int sam_hdr_link_pg(sam_hdr_t *bh) {
 
         hrecs->pg[i].prev_id = hrecs->pg[kh_val(hrecs->pg_hash, k)].id;
         hrecs->pg_end[kh_val(hrecs->pg_hash, k)] = -1;
+        chain_size[i] = chain_size[kh_val(hrecs->pg_hash, k)]+1;
     }
 
     for (i = j = 0; i < hrecs->npg; i++) {
-        if (hrecs->pg_end[i] != -1)
+        if (hrecs->pg_end[i] != -1 && chain_size[i] > 0)
             hrecs->pg_end[j++] = hrecs->pg_end[i];
     }
+    /* Only leafs? Choose the last one! */
+    if (!j && hrecs->npg_end > 0) {
+        hrecs->pg_end[0] = hrecs->pg_end[hrecs->npg_end-1];
+        j = 1;
+    }
+
     hrecs->npg_end = j;
     hrecs->pgs_changed = 0;
 
     /* mark as dirty or empty for rebuild */
     hrecs->dirty = 1;
     redact_header_text(bh);
+    free(chain_size);
 
     return ret;
 }
@@ -2168,6 +2179,12 @@ int sam_hdr_add_pg(sam_hdr_t *bh, const char *name, ...) {
         if (sam_hdr_fill_hrecs(bh) != 0)
             return -1;
         hrecs = bh->hrecs;
+    }
+
+    bh->hrecs->pgs_changed = 1;
+    if (sam_hdr_link_pg(bh) < 0) {
+        hts_log_error("Error linking @PG lines");
+        return -1;
     }
 
     va_list args;

--- a/test/sam.c
+++ b/test/sam.c
@@ -908,7 +908,8 @@ static void test_header_pg_lines(void) {
     hts_set_log_level(old_log_level);
     // End failing tests
 
-    if (strcmp(text, expected) != 0) {
+    text = sam_hdr_str(header);
+    if (!text || strcmp(text, expected) != 0) {
         fail("edited header does not match expected version");
         fprintf(stderr,
                 "---------- Expected:\n%s\n"


### PR DESCRIPTION
1. The length of PG chains is now computed and only chains with at least two PG lines are considered valid candidates for further extension.
2. PG linkage is redone before adding a new PG line.

Fixes https://github.com/samtools/samtools/issues/1235