### PR TITLE
Download index files atomically in idx_test_and_fetch()

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2433,16 +2433,13 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
             return -1;
         }
 
-        if (hwrite(fp, r->seq, r->length) != r->length) {
-            perror(path);
-        }
-        if (hclose(fp) < 0) {
+        ssize_t length_written = hwrite(fp, r->seq, r->length);
+        if (hclose(fp) < 0 || length_written != r->length ||
+            chmod(path_tmp.s, 0444) < 0 ||
+            rename(path_tmp.s, path) < 0) {
+            hts_log_error("Creating reference at %s failed: %s",
+                          path, strerror(errno));
             unlink(path_tmp.s);
-        } else {
-            if (0 == chmod(path_tmp.s, 0444))
-                rename(path_tmp.s, path);
-            else
-                unlink(path_tmp.s);
         }
     }
 

--- a/hts.c
+++ b/hts.c
@@ -1400,14 +1400,16 @@ hFILE *hts_open_tmpfile(const char *fname, const char *mode, kstring_t *tmpname)
     int pid = (int) getpid();
     unsigned ptr = (uintptr_t) tmpname;
     int n = 0;
-    hFILE *fp;
+    hFILE *fp = NULL;
 
     do {
         // Attempt to further uniquify the temporary filename
         unsigned t = ((unsigned) time(NULL)) ^ ((unsigned) clock()) ^ ptr;
         n++;
 
-        ksprintf(ks_clear(tmpname), "%s.tmp_%d_%d_%u", fname, pid, n, t);
+        ks_clear(tmpname);
+        if (ksprintf(tmpname, "%s.tmp_%d_%d_%u", fname, pid, n, t) < 0) break;
+
         fp = hopen(tmpname->s, mode);
     } while (fp == NULL && errno == EEXIST && n < 100);
 

--- a/hts_internal.h
+++ b/hts_internal.h
@@ -67,6 +67,9 @@ void hts_idx_amend_last(hts_idx_t *idx, uint64_t offset);
 
 int hts_idx_fmt(hts_idx_t *idx);
 
+// Construct a unique filename based on fname and open it.
+struct hFILE *hts_open_tmpfile(const char *fname, const char *mode, kstring_t *tmpname);
+
 // Check that index is capable of storing items in range beg..end
 int hts_idx_check_range(hts_idx_t *idx, int tid, hts_pos_t beg, hts_pos_t end);
 


### PR DESCRIPTION
In https://github.com/samtools/samtools/issues/1242#issuecomment-627386086, @valeriuo wrote:

> A footnote: when running parallel jobs on a S3 file, it is advisable to download the index file in the current folder a priori, otherwise each job might try to do that independently, resulting in a corrupt index file.

This is a pretty tragic bug in the index downloading — instead it should use the same technique as the CRAM reference code does to download into a unique temporary filename and atomically `rename()` the file into place at the end.

This PR extracts filename uniquification into a new `hts_open_tmpfile()` function declared in _hts_internal.h_ and uses it in the two places where files are currently downloaded and saved as a byproduct of htslib operations. (Are there any others?)

No code in _hts.c_ currently uses pthreads directly, so instead of mixing `pthread_self()` into `tmpname`, mix in the pointer value of one of the arguments — which will vary across threads. Trick inspired by musl's `mkstemp()` implementation.