### PR TITLE
Improve bam_aux_update_str()

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1,7 +1,7 @@
 /// @file htslib/sam.h
 /// High-level SAM/BAM/CRAM sequence file operations.
 /*
-    Copyright (C) 2008, 2009, 2013-2019 Genome Research Ltd.
+    Copyright (C) 2008, 2009, 2013-2020 Genome Research Ltd.
     Copyright (C) 2010, 2012, 2013 Broad Institute.
 
     Author: Heng Li <lh3@sanger.ac.uk>
@@ -1463,6 +1463,15 @@ int bam_aux_del(bam1_t *b, uint8_t *s);
    @return 0 on success, -1 on failure
    This function will not change the ordering of tags in the bam record.
    New tags will be appended to any existing aux records.
+
+   If @p len is less than zero, the length of the input string will be
+   calculated using strlen().  Otherwise exactly @p len bytes will be
+   copied from @p data to make the new tag.  If these bytes do not
+   include a terminating NUL character, one will be added.  (Note that
+   versions of HTSlib up to 1.10.2 had different behaviour here and
+   simply copied @p len bytes from data.  To generate a valid tag it
+   was necessary to ensure the last character was a NUL, and include
+   it in @p len.)
 
    On failure, errno may be set to one of the following values:
 


### PR DESCRIPTION
While recommending `bam_aux_update_str()` elsewhere, I noticed that it's interface was somewhat unfriendly as it required a NUL-terminated string, and the passed-in length had to include the NUL-terminating byte.  This PR removes that restriction in a backwards-compatible manner so that forgetting to count the NUL no longer creates an invalid tag.  As a side benefit, it becomes possible to create a tag from part of a longer string.

`bam_aux_update_str()` is made a bit more efficient, especially when replacing an existing tag, by reducing the number of `memmove()` calls used to get any following aux tags into the correct position.  It also calculates the new record size more accurately when resizing.

Includes more tests for tag growth and shrinkage, and fixes a (mostly) unrelated bug in `test_mempolicy()` which was not growing records nearly as much as expected.