### PR TITLE
CRAM fix for MD tag generation with "b" FC.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1503,6 +1503,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
                     }
 
                     nm += x;
+                    md_dist = 0;
                 }
             }
 


### PR DESCRIPTION
We don't normally generate these features, using "B" instead.  However some hand crafted CRAM files have shown we didn't create the correct MD tag due to forgetting to clear the distance since last edit, giving rise to the last numeric in MD being high.

Eg: MD:Z:0A98T0 came out as MD:Z:0A98T98 if that last T edit was a "b" feature.

[0503_mapped.cram.zip](https://github.com/samtools/htslib/files/4805153/0503_mapped.cram.zip)
