### PR TITLE
Fix minor issue 994: avoid bcf_update_alleles() crash

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -765,7 +765,7 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     HTSLIB_EXPORT
     int bcf_has_filter(const bcf_hdr_t *hdr, bcf1_t *line, char *filter);
     /**
-     *  bcf_update_alleles() and bcf_update_alleles_str() - update REF and ALLT column
+     *  bcf_update_alleles() and bcf_update_alleles_str() - update REF and ALT column
      *  @alleles:           Array of alleles
      *  @nals:              Number of alleles
      *  @alleles_string:    Comma-separated alleles, starting with the REF allele

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -54,6 +54,9 @@ void write_bcf(char *fname)
     bcf1_t *rec    = bcf_init1();
     if (!rec) error("bcf_init1 : %s", strerror(errno));
 
+    // Check no-op on fresh bcf1_t
+    check0(bcf_update_alleles(hdr, rec, NULL, 0));
+
     // Create VCF header
     kstring_t str = {0,0,0};
     check0(bcf_hdr_append(hdr, "##fileDate=20090805"));
@@ -109,6 +112,9 @@ void write_bcf(char *fname)
     // .. ID
     check0(bcf_update_id(hdr, rec, "rs6054257"));
     // .. REF and ALT
+    const char *alleles[2] = { "G", "A" };
+    check0(bcf_update_alleles(hdr, rec, alleles, 2));
+    check0(bcf_update_alleles(hdr, rec, NULL, 0));
     check0(bcf_update_alleles_str(hdr, rec, "G,A"));
     // .. QUAL
     rec->qual = 29;

--- a/vcf.c
+++ b/vcf.c
@@ -4363,8 +4363,10 @@ static inline int _bcf1_sync_alleles(const bcf_hdr_t *hdr, bcf1_t *line, int nal
     }
     if ( end_info && end_info->v1.i > line->pos )
         line->rlen = end_info->v1.i - line->pos;
-    else
+    else if ( nals > 0 )
         line->rlen = strlen(line->d.allele[0]);
+    else
+        line->rlen = 0;
 
     return 0;
 }
@@ -4656,7 +4658,7 @@ int bcf_get_format_values(const bcf_hdr_t *hdr, bcf1_t *line, const char *tag, v
     {
         *ndst = fmt->n*nsmpl;
         *dst  = realloc(*dst, *ndst*size1);
-        if ( !dst ) return -4;     // could not alloc
+        if ( !*dst ) return -4;     // could not alloc
     }
 
     #define BRANCH(type_t, convert, is_missing, is_vector_end, set_missing, set_vector_end, set_regular, out_type_t) { \


### PR DESCRIPTION
Avoid crash for `bcf_update_alleles(hdr, rec, NULL, 0)`.

Updating a `bcf1_t` to have 0 alleles is not particularly meaningful, but it is a valid state as that's what bcf_init() and bcf_clear() produce. Hence it is a valid thing for bcf_update_alleles() to do too, so calling it with `nals==0` should not crash. Instead set `rlen` the same way that bcf_init() and bcf_clear() leave it. Fixes #994.