### PR TITLE
Fix the multi-threaded CRAM multi-region iterator regression.

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -481,6 +481,34 @@ cram_index *cram_index_query_last(cram_fd *fd, int refid, hts_pos_t end) {
             first++;
     }
 
+    // Compute the start location of next container.
+    //
+    // This is useful for stitching containers together in the multi-region
+    // iterator.  Sadly we can't compute this from the single index line.
+    //
+    // Note we can have neighbouring index entries at the same location
+    // for when we have multi-reference mode and/or multiple slices per
+    // container.
+    cram_index *next = first;
+    do {
+        if (next >= last) {
+            // Next non-empty reference
+            while (++refid+1 < fd->index_sz)
+                if (fd->index[refid+1].nslice)
+                    break;
+            if (refid+1 >= fd->index_sz) {
+                next = NULL;
+            } else {
+                next = fd->index[refid+1].e;
+                last = fd->index[refid+1].e + fd->index[refid+1].nslice;
+            }
+        } else {
+            next++;
+        }
+    } while (next && next->offset == first->offset);
+
+    first->next = next ? next->offset : 0;
+
     return first;
 }
 

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -663,6 +663,7 @@ typedef struct cram_index {
     int     slice;  // 1.0 landmark index, 1.1 landmark value
     int     len;    //                     1.1 - size of slice in bytes
     int64_t offset; // 1.0                 1.1
+    int64_t next;   // derived: offset of next container.
 } cram_index;
 
 typedef struct {

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -297,6 +297,7 @@ enum hts_fmt_option {
     CRAM_OPT_BASES_PER_SLICE,
     CRAM_OPT_STORE_MD,
     CRAM_OPT_STORE_NM,
+    CRAM_OPT_RANGE_NOSEEK, // CRAM_OPT_RANGE minus the seek
 
     // General purpose
     HTS_OPT_COMPRESSION_LEVEL = 100,

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -662,6 +662,45 @@ typedef int hts_readrec_func(BGZF *fp, void *data, void *r, int *tid, hts_pos_t 
 typedef int hts_seek_func(void *fp, int64_t offset, int where);
 typedef int64_t hts_tell_func(void *fp);
 
+/**
+ * @brief File iterator that can handle multiple target regions.
+ * This structure should be considered opaque by end users.
+ * It does both the stepping inside the file and the filtering of alignments.
+ * It can operate in single or multi-region mode, and depending on this,
+ * it uses different fields.
+ *
+ * read_rest (1) - read everything from the current offset, without filtering
+ * finished  (1) - no more iterations
+ * is_cram   (1) - current file has CRAM format
+ * nocoor    (1) - read all unmapped reads
+ *
+ * multi     (1) - multi-region moode
+ * reg_list  - List of target regions
+ * n_reg     - Size of the above list
+ * curr_reg  - List index of the current region of search
+ * curr_intv - Interval index inside the current region; points to a (beg, end)
+ * end       - Used for CRAM files, to preserve the max end coordinate
+ *
+ * multi     (0) - single-region mode
+ * tid       - Reference id of the target region
+ * beg       - Start position of the target region
+ * end       - End position of the target region
+ *
+ * Common fields:
+ * off        - List of file offsets computed from the index
+ * n_off      - Size of the above list
+ * i          - List index of the current file offset
+ * curr_off   - File offset for the next file read
+ * curr_tid   - Reference id of the current alignment
+ * curr_beg   - Start position of the current alignment
+ * curr_end   - End position of the current alignment
+ * nocoor_off - File offset where the unmapped reads start
+ *
+ * readrec    - File specific function that reads an alignment
+ * seek       - File specific function for changing the file offset
+ * tell       - File specific function for indicating the file offset
+ */
+
 typedef struct {
     uint32_t read_rest:1, finished:1, is_cram:1, nocoor:1, multi:1, dummy:27;
     int tid, n_off, i, n_reg;


### PR DESCRIPTION
Fixes #1061

This appears to have been introduced during bfc9f0d and fixed for BAM only in 6149ea6.  The effect on multi-threading decoding for CRAM was significant.

This fix takes a totally different approach, which not only fixes the regression but passes it.  CRAM can do CRAM_OPT_RANGE queries, used by the single version of the iterator, which informs the decode of both start and end range positions.  When threading this means we don't preemptively decode the next container unless it'll actually be used. This same logic is now used in the multi-region iterator, although it's complex.

The general strategy is as follows:

- Ensure we know the next container start from index.  This needs a small tweak to cram_index struct as the next container isn't quite the same as this container + slice offset + slice size (sadly).  I think it's missing the size of the container struct itself.

- When being given a start..end offset, step into the reg_list to find the corresponding chr:start-end range.

- Produce a new CRAM_OPT_RANGE_NOSEEK option that does the same job as the old CRAM_OPT_RANGE opt but without the seek.  This is necessary hts.c does the seek for us and the pseek/ptell only work with each other and not within the cram subdir code itself).

- Identify neighbouring file offsets and merge together their correponding ranges so a block of adjacent offsets becomes a single CRAM_OPT_RANGE query.  We cache the end offset (.v) in iter->end so we can avoid duplicating the seek / range request in subsequent intervals.

- Manage the EOF vs EOR (end of range) return values.  For EOR we have do the incrementing ourselves as we need to restart the loop without triggering the end-of-file or end-of-multi-iterator logic below it.

- Tweak the region sorting a bit so ties are resolved by the max value.  We want the index into reg_list to also be sorted, so we can accurately step through them.  Note this logic is CRAM specific, as the sorting wouldn't work on BAI anyway due to the R-tree.

Some benchmarks on ~37,000 regions returning ~110 million seqs across NA06985.final.cram:

```
CRAM-1.10 no threads:  real  4m37.361s   user  4m21.128s   sys  0m7.988s
CRAM-1.10 -@16:        real  3m14.371s   user 28m48.872s   sys  4m52.442s
CRAM-dev -@16:         real  5m55.670s   user 61m0.005s    sys 11m23.147s
CRAM-current -@16:     real  1m55.701s   user  5m54.234s   sys  0m51.699s
```

The increase in user time between unthreaded and 16 threads is modest. System time increase is considerable, but this appears to primarily be down to glibc malloc inefficiencies.  Using libtcmalloc.so instead gives:
```
1M CRAM-current -@16:  real  1m30.882s   user  6m9.103s    sys  0m4.960s
```
We're still nowhere near using 16 threads, but this is because the average size of each region is significantly smaller than 16 containers worth.