### PR TITLE
Fix mpileup regression between 1.9 and 1.10.

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -4371,7 +4371,7 @@ static int overlap_push(bam_plp_t iter, lbnode_t *node)
     if ( node->b.core.flag&BAM_FMUNMAP || !(node->b.core.flag&BAM_FPROPER_PAIR) ) return 0;
 
     // no overlap possible, unless some wild cigar
-    if ( node->b.core.tid != node->b.core.mtid
+    if ( (node->b.core.mtid >= 0 && node->b.core.tid != node->b.core.mtid)
          || (llabs(node->b.core.isize) >= 2*node->b.core.l_qseq
          && node->b.core.mpos >= node->end) // for those wild cigars
        ) return 0;
@@ -4380,7 +4380,8 @@ static int overlap_push(bam_plp_t iter, lbnode_t *node)
     if ( kitr==kh_end(iter->overlaps) )
     {
         // Only add reads where the mate is still to arrive
-        if (node->b.core.mpos >= node->b.core.pos) {
+        if (node->b.core.mpos >= node->b.core.pos ||
+            ((node->b.core.flag & BAM_FPAIRED) && node->b.core.mpos == -1)) {
             int ret;
             kitr = kh_put(olap_hash, iter->overlaps, bam_get_qname(&node->b), &ret);
             if (ret < 0) return -1;


### PR DESCRIPTION
When RNEXT / PNEXT / TLEN are set to the uninitialised values (* / 0 / 0) the overlap_push function was escaping the overlap removal code.

We now still look for overlaps in this case.  It's not as efficient when it doesn't have these values as we can't optimise the case of detecting non-overlapping reads, but we do get the correct answer again.

Example BAM to demonstrate the issue:

```
@HD	VN:1.6	SO:coordinate
@SQ	SN:bar	LN:10000
foo	163	bar	503	60	20M	*	0	0	AAAAAAAAAAAAAAAAAAAA	FFFFFFFFFFFFFFFFFFFF
foo	83	bar	506	60	20M	*	0	0	AAAAAAAAAAAAAAAAAAAA	GGGGGGGGGGGGGGGGGGGG
```