### PR TITLE
Check for null pointer in source string.

### DIFF
--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -228,6 +228,7 @@ static inline int kputsn(const char *p, size_t l, kstring_t *s)
 
 static inline int kputs(const char *p, kstring_t *s)
 {
+	if (!p) { errno = EFAULT; return -1; }
 	return kputsn(p, strlen(p), s);
 }
 


### PR DESCRIPTION
Considering `kputs` is exposed as a public method and used extensively with data parsed directly from input files, it should check that its source string is not null.
Probably, a similar check should be implemented for `kputsn`, which has the potential of an undefined behaviour when calling `memcpy` with a null pointer.

Credit to OSS-Fuzz
Fixes oss-fuzz 23670