### PR TITLE
Ensure HTSlib prefers its own headers when being compiled

### DIFF
--- a/cram/cram.h
+++ b/cram/cram.h
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CRAM_ALL_H
 
 #include "cram_samtools.h"
-#include "header.h"
+#include "../header.h"
 #include "cram_structs.h"
 #include "cram_io.h"
 #include "cram_encode.h"

--- a/cram/cram.h
+++ b/cram/cram.h
@@ -56,6 +56,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // This contains duplicated portions from cram_io.h and cram_structs.h,
 // so we want to ensure that the prototypes match.
-#include "htslib/cram.h"
+#include "../htslib/cram.h"
 
 #endif

--- a/cram/cram.h
+++ b/cram/cram.h
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef CRAM_ALL_H
 #define CRAM_ALL_H
 
-#include "cram/cram_samtools.h"
+#include "cram_samtools.h"
 #include "header.h"
 #include "cram_structs.h"
 #include "cram_io.h"

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <errno.h>
 
-#include "cram/cram.h"
+#include "cram.h"
 
 /*
  * ---------------------------------------------------------------------------

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cram/cram.h"
 #include "cram/os.h"
-#include "htslib/hts.h"
+#include "../htslib/hts.h"
 
 //Whether CIGAR has just M or uses = and X to indicate match and mismatch
 //#define USE_X

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -48,8 +48,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <inttypes.h>
 
-#include "cram/cram.h"
-#include "cram/os.h"
+#include "cram.h"
+#include "os.h"
 #include "../htslib/hts.h"
 
 //Whether CIGAR has just M or uses = and X to indicate match and mismatch

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cram.h"
 #include "os.h"
-#include "sam_internal.h" // for nibble2base
+#include "../sam_internal.h" // for nibble2base
 #include "../htslib/hts.h"
 #include "../htslib/hts_endian.h"
 

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -46,8 +46,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "cram/cram.h"
 #include "cram/os.h"
 #include "sam_internal.h" // for nibble2base
-#include "htslib/hts.h"
-#include "htslib/hts_endian.h"
+#include "../htslib/hts.h"
+#include "../htslib/hts_endian.h"
 
 KHASH_MAP_INIT_STR(m_s2u64, uint64_t)
 

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -43,8 +43,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <math.h>
 #include <inttypes.h>
 
-#include "cram/cram.h"
-#include "cram/os.h"
+#include "cram.h"
+#include "os.h"
 #include "sam_internal.h" // for nibble2base
 #include "../htslib/hts.h"
 #include "../htslib/hts_endian.h"

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define HTS_BUILDING_LIBRARY // Enables HTSLIB_EXPORT, see htslib/hts_defs.h
 #include <config.h>
 
-#include "htslib/hfile.h"
+#include "../htslib/hfile.h"
 #include "cram/cram.h"
 
 /*

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <config.h>
 
 #include "../htslib/hfile.h"
-#include "cram/cram.h"
+#include "cram.h"
 
 /*
  *-----------------------------------------------------------------------------

--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -64,7 +64,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../htslib/bgzf.h"
 #include "../htslib/hfile.h"
-#include "hts_internal.h"
+#include "../hts_internal.h"
 #include "cram.h"
 #include "os.h"
 

--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -62,8 +62,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/stat.h>
 #include <math.h>
 
-#include "htslib/bgzf.h"
-#include "htslib/hfile.h"
+#include "../htslib/bgzf.h"
+#include "../htslib/hfile.h"
 #include "hts_internal.h"
 #include "cram/cram.h"
 #include "cram/os.h"

--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -65,8 +65,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../htslib/bgzf.h"
 #include "../htslib/hfile.h"
 #include "hts_internal.h"
-#include "cram/cram.h"
-#include "cram/os.h"
+#include "cram.h"
+#include "os.h"
 
 #if 0
 static void dump_index_(cram_index *e, int level) {

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -70,11 +70,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define crc32(a,b,c) libdeflate_crc32((a),(b),(c))
 #endif
 
-#include "cram/cram.h"
-#include "cram/os.h"
+#include "cram.h"
+#include "os.h"
 #include "../htslib/hts.h"
-#include "cram/open_trace_file.h"
-#include "cram/rANS_static.h"
+#include "open_trace_file.h"
+#include "rANS_static.h"
 
 //#define REF_DEBUG
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -72,7 +72,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cram/cram.h"
 #include "cram/os.h"
-#include "htslib/hts.h"
+#include "../htslib/hts.h"
 #include "cram/open_trace_file.h"
 #include "cram/rANS_static.h"
 
@@ -87,9 +87,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define RP(...)
 #endif
 
-#include "htslib/hfile.h"
-#include "htslib/bgzf.h"
-#include "htslib/faidx.h"
+#include "../htslib/hfile.h"
+#include "../htslib/bgzf.h"
+#include "../htslib/faidx.h"
 #include "hts_internal.h"
 
 #ifndef PATH_MAX

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -56,7 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef HAVE_LZMA_H
 #include <lzma.h>
 #else
-#include "os/lzma_stub.h"
+#include "../os/lzma_stub.h"
 #endif
 #endif
 #include <sys/types.h>
@@ -90,7 +90,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../htslib/hfile.h"
 #include "../htslib/bgzf.h"
 #include "../htslib/faidx.h"
-#include "hts_internal.h"
+#include "../hts_internal.h"
 
 #ifndef PATH_MAX
 #define PATH_MAX FILENAME_MAX

--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -43,7 +43,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CRAM_IO_H
 
 #include <stdint.h>
-#include <cram/misc.h>
+
+#include "misc.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cram/cram_samtools.c
+++ b/cram/cram_samtools.c
@@ -36,8 +36,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 
 #include "cram/cram.h"
-#include "htslib/sam.h"
-#include "../sam_internal.h"
+#include "../htslib/sam.h"
+#include "sam_internal.h"
 
 /*---------------------------------------------------------------------------
  * Samtools compatibility portion

--- a/cram/cram_samtools.c
+++ b/cram/cram_samtools.c
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cram.h"
 #include "../htslib/sam.h"
-#include "sam_internal.h"
+#include "../sam_internal.h"
 
 /*---------------------------------------------------------------------------
  * Samtools compatibility portion

--- a/cram/cram_samtools.c
+++ b/cram/cram_samtools.c
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include <stdlib.h>
 
-#include "cram/cram.h"
+#include "cram.h"
 #include "../htslib/sam.h"
 #include "sam_internal.h"
 

--- a/cram/cram_samtools.h
+++ b/cram/cram_samtools.h
@@ -56,7 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define bam_reg2bin(beg,end) hts_reg2bin((beg),(end),14,5)
 
-#include "htslib/sam.h"
+#include "../htslib/sam.h"
 
 enum cigar_op {
     BAM_CMATCH_=BAM_CMATCH,

--- a/cram/cram_stats.c
+++ b/cram/cram_stats.c
@@ -42,8 +42,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <math.h>
 #include <inttypes.h>
 
-#include "cram/cram.h"
-#include "cram/os.h"
+#include "cram.h"
+#include "os.h"
 
 cram_stats *cram_stats_create(void) {
     return calloc(1, sizeof(cram_stats));

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -52,8 +52,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../htslib/thread_pool.h"
 #include "../htslib/cram.h"
-#include "cram/string_alloc.h"
-#include "cram/mFILE.h"
+#include "string_alloc.h"
+#include "mFILE.h"
 #include "../htslib/khash.h"
 
 #ifdef __cplusplus

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -50,11 +50,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <sys/types.h>
 
-#include "htslib/thread_pool.h"
-#include "htslib/cram.h"
+#include "../htslib/thread_pool.h"
+#include "../htslib/cram.h"
 #include "cram/string_alloc.h"
 #include "cram/mFILE.h"
-#include "htslib/khash.h"
+#include "../htslib/khash.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cram/mFILE.c
+++ b/cram/mFILE.c
@@ -42,8 +42,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdarg.h>
 
 #include "../htslib/hts_log.h"
-#include "cram/os.h"
-#include "cram/mFILE.h"
+#include "os.h"
+#include "mFILE.h"
 
 #ifdef HAVE_MMAP
 #include <sys/mman.h>

--- a/cram/mFILE.c
+++ b/cram/mFILE.c
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unistd.h>
 #include <stdarg.h>
 
-#include "htslib/hts_log.h"
+#include "../htslib/hts_log.h"
 #include "cram/os.h"
 #include "cram/mFILE.h"
 

--- a/cram/open_trace_file.c
+++ b/cram/open_trace_file.c
@@ -72,13 +72,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "cram/os.h"
+
+#include "os.h"
 #ifndef PATH_MAX
 #  define PATH_MAX 1024
 #endif
 
-#include "cram/open_trace_file.h"
-#include "cram/misc.h"
+#include "open_trace_file.h"
+#include "misc.h"
 #include "../htslib/hfile.h"
 #include "../htslib/hts_log.h"
 #include "../htslib/hts.h"

--- a/cram/open_trace_file.c
+++ b/cram/open_trace_file.c
@@ -79,9 +79,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cram/open_trace_file.h"
 #include "cram/misc.h"
-#include "htslib/hfile.h"
-#include "htslib/hts_log.h"
-#include "htslib/hts.h"
+#include "../htslib/hfile.h"
+#include "../htslib/hts_log.h"
+#include "../htslib/hts.h"
 
 /*
  * Returns whether the path refers to a regular file.

--- a/cram/open_trace_file.h
+++ b/cram/open_trace_file.h
@@ -64,7 +64,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef OPEN_TRACE_FILE_H
 #define OPEN_TRACE_FILE_H
 
-#include "cram/mFILE.h"
+#include "mFILE.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cram/os.h
+++ b/cram/os.h
@@ -77,7 +77,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <limits.h>
 #include <stdint.h>
-#include "htslib/hts_endian.h"
+
+#include "../htslib/hts_endian.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cram/pooled_alloc.c
+++ b/cram/pooled_alloc.c
@@ -35,8 +35,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include <stdint.h>
 
-#include "cram/pooled_alloc.h"
-#include "cram/misc.h"
+#include "pooled_alloc.h"
+#include "misc.h"
 
 //#define DISABLE_POOLED_ALLOC
 //#define TEST_MAIN

--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -47,8 +47,8 @@
 #include <sys/time.h>
 #include <limits.h>
 
-#include "cram/rANS_static.h"
-#include "cram/rANS_byte.h"
+#include "rANS_static.h"
+#include "rANS_byte.h"
 
 #define TF_SHIFT 12
 #define TOTFREQ (1<<TF_SHIFT)

--- a/cram/string_alloc.c
+++ b/cram/string_alloc.c
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h>
 #include <stdio.h>
 
-#include "cram/string_alloc.h"
+#include "string_alloc.h"
 
 #define MIN_STR_SIZE 1024
 

--- a/htslib/khash.h
+++ b/htslib/khash.h
@@ -129,8 +129,9 @@ int main() {
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
-#include <htslib/kstring.h>
-#include <htslib/kroundup.h>
+
+#include "kstring.h"
+#include "kroundup.h"
 
 /* compiler specific configuration */
 

