### PR TITLE
Link plugins against libhts.so/.dylib and fix dynamically unloading HTSlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ shlib-exports-*.txt
 /test/hts_endian
 /test/longrefs/*.tmp.*
 /test/pileup
+/test/plugins-dlhts
 /test/sam
 /test/tabix/*.tmp.*
 /test/tabix/FAIL*

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
     if test "$USE_CONFIG" = "yes"; then
       MAKE_OPTS= ;
       autoreconf && \
-        eval ./configure --enable-werror $CONFIG_OPTS CFLAGS=\"-g -O3 $CFLAGS\" || \
+        eval ./configure --enable-plugins --enable-werror $CONFIG_OPTS CFLAGS=\"-g -O3 $CFLAGS\" || \
         ( cat config.log; false )
     else
       MAKE_OPTS=-e

--- a/configure.ac
+++ b/configure.ac
@@ -179,8 +179,8 @@ AC_CHECK_FUNCS([gmtime_r fsync drand48 srand48_deterministic])
 AC_CHECK_DECL([fdatasync(int)], [AC_CHECK_FUNCS(fdatasync)])
 
 if test $enable_plugins != no; then
-  AC_SEARCH_LIBS([dlopen], [dl], [],
-    [MSG_ERROR([dlopen() not found
+  AC_SEARCH_LIBS([dlsym], [dl], [],
+    [MSG_ERROR([dlsym() not found
 
 Plugin support requires dynamic linking facilities from the operating system.
 Either configure with --disable-plugins or resolve this error to build HTSlib.])])
@@ -190,8 +190,8 @@ Either configure with --disable-plugins or resolve this error to build HTSlib.])
   AS_IF([test x"$rdynamic_flag" != "xno"],
     [LDFLAGS="$LDFLAGS $rdynamic_flag"
      static_LDFLAGS="$static_LDFLAGS $rdynamic_flag"])
-  case "$ac_cv_search_dlopen" in
-    -l*) static_LIBS="$static_LIBS $ac_cv_search_dlopen" ;;
+  case "$ac_cv_search_dlsym" in
+    -l*) static_LIBS="$static_LIBS $ac_cv_search_dlsym" ;;
   esac
   AC_DEFINE([ENABLE_PLUGINS], 1, [Define if HTSlib should enable plugins.])
   AC_SUBST([PLUGIN_EXT])

--- a/hfile.c
+++ b/hfile.c
@@ -923,7 +923,7 @@ struct hFILE_plugin_list {
 static struct hFILE_plugin_list *plugins = NULL;
 static pthread_mutex_t plugins_lock = PTHREAD_MUTEX_INITIALIZER;
 
-void hfile_shutdown()
+void hfile_shutdown(int do_close_plugin)
 {
     pthread_mutex_lock(&plugins_lock);
 
@@ -936,7 +936,7 @@ void hfile_shutdown()
         struct hFILE_plugin_list *p = plugins;
         if (p->plugin.destroy) p->plugin.destroy();
 #ifdef ENABLE_PLUGINS
-        if (p->plugin.obj) close_plugin(p->plugin.obj);
+        if (p->plugin.obj && do_close_plugin) close_plugin(p->plugin.obj);
 #endif
         plugins = p->next;
         free(p);
@@ -947,7 +947,7 @@ void hfile_shutdown()
 
 static void hfile_exit()
 {
-    hfile_shutdown();
+    hfile_shutdown(0);
     pthread_mutex_destroy(&plugins_lock);
 }
 

--- a/hfile.c
+++ b/hfile.c
@@ -923,11 +923,14 @@ struct hFILE_plugin_list {
 static struct hFILE_plugin_list *plugins = NULL;
 static pthread_mutex_t plugins_lock = PTHREAD_MUTEX_INITIALIZER;
 
-static void hfile_exit()
+void hfile_shutdown()
 {
     pthread_mutex_lock(&plugins_lock);
 
-    kh_destroy(scheme_string, schemes);
+    if (schemes) {
+        kh_destroy(scheme_string, schemes);
+        schemes = NULL;
+    }
 
     while (plugins != NULL) {
         struct hFILE_plugin_list *p = plugins;
@@ -940,6 +943,11 @@ static void hfile_exit()
     }
 
     pthread_mutex_unlock(&plugins_lock);
+}
+
+static void hfile_exit()
+{
+    hfile_shutdown();
     pthread_mutex_destroy(&plugins_lock);
 }
 

--- a/hfile_internal.h
+++ b/hfile_internal.h
@@ -60,7 +60,7 @@ struct hFILE *bgzf_hfile(struct BGZF *fp);
 /*!
   @abstract Closes all hFILE plugins that have been loaded
 */
