### PR TITLE
Set CRAM default qual for lossy qual modes.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1526,6 +1526,8 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 
             if (ds & CRAM_QQ) {
                 if (!c->comp_hdr->codecs[DS_QQ]) return -1;
+                if ((unsigned char)*qual == 255)
+                    memset(qual, 30, cr->len); // ?
                 r |= c->comp_hdr->codecs[DS_QQ]
                     ->decode(s, c->comp_hdr->codecs[DS_QQ], blk,
                              (char *)&qual[pos-1], &len);
@@ -1579,6 +1581,8 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
             }
             if (ds & CRAM_QS) {
                 if (!c->comp_hdr->codecs[DS_QS]) return -1;
+                if ((unsigned char)*qual == 255)
+                    memset(qual, 30, cr->len); // ASCII ?.  Same as htsjdk
                 r |= c->comp_hdr->codecs[DS_QS]
                                 ->decode(s, c->comp_hdr->codecs[DS_QS], blk,
                                          (char *)&qual[pos-1], &out_sz);
@@ -1598,6 +1602,8 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
         case 'Q': { // Quality score; QS
             if (ds & CRAM_QS) {
                 if (!c->comp_hdr->codecs[DS_QS]) return -1;
+                if ((unsigned char)*qual == 255)
+                    memset(qual, 30, cr->len); // ?
                 r |= c->comp_hdr->codecs[DS_QS]
                                 ->decode(s, c->comp_hdr->codecs[DS_QS], blk,
                                          (char *)&qual[pos-1], &out_sz);

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1536,9 +1536,6 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 
             cig_op = BAM_CMATCH;
 
-            cig_len+=len;
-            seq_pos+=len;
-            ref_pos+=len;
             //prev_pos+=len;
             break;
         }


### PR DESCRIPTION
If we have lossy quality enabled and couple that with the use of 'B',
'q' or 'Q' features, CRAM starts off with QUAL being all 255 (as per
BAM spec and "*" quality) and then starts to modify individual
qualities as dictated by the specific features.

However that then produces ASCII quality <space> (q=-1) for the
unmodified bases.  Instead we use ASCII quality "?" (q=30), as per
htsjdk.  We use have quality 255 for sequences with no modifications
at all though.

NB: Neither htslib nor scramble can produce test data to demonstrate
this bug.  I used gdb to tweak the CF value (b cram_encode.c:2769 and
then set cr->cram_flags=0) along with using a SAM file using IUPAC
codes in the sequence.

See https://github.com/jkbonfield/hts-specs/blob/CRAM_tests/test/cram/passed/1003_qual.cram for a cram file to tickle this bug.