### PR TITLE
Improve SAM parser unrecognised RNAME warnings

### DIFF
--- a/textutils_internal.h
+++ b/textutils_internal.h
@@ -171,6 +171,21 @@ static inline int isxdigit_c(char c) { return isxdigit((unsigned char) c); }
 static inline char tolower_c(char c) { return tolower((unsigned char) c); }
 static inline char toupper_c(char c) { return toupper((unsigned char) c); }
 
+/// Copy possibly malicious text data to a buffer
+/** @param buf     Destination buffer
+    @param buflen  Size of the destination buffer (>= 4; >= 6 when quotes used)
+    @param quote   Quote character (or '\0' for no quoting of the output)
+    @param s       String to be copied
+    @param len     Length of the input string, or SIZE_MAX to copy until '\0'
+    @return The destination buffer, @a buf.
+
+Copies the source text string (escaping any unprintable characters) to the
+destination buffer. The destination buffer will always be NUL-terminated;
+the text will be truncated (and "..." appended) if necessary to make it fit.
+ */
+const char *hts_strprint(char *buf, size_t buflen, char quote,
+                         const char *s, size_t len);
+
 // Faster replacements for strtol, for use when parsing lots of numbers.
 // Note that these only handle base 10 and do not skip leading whitespace
 

--- a/vcf.c
+++ b/vcf.c
@@ -79,25 +79,6 @@ static bcf_idinfo_t bcf_idinfo_def = { .info = { 15, 15, 15 }, .hrec = { NULL, N
 #define BCF_IS_64BIT (1<<30)
 
 
-static const char *dump_char(char *buffer, char c)
-{
-    switch (c) {
-    case '\n': strcpy(buffer, "\\n"); break;
-    case '\r': strcpy(buffer, "\\r"); break;
-    case '\t': strcpy(buffer, "\\t"); break;
-    case '\'':
-    case '\"':
-    case '\\':
-        sprintf(buffer, "\\%c", c);
-        break;
-    default:
-        if (isprint_c(c)) sprintf(buffer, "%c", c);
-        else sprintf(buffer, "\\x%02X", (unsigned char) c);
-        break;
-    }
-    return buffer;
-}
-
 static char *find_chrom_header_line(char *s)
 {
     char *nl;
@@ -2481,8 +2462,9 @@ static int vcf_parse_format(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v, char *p
             }
             else {
                 char buffer[8];
-                hts_log_error("Invalid character '%s' in '%s' FORMAT field at %s:%"PRIhts_pos"",
-                    dump_char(buffer, *t), h->id[BCF_DT_ID][z->key].key, bcf_seqname_safe(h,v), v->pos+1);
+                hts_log_error("Invalid character %s in '%s' FORMAT field at %s:%"PRIhts_pos"",
+                    hts_strprint(buffer, sizeof buffer, '\'', t, 1),
+                    h->id[BCF_DT_ID][z->key].key, bcf_seqname_safe(h,v), v->pos+1);
                 v->errcode |= BCF_ERR_CHAR;
                 return -1;
             }


### PR DESCRIPTION
Dusting off another minor branch from a few months ago… This addresses most of the small warning improvements noted in passing on samtools/samtools#1158:

> There is room for improvement in the warning: it could give an indication of the line number in question and/or print out the problematic contig name (carefully, as this is potentially adversarial input); and there is a buglet (`s/tid/mtid/`) nearby (and a typo in the message).

To print out the contig name, the PR adds a hopefully armour-plated `hts_strprint()` utility function which formats user-supplied text truncated to a sensible length and with unprintable characters escaped. This may be helpful for printing out adversarial input elsewhere in htslib. Added some tests (which pass plain `valgrind`) to _test/test_str2int.c_ as it exercises other functions in _textutils_internal.h_ but they might be better somewhere less misleadingly named… :smile: