### PR TITLE
Add more checks for broken BCF files

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -1051,7 +1051,7 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
         if ( !hdr || rid<0 || rid>=hdr->n[BCF_DT_CTG] ) return NULL;
         return hdr->id[BCF_DT_CTG][rid].key;
     }
-    static inline const char *bcf_seqname(const bcf_hdr_t *hdr, bcf1_t *rec) {
+    static inline const char *bcf_seqname(const bcf_hdr_t *hdr, const bcf1_t *rec) {
         return bcf_hdr_id2name(hdr, rec ? rec->rid : -1);
     }
 
@@ -1062,7 +1062,7 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
         supplied or rec->rid was out of range) it returns the string
         "(unknown)".
     */
-    static inline const char *bcf_seqname_safe(const bcf_hdr_t *hdr, bcf1_t *rec) {
+    static inline const char *bcf_seqname_safe(const bcf_hdr_t *hdr, const bcf1_t *rec) {
         const char *name = bcf_seqname(hdr, rec);
         return name ? name : "(unknown)";
     }

--- a/vcf.c
+++ b/vcf.c
@@ -3093,7 +3093,10 @@ int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s)
                     case BCF_BT_INT64: if ( z->v1.i==bcf_int64_missing ) kputc('.', s); else kputll(z->v1.i, s); break;
                     case BCF_BT_FLOAT: if ( bcf_float_is_missing(z->v1.f) ) kputc('.', s); else kputd(z->v1.f, s); break;
                     case BCF_BT_CHAR:  kputc(z->v1.i, s); break;
-                    default: hts_log_error("Unexpected type %d at %s:%"PRIhts_pos, z->type, bcf_seqname_safe(h, v), v->pos+1); exit(1); break;
+                    default:
+                        hts_log_error("Unexpected type %d at %s:%"PRIhts_pos, z->type, bcf_seqname_safe(h, v), v->pos+1);
+                        errno = EINVAL;
+                        return -1;
                 }
             }
             else bcf_fmt_array(s, z->len, z->type, z->vptr);


### PR DESCRIPTION
It is possible to make a sparse set of ids in the VCF header using IDX= annotations, which can cause problems
if a BCF record refers to one of the indexes that does not exist.  This adds checks to `bcf_record_check()` and `vcf_format()` to catch these cases and return gracefully instead of crashing.

Ideally the checks in `bcf_record_check()` would be enough, but it isn't able to access the header when called from an iterator so has to skip these tests in that case.  `vcf_format()` does have access to the header, so can at least stop itself from behaving badly.  Any code looking up these dictionary values between the two functions still needs to take similar precautions to ensure values in BCF records are valid, at least until we can work out how to make `bcf_record_check()` work better in the iterator case.

A future PR will add some more error checking to `vcf_format()`, this one has deliberately been limited to just catching these invalid index values.

Credit to OSS-Fuzz
Fixes oss-fuzz 23670