### PR TITLE
Avoid warnings from recent and upcoming Clang and GCC releases [minor]

### DIFF
--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -184,7 +184,7 @@ struct cram_file_def {
     char    magic[4];
     uint8_t major_version;
     uint8_t minor_version;
-    char    file_id[20];      // Filename or SHA1 checksum
+    char    file_id[20] HTS_NONSTRING; // Filename or SHA1 checksum
 };
 
 #define CRAM_MAJOR_VERS(v) ((v) >> 8)

--- a/hts.c
+++ b/hts.c
@@ -1711,7 +1711,8 @@ hts_idx_t *hts_idx_init(int n, int fmt, uint64_t offset0, int min_shift, int n_l
     idx->min_shift = min_shift;
     idx->n_lvls = n_lvls;
     idx->n_bins = ((1<<(3 * n_lvls + 3)) - 1) / 7;
-    idx->z.save_bin = idx->z.save_tid = idx->z.last_tid = idx->z.last_bin = 0xffffffffu;
+    idx->z.save_tid = idx->z.last_tid = -1;
+    idx->z.save_bin = idx->z.last_bin = 0xffffffffu;
     idx->z.save_off = idx->z.last_off = idx->z.off_beg = idx->z.off_end = offset0;
     idx->z.last_coor = 0xffffffffu;
     if (n) {

--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -46,6 +46,12 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_GCC_AT_LEAST(major, minor) 0
 #endif
 
+#if HTS_COMPILER_HAS(__nonstring__) || HTS_GCC_AT_LEAST(8,1)
+#define HTS_NONSTRING __attribute__ ((__nonstring__))
+#else
+#define HTS_NONSTRING
+#endif
+
 #if HTS_COMPILER_HAS(__noreturn__) || HTS_GCC_AT_LEAST(3,0)
 #define HTS_NORETURN __attribute__ ((__noreturn__))
 #else

--- a/test/test-regidx.c
+++ b/test/test-regidx.c
@@ -189,9 +189,9 @@ void test_custom_payload(void)
 
 void get_random_region(uint32_t min, uint32_t max, uint32_t *beg, uint32_t *end)
 {
-    long int b = rand(), e = rand();
-    *beg = min + (float)b * (max-min) / RAND_MAX;
-    *end = *beg + (float)e * (max-*beg) / RAND_MAX;
+    uint64_t b = rand(), e = rand();
+    *beg = min + (b * (max-min)) / RAND_MAX;
+    *end = *beg + (e * (max-*beg)) / RAND_MAX;
 }
 
 void test_random(int nregs, uint32_t min, uint32_t max)


### PR DESCRIPTION
Compiling htslib with GCC 10.1 or **trunk** produces:

```
hts.c: In function 'hts_idx_init':
hts.c:1714:59: warning: overflow in conversion from 'uint32_t' {aka 'unsigned int'} to 'int' changes value from 'idx->z.last_bin = 4294967295' to '-1' [-Woverflow]
 1714 |     idx->z.save_bin = idx->z.save_tid = idx->z.last_tid = idx->z.last_bin = 0xffffffffu;
      |                                                           ^~~
cram/cram_io.c: In function 'cram_dopen':
cram/cram_io.c:4493:9: warning: '__builtin_strncpy' specified bound 20 equals destination size [-Wstringop-truncation]
 4493 |         strncpy(def->file_id, filename, 20);
      |         ^~~~~~~
```


Compiling it with Clang **master** (the upcoming release 11) produces:
```
test/test-regidx.c:193:41: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
    *beg = min + (float)b * (max-min) / RAND_MAX;
                                      ~ ^~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdlib.h:105:18: note: expanded from macro 'RAND_MAX'
#define RAND_MAX        0x7fffffff
                        ^~~~~~~~~~
test/test-regidx.c:194:43: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
    *end = *beg + (float)e * (max-*beg) / RAND_MAX;
                                        ~ ^~~~~~~~
```

Fixed variously as described in the commit message:

Annotating `file_id` with `nonstring` lets us use `strncpy()` for its original “copy a C string to a fixed-length NUL-padded only-maybe-NUL-terminated buffer” purpose. Happily _hts_defs.h_ provides infrastructure for portably using new `__attribute__` macros.

Recode the `RAND_MAX` thing using uint64_t arithmetic rather than (32-bit) float arithmetic.