-void hfile_shutdown(void);
+void hfile_shutdown(int do_close_plugin);
 
 struct hFILE_backend {
     /* As per read(2), returning the number of bytes read (possibly 0) or

--- a/hfile_internal.h
+++ b/hfile_internal.h
@@ -57,6 +57,11 @@ struct BGZF;
  */
 struct hFILE *bgzf_hfile(struct BGZF *fp);
 
+/*!
+  @abstract Closes all hFILE plugins that have been loaded
+*/
+void hfile_shutdown(void);
+
 struct hFILE_backend {
     /* As per read(2), returning the number of bytes read (possibly 0) or
        negative (and setting errno) on errors.  Front-end code will call this

--- a/hts.c
+++ b/hts.c
@@ -3996,6 +3996,11 @@ int hts_resize_array_(size_t item_size, size_t num, size_t size_sz,
     return 0;
 }
 
+void hts_lib_shutdown()
+{
+    hfile_shutdown();
+}
+
 void hts_free(void *ptr) {
     free(ptr);
 }

--- a/hts.c
+++ b/hts.c
@@ -3998,7 +3998,7 @@ int hts_resize_array_(size_t item_size, size_t num, size_t size_sz,
 
 void hts_lib_shutdown()
 {
-    hfile_shutdown();
+    hfile_shutdown(1);
 }
 
 void hts_free(void *ptr) {

--- a/hts_internal.h
+++ b/hts_internal.h
@@ -95,8 +95,10 @@ void hts_path_itr_setup(struct hts_path_itr *itr, const char *path,
 
 const char *hts_path_itr_next(struct hts_path_itr *itr);
 
-void *load_plugin(void **pluginp, const char *filename, const char *symbol);
+typedef void plugin_void_func(void);
+plugin_void_func *load_plugin(void **pluginp, const char *filename, const char *symbol);
 void *plugin_sym(void *plugin, const char *name, const char **errmsg);
+plugin_void_func *plugin_func(void *plugin, const char *name, const char **errmsg);
 void close_plugin(void *plugin);
 
 /*

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -161,6 +161,16 @@ int hts_resize_array_(size_t, size_t, size_t, void *, void **, int,
                          (void **)(ptr), (flags), __func__) \
      : 0)
 
+/// Release resources when dlclosing a dynamically loaded HTSlib
+/** @discussion
+ *  Normally HTSlib cleans up automatically when your program exits,
+ *  whether that is via exit(3) or returning from main(). However if you
+ *  have dlopen(3)ed HTSlib and wish to close it before your main program
+ *  exits, you must call hts_lib_shutdown() before dlclose(3).
+*/
+HTSLIB_EXPORT
+void hts_lib_shutdown(void);
+
 /**
  * Wrapper function for free(). Enables memory deallocation across DLL
  * boundary. Should be used by all applications, which are compiled

--- a/test/plugins-dlhts.c
+++ b/test/plugins-dlhts.c
@@ -1,0 +1,157 @@
+/*  test/plugins-dlhts.c -- Test plugins with dynamically loaded libhts.
+
+    Copyright (C) 2020 University of Glasgow.
+
+    Author: John Marshall <John.W.Marshall@glasgow.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#if defined _WIN32 || defined __CYGWIN__ || defined __MSYS__
+#define SKIP "running on Windows"
+#elif !defined ENABLE_PLUGINS
+#define SKIP "plugins being disabled"
+#endif
+
+#ifndef SKIP
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <string.h>
+
+#ifndef EPROTONOSUPPORT
+#define EPROTONOSUPPORT ENOSYS
+#endif
+
+void *sym(void *htslib, const char *name)
+{
+    void *ptr = dlsym(htslib, name);
+    if (ptr == NULL) {
+        fprintf(stderr, "Can't find symbol \"%s\": %s\n", name, dlerror());
+        exit(EXIT_FAILURE);
+    }
+    return ptr;
+}
+
+int errors = 0;
+int verbose = 0;
+
+struct hFILE;
+typedef struct hFILE *hopen_func(const char *fname, const char *mode, ...);
+typedef void hclose_abruptly_func(struct hFILE *fp);
+
+hopen_func *hopen_p;
+hclose_abruptly_func *hclose_abruptly_p;
+
+void test_hopen(const char *fname, int expected)
+{
+    struct hFILE *fp = hopen_p(fname, "r");
+    if (fp) {
+        hclose_abruptly_p(fp);
+        fprintf(stderr, "Opening \"%s\" actually succeeded\n", fname);
+        errors++;
+        return;
+    }
+
+    int supported = (errno != EPROTONOSUPPORT);
+    if (supported != expected) {
+        fprintf(stderr, "Opening \"%s\" failed badly: %s\n", fname, strerror(errno));
+        errors++;
+    }
+    else if (verbose)
+        printf("Opening \"%s\" produces %s\n", fname, strerror(errno));
+}
+
+int main(int argc, char **argv)
+{
+    int dlflags = RTLD_NOW;
+    int c;
+
+    while ((c = getopt(argc, argv, "glv")) >= 0)
+        switch (c) {
+        case 'g': dlflags |= RTLD_GLOBAL; break;
+        case 'l': dlflags |= RTLD_LOCAL;  break;
+        case 'v': verbose++; break;
+        }
+
+    if (optind >= argc) {
+        fprintf(stderr, "Usage: plugins-dlhts [-glv] LIBHTSFILE\n");
+        return EXIT_FAILURE;
+    }
+
+    void *htslib = dlopen(argv[optind], dlflags);
+    if (htslib == NULL) {
+        fprintf(stderr, "Can't dlopen \"%s\": %s\n", argv[optind], dlerror());
+        return EXIT_FAILURE;
+    }
+
+    if (verbose) {
+        int *hts_verbosep = sym(htslib, "hts_verbose");
+        *hts_verbosep += verbose;
+
+        typedef const char *cstr_func(void);
+        printf("Loaded HTSlib %s\n", ((cstr_func *) sym(htslib, "hts_version"))());
+    }
+
+    hopen_p = (hopen_func *) sym(htslib, "hopen");
+    hclose_abruptly_p = (hclose_abruptly_func *) sym(htslib, "hclose_abruptly");
+
+    test_hopen("bad-scheme:unsupported", 0);
+#ifdef HAVE_LIBCURL
+    test_hopen("https://localhost:99999/invalid_port", 1);
+#endif
+#ifdef ENABLE_GCS
+    test_hopen("gs:invalid", 1);
+#endif
+#ifdef ENABLE_S3
+    test_hopen("s3:invalid", 1);
+#endif
+
+    typedef void void_func(void);
+    ((void_func *) sym(htslib, "hts_lib_shutdown"))();
+
+    if (dlclose(htslib) < 0) {
+        fprintf(stderr, "Can't dlclose \"%s\": %s\n", argv[optind], dlerror());
+        errors++;
+    }
+
+    if (errors > 0) {
+        printf("FAILED: %d errors\n", errors);
+        return EXIT_FAILURE;
+    }
+
+    if (verbose) printf("All tests passed\n");
+    return EXIT_SUCCESS;
+}
+
+#else
+
+int main()
+{
+    printf("Tests skipped due to " SKIP "\n");
+    return EXIT_SUCCESS;
+}
+
+#endif

--- a/test/plugins-dlhts.c
+++ b/test/plugins-dlhts.c
@@ -91,6 +91,13 @@ void test_hopen(const char *fname, int expected)
         printf("Opening \"%s\" produces %s\n", fname, strerror(errno));
 }
 
+void verbose_log(const char *message)
+{
+    fflush(stderr);
+    if (verbose) puts(message);
+    fflush(stdout);
+}
+
 int main(int argc, char **argv)
 {
     int dlflags = RTLD_NOW;
@@ -136,12 +143,16 @@ int main(int argc, char **argv)
     test_hopen("s3:invalid", 1);
 #endif
 
+    verbose_log("Calling hts_lib_shutdown()");
     (func(htslib, "hts_lib_shutdown"))();
 
+    verbose_log("Calling dlclose(htslib)");
     if (dlclose(htslib) < 0) {
         fprintf(stderr, "Can't dlclose \"%s\": %s\n", argv[optind], dlerror());
         errors++;
     }
+
+    verbose_log("Returning from main()");
 
     if (errors > 0) {
         printf("FAILED: %d errors\n", errors);

--- a/test/plugins-dlhts.c
+++ b/test/plugins-dlhts.c
@@ -55,6 +55,13 @@ void *sym(void *htslib, const char *name)
     return ptr;
 }
 
+typedef void void_func(void);
+void_func *func(void *htslib, const char *name) {
+    void_func *fptr;
+    *(void **) &fptr = sym(htslib, name);
+    return fptr;
+}
+
 int errors = 0;
 int verbose = 0;
 
@@ -112,11 +119,11 @@ int main(int argc, char **argv)
         *hts_verbosep += verbose;
 
         typedef const char *cstr_func(void);
-        printf("Loaded HTSlib %s\n", ((cstr_func *) sym(htslib, "hts_version"))());
+        printf("Loaded HTSlib %s\n", ((cstr_func *) func(htslib, "hts_version"))());
     }
 
-    hopen_p = (hopen_func *) sym(htslib, "hopen");
-    hclose_abruptly_p = (hclose_abruptly_func *) sym(htslib, "hclose_abruptly");
+    hopen_p = (hopen_func *) func(htslib, "hopen");
+    hclose_abruptly_p = (hclose_abruptly_func *) func(htslib, "hclose_abruptly");
 
     test_hopen("bad-scheme:unsupported", 0);
 #ifdef HAVE_LIBCURL
@@ -129,8 +136,7 @@ int main(int argc, char **argv)
     test_hopen("s3:invalid", 1);
 #endif
 
-    typedef void void_func(void);
-    ((void_func *) sym(htslib, "hts_lib_shutdown"))();
+    (func(htslib, "hts_lib_shutdown"))();
 
     if (dlclose(htslib) < 0) {
         fprintf(stderr, "Can't dlclose \"%s\": %s\n", argv[optind], dlerror());

--- a/test/with-shlib.sh
+++ b/test/with-shlib.sh
@@ -1,0 +1,65 @@
+#!/bin/sh -e
+# test/with-shlib.sh -- make shared libhts available via $LD_LIBRARY_PATH etc.
+#
+#    Copyright (C) 2020 University of Glasgow.
+#
+#    Author: John Marshall <John.W.Marshall@glasgow.ac.uk>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+libdir=${0%/*}/libdir-$$.tmp
+case $libdir in
+/*) abslibdir=$libdir ;;
+*)  abslibdir=$PWD/$libdir ;;
+esac
+
+# Create a directory containing *only* the shared libhts, and add it
+# to the platform-appropriate $LD_LIBRARY_PATH environment variable.
+
+mkdir $libdir
+
+case `uname -s` in
+Darwin)
+    (cd $libdir; ln -s ../../libhts.*.dylib .)
+    export DYLD_LIBRARY_PATH=$abslibdir${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}
+    ;;
+
+*CYGWIN*)
+    (cd $libdir; ln -s ../../cyghts-*.dll .)
+    export PATH="$abslibdir${PATH:+;$PATH}"
+    ;;
+
+*MSYS*|*MINGW*)
+    (cd $libdir; cp -p ../../hts-*.dll .)
+    export PATH="$abslibdir${PATH:+;$PATH}"
+    ;;
+
+*)
+    (cd $libdir; ln -s ../../libhts.so.* .)
+    export LD_LIBRARY_PATH=$abslibdir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+    ;;
+esac
+
+status=0
+"$@" || status=$?
+
+rm $libdir/*hts*
+rmdir $libdir
+
+exit $status


### PR DESCRIPTION
Previously I was trying to avoid linking the `hfile_*.so` plugins back to `libhts`, probably mainly because I didn't want arbitrary numbers of libhtses in the address space at once — but of course `dlopen`'s reference counting prevents any such weirdness. Other reasons for not linking them to _libhts.so/.dylib/etc_ are:

* Avoiding plugins being tied to a particular libhts SOVERSION
* Especially if your main program (e.g. samtools) has libhts.a statically linked, avoiding needing to dynamically link to libhts at all and so avoiding needing to set `$LD_LIBRARY_PATH` or rpath or etc so that you can find libhts.so/.dylib

But there is a very good reason **for** linking them to _libhts.so_:

* Making programs that dynamically load libhts with the default `dlopen` flags on Linux able to use htslib plugins at all

Who on earth dynamically loads libhts? Language bindings.

Notably Python loads Cython modules with default `dlopen` flags, so this enables pysam on Linux to use remote file access plugins. Which is a pretty big win.

----

Also a new test program _test/plugins-dlhts_ that exercises this. This program `dlopen()`s htslib, accesses a few dummy files, and `dlclose()`s htslib. Which led to a segfault. The other half of this commit fixes the segfault, by adding a `hts_lib_shutdown()` function that must be called if you want to `dlclose(htslib)` prior to general program exit. See the commit message for details.

As this is the first htslib test that tests things linked to the shared library, we need to set `$LD_LIBRARY_PATH` etc so that the freshly-built _libhts.so/.dylib/etc_ is used. This commit also adds _test/with-shlib.sh_, a script that creates a suitable temporary libdir containing **only** the freshly-built shared libhts.