### PR TITLE
Fixed a (harmless) CRAM uninitialised data access.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1526,7 +1526,8 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
 
             if (ds & CRAM_QQ) {
                 if (!c->comp_hdr->codecs[DS_QQ]) return -1;
-                if ((unsigned char)*qual == 255)
+                if ((ds & CRAM_QS) && !(cf & CRAM_FLAG_PRESERVE_QUAL_SCORES)
+                    && (unsigned char)*qual == 255)
                     memset(qual, 30, cr->len); // ?
                 r |= c->comp_hdr->codecs[DS_QQ]
                     ->decode(s, c->comp_hdr->codecs[DS_QQ], blk,
@@ -1578,7 +1579,8 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
             }
             if (ds & CRAM_QS) {
                 if (!c->comp_hdr->codecs[DS_QS]) return -1;
-                if ((unsigned char)*qual == 255)
+                if (!(cf & CRAM_FLAG_PRESERVE_QUAL_SCORES)
+                    && (unsigned char)*qual == 255)
                     memset(qual, 30, cr->len); // ASCII ?.  Same as htsjdk
                 r |= c->comp_hdr->codecs[DS_QS]
                                 ->decode(s, c->comp_hdr->codecs[DS_QS], blk,
@@ -1599,7 +1601,8 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
         case 'Q': { // Quality score; QS
             if (ds & CRAM_QS) {
                 if (!c->comp_hdr->codecs[DS_QS]) return -1;
-                if ((unsigned char)*qual == 255)
+                if (!(cf & CRAM_FLAG_PRESERVE_QUAL_SCORES) &&
+                    (unsigned char)*qual == 255)
                     memset(qual, 30, cr->len); // ?
                 r |= c->comp_hdr->codecs[DS_QS]
                                 ->decode(s, c->comp_hdr->codecs[DS_QS], blk,


### PR DESCRIPTION
This was caused by the fix in PR #1094.

The problem there was data without explicit quality scores being set
(CF data series with "preserve qual scores" not set) could be coupled
with explicit Q or q feature codes to add qualities at specific
sites.  Without quals, the default is "*" (a run of Q255), but we
can't just amend a few qualities here and there as that leads to a mix
of Q255 and Q-something-else.  We memset from Q255 to Q-something-else
the on the first explicit quality change.

The flaw is that this check is applied even on data where the
"preserve qual scores" CF value is set, but we haven't initialised the
quality string to all-Q255 in that scenario.

However it was totally harmless, as if we preserve quality scores,
then the entire array of quality values are then subsequently
overwritten (after applying any per-base qualities - dumb I know, but
it was never intended for that scenario).  So irrespective of the
outcome of the uninitialised check and whether or not the memset to
Q30 happened, the data still ends up the same thing.

Note curiously this does not show up with -fsanitize=address, but
valgrind does detect it.  Hence the test harness was passing fine.