### PR TITLE
[CRAM] incomplete decode to encode conversion

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -2163,7 +2163,7 @@ int cram_codec_decoder2encoder(cram_fd *fd, cram_codec *c) {
         c->store = cram_external_encode_store;
         if (c->decode == cram_external_decode_int)
             c->encode = cram_external_encode_int;
-        if (c->decode == cram_external_decode_long)
+        else if (c->decode == cram_external_decode_long)
             c->encode = cram_external_encode_long;
         else if (c->decode == cram_external_decode_char)
             c->encode = cram_external_encode_char;

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -316,7 +316,8 @@ int cram_transcode_rg(cram_fd *in, cram_fd *out,
     ch = cram_decode_compression_header(in, o_blk);
     if (cram_block_compression_hdr_set_rg(ch, new_rg) != 0)
         return -1;
-    cram_block_compression_hdr_decoder2encoder(in, ch);
+    if (cram_block_compression_hdr_decoder2encoder(in, ch) != 0)
+        return -1;
     n_blk = cram_encode_compression_header(in, c, ch);
     cram_free_compression_header(ch);
 


### PR DESCRIPTION
Because of the missing `else`, `cram_codec_decoder2encoder` was erroneously returning **-1**, causing its caller method `cram_block_compression_hdr_decoder2encoder` to abort converting the other codecs from decoding to encoding. This resulted in uninitialized codec fields, which were subsequently used.

Fixes https://github.com/samtools/samtools/issues/1276