### PR TITLE
Collected minor issues: warning fixes, buglets

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -1906,7 +1906,7 @@ int hts_idx_push(hts_idx_t *idx, int tid, hts_pos_t beg, hts_pos_t end, uint64_t
         hts_log_error("Unsorted positions on sequence #%d: %"PRIhts_pos" followed by %"PRIhts_pos, tid+1, idx->z.last_coor+1, beg+1);
         return -1;
     }
-    else if (end < beg) {
+    if (end < beg) {
         // Malformed ranges are errors. (Empty ranges (beg==end) are unusual but acceptable.)
         hts_log_error("Invalid record on sequence #%d: end %"PRId64" < begin %"PRId64, tid+1, end, beg+1);
         return -1;

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -267,8 +267,9 @@ hwrite(hFILE *fp, const void *buffer, size_t nbytes)
     extern ssize_t hwrite2(hFILE *, const void *, size_t, size_t);
     extern int hfile_set_blksize(hFILE *fp, size_t bufsiz);
 
-    if(!fp->mobile){
-        if (fp->limit - fp->begin < nbytes){
+    if (!fp->mobile) {
+        size_t n = fp->limit - fp->begin;
+        if (n < nbytes) {
             hfile_set_blksize(fp, fp->limit - fp->buffer + nbytes);
             fp->end = fp->limit;
         }

--- a/htslib/hts_endian.h
+++ b/htslib/hts_endian.h
@@ -242,7 +242,7 @@ static inline int16_t le_to_i16(const uint8_t *buf) {
  */
 static inline int32_t le_to_i32(const uint8_t *buf) {
     uint32_t v = le_to_u32(buf);
-    return v < 0x80000000U ? v : -((int32_t) (0xffffffffU - v)) - 1;
+    return v < 0x80000000U ? (int32_t) v : -((int32_t) (0xffffffffU - v)) - 1;
 }
 
 /// Get an int64_t value from an unsigned byte array
@@ -254,7 +254,7 @@ static inline int32_t le_to_i32(const uint8_t *buf) {
 static inline int64_t le_to_i64(const uint8_t *buf) {
     uint64_t v = le_to_u64(buf);
     return (v < 0x8000000000000000ULL
-            ? v : -((int64_t) (0xffffffffffffffffULL - v)) - 1);
+            ? (int64_t) v : -((int64_t) (0xffffffffffffffffULL - v)) - 1);
 }
 
 // Converting the other way is easier as signed -> unsigned is well defined.


### PR DESCRIPTION
More collected minor items:

* Fix a buglet in the #917 check: this should be tested even if this is the first read on a new chromosome.

* Fix `-Wextra` warnings emanating from the public _htslib/*.h_ headers:

```
$ gcc-9 -c -Wall -Wextra includeall.c
In file included from includeall.c:4:
htslib/hfile.h: In function 'hwrite':
htslib/hfile.h:271:35: warning: comparison of integer expressions of different signedness: 'long int' and 'size_t' {aka 'long unsigned int'} [-Wsign-compare]
  271 |         if (fp->limit - fp->begin < nbytes){
      |                                   ^
In file included from includeall.c:7:
htslib/hts_endian.h: In function 'le_to_i32':
htslib/hts_endian.h:245:34: warning: operand of ?: changes signedness from 'int' to 'uint32_t' {aka 'unsigned int'} due to unsignedness of other operand [-Wsign-compare]
  245 |     return v < 0x80000000U ? v : -((int32_t) (0xffffffffU - v)) - 1;
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
htslib/hts_endian.h: In function 'le_to_i64':
htslib/hts_endian.h:257:19: warning: operand of ?: changes signedness from 'long long int' to 'uint64_t' {aka 'long long unsigned int'} due to unsignedness of other operand [-Wsign-compare]
  257 |             ? v : -((int64_t) (0xffffffffffffffffULL - v)) - 1);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

(Clang only spots the _hfile.h_ one. The _hts_endian.h_ ones appear to be another instance of dc3303b6da542f74c965b3f3f50a58776f87104b and in fact there's another instance without the cast in `safe_itf8_get()` in _cram/cram_io.h_ that probably needs it too.)
