### PR TITLE
Allow multiple bcf readers without index

### DIFF
--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -38,7 +38,7 @@ DEALINGS IN THE SOFTWARE.  */
 
         bcf_srs_t *sr = bcf_sr_init();
         bcf_sr_set_opt(sr, BCF_SR_PAIR_LOGIC, BCF_SR_PAIR_BOTH_REF);
-        bcf_sr_set_opt(sr, BCF_SR_REQUIRE_IDX);
+        bcf_sr_set_opt(sr, BCF_SR_REQUIRE_IDX_THROW);
         for (i=0; i<nfiles; i++)
             bcf_sr_add_reader(sr,files[i]);
         while ( bcf_sr_next_line(sr) )
@@ -92,9 +92,13 @@ extern "C" {
 #define BCF_SR_PAIR_BOTH       (BCF_SR_PAIR_SNPS|BCF_SR_PAIR_INDELS)
 #define BCF_SR_PAIR_BOTH_REF   (BCF_SR_PAIR_SNPS|BCF_SR_PAIR_INDELS|BCF_SR_PAIR_SNP_REF|BCF_SR_PAIR_INDEL_REF)
 
+#define BSF_SR_REQUIRE_INDEX_THROW 1  // Error when using multiple readers without indexes (default)
+#define BSF_SR_REQUIRE_INDEX_WARN  2  // Warn and proceed
+
 typedef enum
 {
-    BCF_SR_REQUIRE_IDX,
+    BCF_SR_REQUIRE_IDX_THROW,
+    BCF_SR_REQUIRE_IDX_WARN,
     BCF_SR_PAIR_LOGIC       // combination of the PAIR_* values above
 }
 bcf_sr_opt_t;

--- a/test/test-bcf-sr.c
+++ b/test/test-bcf-sr.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
 
     bcf_srs_t *sr = bcf_sr_init();
     bcf_sr_set_opt(sr, BCF_SR_PAIR_LOGIC, pair);
-    bcf_sr_set_opt(sr, BCF_SR_REQUIRE_IDX);
+    bcf_sr_set_opt(sr, BCF_SR_REQUIRE_IDX_THROW);
     for (i=0; i<nvcf; i++)
         if ( !bcf_sr_add_reader(sr,vcf[i]) ) error("Failed to open %s: %s\n", vcf[i],bcf_sr_strerror(sr->errnum));
 


### PR DESCRIPTION
This adds logic allowing htslib to warn, instead of throw, when using multiple bcf readers without an index. The default is to throw.

This is will allow bcftools, when lightly modified, to merge multiple VCFs without requiring indexes. This is useful for cases where `bcftools view` commands have been used to create subsampled VCFs for multiple levels of data access.

The above situation is currently present for some users in the [BioData CATALYST](https://biodatacatalyst.nhlbi.nih.gov/) project, a consortium project involve the Broad institute, the Universty of Chicago, The University of California Santa Cruz, and others. Large multisample VCFs are available in cloud buckets without indexes. Currently there is no straightforward way to use bcftools to merge these files without first indexing them, even though they are known to be aligned.

There was already an [abortive attempt to bring this functionality to samtools](https://github.com/samtools/htslib/pull/203). At that time the samtools developers seemed open to the implementation proposed in this PR, but unfortunately the work never went forward.