### PR TITLE
Update to the depth filtering for mpileup.

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1650,6 +1650,17 @@ typedef struct __bam_mplp_t *bam_mplp_t;
     HTSLIB_EXPORT
     void bam_plp_set_maxcnt(bam_plp_t iter, int maxcnt);
 
+    /**
+     *  bam_plp_set_cntpos() - indicate which end of reach to apply maxcnt.
+     *  @plp:    The bam_plp_t initialised using bam_plp_init.
+     *  @end:    A fraction along the read from 0.0 (start) to 1.0 (end).
+     *           Defaults to 0.0 which makes maxcnt a true upper-bound value.
+     *           Using 1.0 makes maxcnt a lower-bound, with upper-bound
+     *           varying based on length and coordinate distribution.
+     */
+    HTSLIB_EXPORT
+    void bam_plp_set_cntpos(bam_plp_t iter, double end);
+
     HTSLIB_EXPORT
     void bam_plp_reset(bam_plp_t iter);
 
@@ -1711,6 +1722,18 @@ typedef struct __bam_mplp_t *bam_mplp_t;
 
     HTSLIB_EXPORT
     void bam_mplp_set_maxcnt(bam_mplp_t iter, int maxcnt);
+
+    /**
+     *  bam_mplp_set_cntpos() - indicate which end of reach to apply maxcnt.
+     *  @mplp:   The bam_mplp_t initialised using bam_mplp_init.
+     *  @end:    A fraction along the read from 0.0 (start) to 1.0 (end).
+     *           Defaults to 0.0 which makes maxcnt a true upper-bound value.
+     *           Using 1.0 makes maxcnt a lower-bound, with upper-bound
+     *           varying based on length and coordinate distribution.
+     */
+    HTSLIB_EXPORT
+    void bam_mplp_set_cntpos(bam_mplp_t iter, double end);
+
 
     HTSLIB_EXPORT
     int bam_mplp_auto(bam_mplp_t iter, int *_tid, int *_pos, int *n_plp, const bam_pileup1_t **plp);

