### PR TITLE
Fix check for VCF record size

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -2354,16 +2354,17 @@ static int vcf_parse_format(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v, char *p
             v->errcode |= BCF_ERR_LIMITS;
             return -1;
         }
-        f->offset = mem->l;
 
         // Limit the total memory to ~2Gb per VCF row.  This should mean
         // malformed VCF data is less likely to take excessive memory and/or
         // time.
-        if (v->n_sample * (uint64_t)f->size > INT_MAX) {
+        if ((uint64_t) mem->l + v->n_sample * (uint64_t)f->size > INT_MAX) {
             hts_log_error("Excessive memory required by FORMAT fields at %s:%"PRIhts_pos, bcf_seqname_safe(h,v), v->pos+1);
             v->errcode |= BCF_ERR_LIMITS;
             return -1;
         }
+
+        f->offset = mem->l;
         if (ks_resize(mem, mem->l + v->n_sample * (size_t)f->size) < 0) {
             hts_log_error("Memory allocation failure at %s:%"PRIhts_pos, bcf_seqname_safe(h,v), v->pos+1);
             v->errcode |= BCF_ERR_LIMITS;


### PR DESCRIPTION
The check for excessive record size in vcf_parse_format() only looked at individual fields.  It was therefore possible to exceed the limit and overflow fmt_aux_t::offset by having multiple fields with a combined size that went over INT_MAX.
Fix by including the amount of memory used so far in the check.

Credit to OSS-Fuzz
Fixes oss-fuzz 24097