--- a/htslib/khash_str2int.h
+++ b/htslib/khash_str2int.h
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef HTSLIB_KHASH_STR2INT_H
 #define HTSLIB_KHASH_STR2INT_H
 
-#include <htslib/khash.h>
+#include "khash.h"
 
 KHASH_MAP_INIT_STR(str2int, int)
 

--- a/test/fieldarith.c
+++ b/test/fieldarith.c
@@ -26,7 +26,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <stdio.h>
 
-#include "htslib/sam.h"
+#include "../htslib/sam.h"
 
 int ntests = 0;
 int nfailures = 0;

--- a/test/fuzz/hts_open_fuzzer.c
+++ b/test/fuzz/hts_open_fuzzer.c
@@ -31,10 +31,11 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include "htslib/hfile.h"
-#include "htslib/hts.h"
-#include "htslib/sam.h"
-#include "htslib/vcf.h"
+
+#include "../../htslib/hfile.h"
+#include "../../htslib/hts.h"
+#include "../../htslib/sam.h"
+#include "../../htslib/vcf.h"
 
 static void hts_close_or_abort(htsFile* file) {
     if (hts_close(file) != 0) {

--- a/test/hfile.c
+++ b/test/hfile.c
@@ -31,9 +31,9 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <sys/stat.h>
 
-#include "htslib/hfile.h"
-#include "htslib/hts_defs.h"
-#include "htslib/kstring.h"
+#include "../htslib/hfile.h"
+#include "../htslib/hts_defs.h"
+#include "../htslib/kstring.h"
 
 void HTS_NORETURN fail(const char *format, ...)
 {

--- a/test/hts_endian.c
+++ b/test/hts_endian.c
@@ -28,7 +28,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <stdint.h>
 #include <inttypes.h>
-#include "htslib/hts_endian.h"
+
+#include "../htslib/hts_endian.h"
 
 typedef struct {
     uint8_t u8[2];

--- a/test/pileup.c
+++ b/test/pileup.c
@@ -47,8 +47,9 @@ samtools mpileup -B -Q 0 in.bam | perl -lane \
 #include <errno.h>
 #include <ctype.h>
 #include <unistd.h>
-#include "htslib/sam.h"
-#include "htslib/kstring.h"
+
+#include "../htslib/sam.h"
+#include "../htslib/kstring.h"
 
 #define MIN(a,b) ((a)<(b)?(a):(b))
 

--- a/test/sam.c
+++ b/test/sam.c
@@ -35,14 +35,14 @@ DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 
 // Suppress message for faidx_fetch_nseq(), which we're intentionally testing
-#include "htslib/hts_defs.h"
+#include "../htslib/hts_defs.h"
 #undef HTS_DEPRECATED
 #define HTS_DEPRECATED(message)
 
-#include "htslib/sam.h"
-#include "htslib/faidx.h"
-#include "htslib/khash.h"
-#include "htslib/hts_log.h"
+#include "../htslib/sam.h"
+#include "../htslib/faidx.h"
+#include "../htslib/khash.h"
+#include "../htslib/hts_log.h"
 
 KHASH_SET_INIT_STR(keep)
 typedef khash_t(keep) *keephash_t;

--- a/test/test-bcf-sr.c
+++ b/test/test-bcf-sr.c
@@ -32,7 +32,8 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <inttypes.h>
-#include <htslib/synced_bcf_reader.h>
+
+#include "../htslib/synced_bcf_reader.h"
 
 void error(const char *format, ...)
 {

--- a/test/test-bcf-translate.c
+++ b/test/test-bcf-translate.c
@@ -24,8 +24,10 @@
 */
 
 #include <config.h>
+
 #include <stdio.h>
-#include <htslib/vcf.h>
+
+#include "../htslib/vcf.h"
 
 void error(const char *format, ...)
 {

--- a/test/test-parse-reg.c
+++ b/test/test-parse-reg.c
@@ -44,8 +44,8 @@
 #include <stdint.h>
 #include <inttypes.h>
 
-#include <htslib/hts.h>
-#include <htslib/sam.h>
+#include "../htslib/hts.h"
+#include "../htslib/sam.h"
 
 void reg_expected(sam_hdr_t *hdr, const char *reg, int flags,
                  char *reg_exp, int tid_exp, hts_pos_t beg_exp, hts_pos_t end_exp) {

--- a/test/test-regidx.c
+++ b/test/test-regidx.c
@@ -33,9 +33,10 @@
 #include <string.h>
 #include <getopt.h>
 #include <time.h>
-#include "htslib/kstring.h"
-#include "htslib/regidx.h"
-#include "htslib/hts_defs.h"
+
+#include "../htslib/kstring.h"
+#include "../htslib/regidx.h"
+#include "../htslib/hts_defs.h"
 #include "textutils_internal.h"
 
 static int verbose = 0;

--- a/test/test-regidx.c
+++ b/test/test-regidx.c
@@ -37,7 +37,7 @@
 #include "../htslib/kstring.h"
 #include "../htslib/regidx.h"
 #include "../htslib/hts_defs.h"
-#include "textutils_internal.h"
+#include "../textutils_internal.h"
 
 static int verbose = 0;
 

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -25,10 +25,11 @@ DEALINGS IN THE SOFTWARE.  */
 #include <config.h>
 
 #include <stdio.h>
-#include <htslib/hts.h>
-#include <htslib/vcf.h>
-#include <htslib/kstring.h>
-#include <htslib/kseq.h>
+
+#include "../htslib/hts.h"
+#include "../htslib/vcf.h"
+#include "../htslib/kstring.h"
+#include "../htslib/kseq.h"
 
 void error(const char *format, ...)
 {

--- a/test/test-vcf-sweep.c
+++ b/test/test-vcf-sweep.c
@@ -25,7 +25,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include <config.h>
 
 #include <stdio.h>
-#include <htslib/vcf_sweep.h>
+
+#include "../htslib/vcf_sweep.h"
 
 int main(int argc, char **argv)
 {

--- a/test/test_bgzf.c
+++ b/test/test_bgzf.c
@@ -37,7 +37,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include "../htslib/bgzf.h"
 #include "../htslib/hfile.h"
-#include "hfile_internal.h"
+#include "../hfile_internal.h"
 
 const char *bgzf_suffix = ".gz";
 const char *idx_suffix  = ".gzi";

--- a/test/test_bgzf.c
+++ b/test/test_bgzf.c
@@ -34,8 +34,9 @@ DEALINGS IN THE SOFTWARE.
 #include <inttypes.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include "htslib/bgzf.h"
-#include "htslib/hfile.h"
+
+#include "../htslib/bgzf.h"
+#include "../htslib/hfile.h"
 #include "hfile_internal.h"
 
 const char *bgzf_suffix = ".gz";

--- a/test/test_index.c
+++ b/test/test_index.c
@@ -26,8 +26,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdio.h>
 #include <getopt.h>
 
-#include "htslib/sam.h"
-#include "htslib/vcf.h"
+#include "../htslib/sam.h"
+#include "../htslib/vcf.h"
 
 void usage(FILE *fp) {
     fprintf(fp, "Usage: test_index [opts] in.{sam.gz,bam,cram}|in.{vcf.gz,bcf}\n\n");

--- a/test/test_kstring.c
+++ b/test/test_kstring.c
@@ -31,7 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <inttypes.h>
 #include <getopt.h>
 
-#include <htslib/kstring.h>
+#include "../htslib/kstring.h"
 
 static inline void clamp(int64_t *val, int64_t min, int64_t max) {
     if (*val < min) *val = min;

--- a/test/test_realn.c
+++ b/test/test_realn.c
@@ -30,9 +30,10 @@ DEALINGS IN THE SOFTWARE.  */
 #include <errno.h>
 #include <getopt.h>
 #include <limits.h>
-#include "htslib/sam.h"
-#include "htslib/hts.h"
-#include "htslib/faidx.h"
+
+#include "../htslib/sam.h"
+#include "../htslib/hts.h"
+#include "../htslib/faidx.h"
 
 void usage(const char *prog) {
     fprintf(stderr, "Usage: %s -i <in.sam> -o <out.sam> -f <ref.fa>\n", prog);

--- a/test/test_str2int.c
+++ b/test/test_str2int.c
@@ -29,7 +29,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include <inttypes.h>
 #include <stdlib.h>
 #include <getopt.h>
-#include "textutils_internal.h"
+
+#include "../textutils_internal.h"
 
 // Test hts_str2int() and hts_str2uint() on various values around the
 // maximum (or minimum for negative numbers) allowed for the given

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -32,7 +32,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <getopt.h>
 #include <stdint.h>
 
-#include "cram/cram.h"
+#include "../cram/cram.h"
 #include "../htslib/sam.h"
 #include "../htslib/vcf.h"
 #include "../htslib/hts_log.h"

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -33,9 +33,9 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdint.h>
 
 #include "cram/cram.h"
-#include "htslib/sam.h"
-#include "htslib/vcf.h"
-#include "htslib/hts_log.h"
+#include "../htslib/sam.h"
+#include "../htslib/vcf.h"
+#include "../htslib/hts_log.h"
 
 struct opts {
     char *fn_ref;

--- a/test/thrash_threads1.c
+++ b/test/thrash_threads1.c
@@ -28,7 +28,8 @@ DEALINGS IN THE SOFTWARE.
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include "htslib/bgzf.h"
+
+#include "../htslib/bgzf.h"
 
 int main(int argc, char *argv[]) {
     if (argc <= 1) {

--- a/test/thrash_threads2.c
+++ b/test/thrash_threads2.c
@@ -28,8 +28,9 @@ DEALINGS IN THE SOFTWARE.
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include "htslib/bgzf.h"
-#include "htslib/thread_pool.h"
+
+#include "../htslib/bgzf.h"
+#include "../htslib/thread_pool.h"
 
 int main(int argc, char *argv[]) {
     int i;

--- a/test/thrash_threads3.c
+++ b/test/thrash_threads3.c
@@ -27,7 +27,8 @@ DEALINGS IN THE SOFTWARE.
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include "htslib/bgzf.h"
+
+#include "../htslib/bgzf.h"
 
 int main(int argc, char *argv[]) {
     char buf[1000000];

--- a/test/thrash_threads4.c
+++ b/test/thrash_threads4.c
@@ -26,8 +26,9 @@ DEALINGS IN THE SOFTWARE.
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
-#include "htslib/bgzf.h"
-#include "htslib/thread_pool.h"
+
+#include "../htslib/bgzf.h"
+#include "../htslib/thread_pool.h"
 
 int main(int argc, char *argv[]) {
     if (argc <= 1) {

--- a/test/thrash_threads5.c
+++ b/test/thrash_threads5.c
@@ -27,8 +27,9 @@ DEALINGS IN THE SOFTWARE.
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include "htslib/bgzf.h"
-#include "htslib/thread_pool.h"
+
+#include "../htslib/bgzf.h"
+#include "../htslib/thread_pool.h"
 
 #define N 1000
 int main(int argc, char *argv[]) {

--- a/test/thrash_threads6.c
+++ b/test/thrash_threads6.c
@@ -26,8 +26,9 @@ DEALINGS IN THE SOFTWARE.
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
-#include "htslib/bgzf.h"
-#include "htslib/thread_pool.h"
+
+#include "../htslib/bgzf.h"
+#include "../htslib/thread_pool.h"
 
 int main(int argc, char *argv[]) {
     if (argc <= 1) {

--- a/test/thrash_threads7.c
+++ b/test/thrash_threads7.c
@@ -36,7 +36,8 @@ DEALINGS IN THE SOFTWARE.
 #include <unistd.h>
 #include <sys/time.h>
 #include <errno.h>
-#include "htslib/thread_pool.h"
+
+#include "../htslib/thread_pool.h"
 
 
 void *job(void *v) {


### PR DESCRIPTION
The full preprocessor search path for #include "..." is typically:

    1) directory of the file containing the #include directive
    2) environment variables $CPATH, $C_INCLUDE_PATH, etc
    3) command line options -I etc
    4) system include directories

It's easy to oversimplify (1) as “the current directory” but that's misleading when the compiler's PWD is always the top-level htslib source directory but the “current directory of the `#include` directive” might be one of the subdirectories.

When a top-level _*.[ch]_ file does `#include "htslib/foo.h"`, the nearby header file within the source tree is found due to (1). When a file in a subdirectory (_htslib/*.h_, _cram/*.[ch]_, or _test/*.c_) does the same `#include`, the nearby header file is intended to be found due to (3) via the Makefile's hard-coded `-I.` — `.` here being the compiler process's $PWD, i.e., the top-level HTSlib source directory.

However the latter can be subverted if there is an "htslib" directory containing foo.h in $CPATH, $C_INCLUDE_PATH, or on the command line prior to the hard-coded `-I.`. This will be the case if users have made a previous HTSlib installation accessible via $CPATH/etc or by adding a -I option to $(CFLAGS) (rather than $(CPPFLAGS)). One reason we have found this hard to reproduce in the past is that we have naturally added dummy `-I` options to CPPFLAGS, but that comes later in the search path than `-I.`. Naive users OTOH are likely to add their dummy `-I` options to CFLAGS.

Avoid this and fix #347 by adding `../` to #includes in subdirectories (and always using `""` rather than `<>`), so that includes within HTSlib (even from the source subdirectories) are found due to (1).

This PR is split into three commits: for _htslib/*.h_, for _cram/*.h_, and for all other _*.h_ files. The question is whether to apply 1, 2, or all 3 commits.

* The first commit covers the public headers, which is the likely scenario of “oops I added my previous HTSlib installation to `$C_INCLUDE_PATH`”.

* Adding the second commit extends this to the private _cram/*.h_ headers. See the commit messages for details; note that for a (long) time [Debian packaged and shipped these headers](https://twitter.com/jomarnz/status/1207233704822747139) alongside _htslib/*.h_.

* Adding the third commit as well extends this to all intra-HTSlib inclusions, so they're all similarly somewhat uglified. With this, the only `#include`s in HTSlib still depending on (3)'s hard-coded `-I.` are each _*.c_ file's `#include <config.h>`.

Probably the answer is either to apply 1 (for the minimal change) or all 3 commits (for consistency).