--- a/sam.c
+++ b/sam.c
@@ -4139,6 +4139,8 @@ int bam_plp_insertion(const bam_pileup1_t *p, kstring_t *ins, int *del_len) {
 KHASH_MAP_INIT_STR(olap_hash, lbnode_t *)
 typedef khash_t(olap_hash) olap_hash_t;
 
+#define MAX_AHEAD 4096
+
 struct __bam_plp_t {
     mempool_t *mp;
     lbnode_t *head, *tail;
@@ -4152,6 +4154,10 @@ struct __bam_plp_t {
     bam_plp_auto_f func;
     void *data;
     olap_hash_t *overlaps;
+
+    uint32_t depth[MAX_AHEAD];
+    uint64_t last_depth_pos;
+    double depth_pos_fract;
 
     // For notification of creation and destruction events
     // and associated client-owned pointer.
@@ -4172,6 +4178,9 @@ bam_plp_t bam_plp_init(bam_plp_auto_f func, void *data)
         iter->data = data;
         iter->b = bam_init1();
     }
+    memset(iter->depth, 0, MAX_AHEAD * sizeof(*iter->depth));
+    iter->depth_pos_fract = 0;  // fraction between 0 = left and 1 = right
+    iter->last_depth_pos = 0;
     return iter;
 }
 
@@ -4494,21 +4503,60 @@ const bam_pileup1_t *bam_plp_next(bam_plp_t iter, int *_tid, int *_pos, int *_n_
 
 int bam_plp_push(bam_plp_t iter, const bam1_t *b)
 {
+    uint64_t endpos = 0;
+
     if (iter->error) return -1;
     if (b) {
         if (b->core.tid < 0) { overlap_remove(iter, b); return 0; }
         // Skip only unmapped reads here, any additional filtering must be done in iter->func
         if (b->core.flag & BAM_FUNMAP) { overlap_remove(iter, b); return 0; }
-        if (iter->tid == b->core.tid && iter->pos == b->core.pos && iter->mp->cnt > iter->maxcnt)
-        {
+        if (iter->depth_pos_fract == 0
+            && iter->tid == b->core.tid
+            && iter->pos == b->core.pos
+            && iter->mp->cnt > iter->maxcnt) {
+            // Removal from left-end depth; mp->cnt
             overlap_remove(iter, b);
             return 0;
+        } else if (iter->depth_pos_fract > 0
+                   && iter->tid == b->core.tid
+                   && iter->pos == b->core.pos) {
+            // Removal from depth somewhere else along read
+            endpos = bam_endpos(b);
+            uint32_t len = (uint32_t)(endpos - b->core.pos - 1);
+            len = len * iter->depth_pos_fract + 0.4999;
+            if (b->core.pos + len < iter->last_depth_pos
+                && iter->depth[(b->core.pos+len)%MAX_AHEAD] > iter->maxcnt) {
+                // NB this means read longer than MAX_AHEAD (after downsizing
+                // by depth_pos fraction) will be retained as by definition
+                // it'll have zero coverage that far out.
+                overlap_remove(iter, b);
+                return 0;
+            }
+
+            // Zero newly observed iter depth elemtns.
+            uint64_t end_clipped = endpos, p;
+            if (end_clipped > iter->pos + MAX_AHEAD)
+                end_clipped = iter->pos + MAX_AHEAD;
+            if (iter->last_depth_pos < end_clipped) {
+                //iter->last_depth_pos = end_clipped;
+                if (iter->last_depth_pos < end_clipped-MAX_AHEAD)
+                    iter->last_depth_pos = end_clipped-MAX_AHEAD;
+                for (p = iter->last_depth_pos; p < end_clipped; p++)
+                    iter->depth[p % MAX_AHEAD] = 0;
+                iter->last_depth_pos = end_clipped;
+            }
+
+            // Increment depth
+            for (p = b->core.pos; p < end_clipped; p++)
+                iter->depth[p % MAX_AHEAD]++;
         }
         if (bam_copy1(&iter->tail->b, b) == NULL)
             return -1;
         iter->tail->b.id = iter->id++;
         iter->tail->beg = b->core.pos;
-        iter->tail->end = bam_endpos(b);
+        if (!endpos)
+            endpos = bam_endpos(b);
+        iter->tail->end = endpos;
         iter->tail->s = g_cstate_null; iter->tail->s.end = iter->tail->end - 1; // initialize cstate_t
         if (b->core.tid < iter->max_tid) {
             hts_log_error("The input is not sorted (chromosomes out of order)");
@@ -4602,6 +4650,11 @@ void bam_plp_set_maxcnt(bam_plp_t iter, int maxcnt)
     iter->maxcnt = maxcnt;
 }
 
+void bam_plp_set_cntpos(bam_plp_t iter, double end)
+{
+    iter->depth_pos_fract = end;
+}
+
 /************************
  *** Mpileup iterator ***
  ************************/
@@ -4649,6 +4702,13 @@ void bam_mplp_set_maxcnt(bam_mplp_t iter, int maxcnt)
     int i;
     for (i = 0; i < iter->n; ++i)
         iter->iter[i]->maxcnt = maxcnt;
+}
+
+void bam_mplp_set_cntpos(bam_mplp_t iter, double end)
+{
+    int i;
+    for (i = 0; i < iter->n; ++i)
+        iter->iter[i]->depth_pos_fract = end;
 }
 
 void bam_mplp_destroy(bam_mplp_t iter)


### PR DESCRIPTION
We can now count the depth anywhere along the read rather than only at the left end.  It's not buffering reads up so it doesn't know what's about to come, so for any individual column it'll still favour reads that end near a column than start near a column, but by counting at the right hand end we avoid the boom & bust approach to before where the coverage could plumet to zero immediately following a large spike.

With iter->depth_pos = 1.0 the coverage ends up being a minimum of maxcnt (assuming the true coverage is higher), rather than a maximum of maxcnt.  So we go over-depth, but avoid the drop outs.

The following plot shows an example of fake amplicon based sequencing (350bp amplicons every 300bp) with full unlimited depth, reducing depth on the current develop branch, with this PR, and with an alternative more complex set of heuristics[1].  Plots are staggered marginally in X for clarity only.

![pe](https://user-images.githubusercontent.com/2210525/84685086-8e11a200-af31-11ea-9acb-f1efbddd4269.png)

[1] Reading simulated data consisting of qname, pos and len (on ref, not len of seq).
```
    while(scanf("%s %d %d\n", name, &pos, &len) == 3) {                         
        if (min > pos)                                                          
            min = pos;                                                          
                                                                                
        if (max < pos + len)                                                    
            max = pos + len;                                                    
                                                                                
        if (depth[pos] > max_depth * 0.5) {                                     
            khint_t h = __ac_Wang_hash(__ac_X31_hash_string(name) ^ seed);      
            if ((double)h / 0xffffffff >                                        
                  pow((max-1.0-max2)/(len+.01),2)                               
                * pow((1-(depth[max-1]+.1)/max_depth), 2)                       
                * pow((max_depth+.1)/depth[pos],2)*2) {
                continue;                                                       
            }                                                                   
        }                                                                       

        int p;                                                                  
        for (p = pos; p < pos+len; p++) {                                       
            depth[p]++;                                                         
            if (max2 < p && depth[p] >= max_depth)                              
                max2 = p;                                                       
        }                                                                       
    }                                                                           
```

The name hash is used as a random number generator for removal of reads, but it gives a bias towards keeping pairs together.  It's not perfect by any stretch, being stochastic, but at 1k depth out of a pool of ~300k depth about 1 in 4 reads also had their mate pair, compared to just 6% if using drand48 as the random number generator instead of h.