### PR TITLE
Fix hfile_libcurl breakage when using libcurl 7.69.1 or later

### DIFF
--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -221,6 +221,8 @@ static int easy_errno(CURL *easy, CURLcode err)
         return EEXIST;
 
     default:
+        hts_log_error("Libcurl reported error %d (%s)", (int) err,
+                      curl_easy_strerror(err));
         return EIO;
     }
 }
@@ -241,6 +243,8 @@ static int multi_errno(CURLMcode errm)
         return ENOMEM;
 
     default:
+        hts_log_error("Libcurl reported error %d (%s)", (int) errm,
+                      curl_multi_strerror(errm));
         return EIO;
     }
 }
@@ -818,8 +822,13 @@ static ssize_t libcurl_read(hFILE *fpv, void *bufferv, size_t nbytes)
         fp->buffer.ptr.rd = buffer;
         fp->buffer.len = nbytes;
         fp->paused = 0;
-        err = curl_easy_pause(fp->easy, CURLPAUSE_CONT);
-        if (err != CURLE_OK) { errno = easy_errno(fp->easy, err); return -1; }
+        if (!fp->finished) {
+            err = curl_easy_pause(fp->easy, CURLPAUSE_CONT);
+            if (err != CURLE_OK) {
+                errno = easy_errno(fp->easy, err);
+                return -1;
+            }
+        }
 
         while (! fp->paused && ! fp->finished) {
             if (wait_perform(fp) < 0) return -1;
@@ -1046,12 +1055,6 @@ static int restart_from_position(hFILE_libcurl *fp, off_t pos) {
     }
     temp_fp.nrunning = ++fp->nrunning;
 
-    err = curl_easy_pause(temp_fp.easy, CURLPAUSE_CONT);
-    if (err != CURLE_OK) {
-        save_errno = easy_errno(temp_fp.easy, err);
-        goto error_remove;
-    }
-
     while (! temp_fp.paused && ! temp_fp.finished)
         if (wait_perform(&temp_fp) < 0) {
             save_errno = errno;
@@ -1127,8 +1130,10 @@ static int libcurl_close(hFILE *fpv)
     fp->buffer.len = 0;
     fp->closing = 1;
     fp->paused = 0;
-    err = curl_easy_pause(fp->easy, CURLPAUSE_CONT);
-    if (err != CURLE_OK) save_errno = easy_errno(fp->easy, err);
+    if (!fp->finished) {
+        err = curl_easy_pause(fp->easy, CURLPAUSE_CONT);
+        if (err != CURLE_OK) save_errno = easy_errno(fp->easy, err);
+    }
 
     while (save_errno == 0 && ! fp->paused && ! fp->finished)
         if (wait_perform(fp) < 0) save_errno = errno;


### PR DESCRIPTION
Curl update curl/curl#5050 (pause: bail out on bad input) made curl_easy_pause() return an error if passed
a disconnected CURL handle.  In hfile_libcurl this could happen when libcurl_read() or libcurl_close() was called after all
bytes had been read; or all the time in restart_from_position().

Fix by checking for fp->finished in libcurl_read() and libcurl_close(); and by removing the curl_easy_pause() in restart_from_position().

Thanks to @jmarshall for tracking down the exact libcurl change that caused the incompatibility.

Fixes samtools/samtools#1254 (Trouble reading SRA CRAM files in Google Cloud buckets)
Fixes samtools/samtools#1284 (samtools view crashes reading from amazon s3 http url?)