### PR TITLE
Add struct tags to htslib/*.h public typedefs

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -167,7 +167,7 @@ typedef struct
 }
 bgzidx1_t;
 
-struct __bgzidx_t
+struct bgzidx_t
 {
     int noffs, moffs;       // the size of the index, n:used, m:allocated
     bgzidx1_t *offs;        // offsets

--- a/faidx.c
+++ b/faidx.c
@@ -52,7 +52,7 @@ typedef struct {
 } faidx1_t;
 KHASH_MAP_INIT_STR(s, faidx1_t)
 
-struct __faidx_t {
+struct faidx_t {
     BGZF *bgzf;
     int n, m;
     char **name;

--- a/hts.c
+++ b/hts.c
@@ -1645,7 +1645,7 @@ typedef struct {
     uint64_t *offset;
 } lidx_t;
 
-struct __hts_idx_t {
+struct hts_idx_t {
     int fmt, min_shift, n_lvls, n_bins;
     uint32_t l_meta;
     int32_t n, m;

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -53,7 +53,7 @@ struct hFILE;
 struct hts_tpool;
 struct kstring_t;
 struct bgzf_mtaux_t;
-typedef struct __bgzidx_t bgzidx_t;
+typedef struct bgzidx_t bgzidx_t;
 typedef struct bgzf_cache_t bgzf_cache_t;
 struct z_stream_s;
 

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -66,9 +66,9 @@ extern "C" {
     wrapped in the same way.
  */
 
-struct __faidx_t;
+struct faidx_t;
 /// Opaque structure representing FASTA index
-typedef struct __faidx_t faidx_t;
+typedef struct faidx_t faidx_t;
 
 /// File format to be dealing with.
 enum fai_format_options {

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -222,8 +222,8 @@ typedef struct htsFormat {
     void *specific;  // format specific options; see struct hts_opt.
 } htsFormat;
 
-struct __hts_idx_t;
-typedef struct __hts_idx_t hts_idx_t;
+struct hts_idx_t;
+typedef struct hts_idx_t hts_idx_t;
 
 // Maintainers note htsFile cannot be an opaque structure because some of its
 // fields are part of libhts.so's ABI (hence these fields must not be moved):

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -729,11 +729,6 @@ typedef struct hts_itr_t {
     } bins;
 } hts_itr_t;
 
-typedef struct aux_key_t {
-    int key;
-    uint64_t min_off, max_off;
-} aux_key_t;
-
 typedef hts_itr_t hts_itr_multi_t;
 
     #define hts_bin_first(l) (((1<<(((l)<<1) + (l))) - 1) / 7)

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -235,7 +235,7 @@ typedef struct __hts_idx_t hts_idx_t;
 //  - is_bgzf and is_cram flags indicate which fp union member to use.
 //    Note is_bgzf being set does not indicate the flag is BGZF compressed,
 //    nor even whether it is compressed at all (eg on naked BAMs).
-typedef struct {
+typedef struct htsFile {
     uint32_t is_bin:1, is_write:1, is_be:1, is_cram:1, is_bgzf:1, dummy:27;
     int64_t lineno;
     kstring_t line;
@@ -259,7 +259,7 @@ typedef struct {
 // Reasons for explicitly setting it could be where many more file
 // descriptors are in use than threads, so keeping memory low is
 // important.
-typedef struct {
+typedef struct htsThreadPool {
     struct hts_tpool *pool; // The shared thread pool itself
     int qsize;    // Size of I/O queue to use for this fp
 } htsThreadPool;
@@ -645,22 +645,22 @@ typedef int64_t hts_pos_t;
 // #define PRIhts_pos PRId32
 // typedef int32_t hts_pos_t;
 
-typedef struct {
+typedef struct hts_pair_pos_t {
    hts_pos_t beg, end;
 } hts_pair_pos_t;
 
 typedef hts_pair_pos_t hts_pair32_t;  // For backwards compatibility
 
-typedef struct {
+typedef struct hts_pair64_t {
     uint64_t u, v;
 } hts_pair64_t;
 
-typedef struct {
+typedef struct hts_pair64_max_t {
     uint64_t u, v;
     uint64_t max;
 } hts_pair64_max_t;
 
-typedef struct {
+typedef struct hts_reglist_t {
     const char *reg;
     hts_pair_pos_t *intervals;
     int tid;
@@ -711,7 +711,7 @@ typedef int64_t hts_tell_func(void *fp);
  * tell       - File specific function for indicating the file offset
  */
 
-typedef struct {
+typedef struct hts_itr_t {
     uint32_t read_rest:1, finished:1, is_cram:1, nocoor:1, multi:1, dummy:27;
     int tid, n_off, i, n_reg;
     hts_pos_t beg, end;
@@ -729,7 +729,7 @@ typedef struct {
     } bins;
 } hts_itr_t;
 
-typedef struct {
+typedef struct aux_key_t {
     int key;
     uint64_t min_off, max_off;
 } aux_key_t;

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -225,7 +225,13 @@ typedef struct htsFormat {
 struct hts_idx_t;
 typedef struct hts_idx_t hts_idx_t;
 
-// Maintainers note htsFile cannot be an opaque structure because some of its
+/**
+ * @brief File handle returned by hts_open() etc.
+ * This structure should be considered opaque by end users. There should be
+ * no need to access most fields directly in user code, and in cases where
+ * it is desirable accessor functions such as hts_get_format() are provided.
+ */
+// Maintainers note htsFile cannot be an incomplete struct because some of its
 // fields are part of libhts.so's ABI (hence these fields must not be moved):
 //  - fp is used in the public sam_itr_next()/etc macros
 //  - is_bin is used directly in samtools <= 1.1 and bcftools <= 1.1

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -71,7 +71,7 @@ typedef struct kstring_t {
 } kstring_t;
 #endif
 
-typedef struct {
+typedef struct ks_tokaux_t {
 	uint64_t tab[4];
 	int sep, finished;
 	const char *p; // end of the current token

--- a/htslib/regidx.h
+++ b/htslib/regidx.h
@@ -80,7 +80,7 @@ extern "C" {
 #define REGIDX_MAX (1ULL << 35)
 
 typedef struct regidx_t regidx_t;
-typedef struct
+typedef struct regitr_t
 {
     hts_pos_t beg,end;
     void *payload;

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -200,7 +200,7 @@ extern const int8_t bam_cigar_table[256];
  @field  mpos    0-based leftmost coordinate of next read in template
  @field  isize   observed template length ("insert size")
  */
-typedef struct {
+typedef struct bam1_core_t {
     hts_pos_t pos;
     int32_t tid;
     uint16_t bin; // NB: invalid on 64-bit pos
@@ -239,7 +239,7 @@ typedef struct {
  5. Per base qualilties are stored in the Phred scale with no +33 offset.
     Ie as per the BAM specification and not the SAM ASCII printable method.
  */
-typedef struct {
+typedef struct bam1_t {
     bam1_core_t core;
     uint64_t id;
     uint8_t *data;
@@ -1610,7 +1610,7 @@ typedef union {
  implementation of alignment viewers, but calculating this has some
  overhead.
  */
-typedef struct {
+typedef struct bam_pileup1_t {
     bam1_t *b;
     int32_t qpos;
     int indel, level;

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1621,11 +1621,11 @@ typedef struct bam_pileup1_t {
 
 typedef int (*bam_plp_auto_f)(void *data, bam1_t *b);
 
-struct __bam_plp_t;
-typedef struct __bam_plp_t *bam_plp_t;
+struct bam_plp_s;
+typedef struct bam_plp_s *bam_plp_t;
 
-struct __bam_mplp_t;
-typedef struct __bam_mplp_t *bam_mplp_t;
+struct bam_mplp_s;
+typedef struct bam_mplp_s *bam_mplp_t;
 
     /**
      *  bam_plp_init() - sets an iterator over multiple

--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -132,7 +132,7 @@ typedef struct _bcf_sr_regions_t
 }
 bcf_sr_regions_t;
 
-typedef struct
+typedef struct bcf_sr_t
 {
     htsFile *file;
     tbx_t *tbx_idx;
@@ -154,7 +154,7 @@ typedef enum
 }
 bcf_sr_error;
 
-typedef struct
+typedef struct bcf_srs_t
 {
     // Parameters controlling the logic
     int collapse;           // Do not access directly, use bcf_sr_set_pairing_logic() instead

--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -100,7 +100,9 @@ typedef enum
 }
 bcf_sr_opt_t;
 
-typedef struct _bcf_sr_regions_t
+struct bcf_sr_region_t;
+
+typedef struct bcf_sr_regions_t
 {
     // for reading from tabix-indexed file (big data)
     tbx_t *tbx;             // tabix index
@@ -115,11 +117,11 @@ typedef struct _bcf_sr_regions_t
     int als_type;           // alleles type, currently VCF_SNP or VCF_INDEL
 
     // user handler to deal with skipped regions without a counterpart in VCFs
-    void (*missed_reg_handler)(struct _bcf_sr_regions_t *, void *);
+    void (*missed_reg_handler)(struct bcf_sr_regions_t *, void *);
     void *missed_reg_data;
 
     // for in-memory regions (small data)
-    struct _region_t *regs; // the regions
+    struct bcf_sr_region_t *regs; // the regions
 
     // shared by both tabix-index and in-memory regions
     void *seq_hash;         // keys: sequence names, values: index to seqs

--- a/htslib/tbx.h
+++ b/htslib/tbx.h
@@ -40,13 +40,13 @@ extern "C" {
 #define TBX_VCF     2
 #define TBX_UCSC    0x10000
 
-typedef struct {
+typedef struct tbx_conf_t {
     int32_t preset;
     int32_t sc, bc, ec; // seq col., beg col. and end col.
     int32_t meta_char, line_skip;
 } tbx_conf_t;
 
-typedef struct {
+typedef struct tbx_t {
     tbx_conf_t conf;
     hts_idx_t *idx;
     void *dict;

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -142,9 +142,9 @@ extern uint8_t bcf_type_shift[];
 #define VCF_BND     16    // breakend
 #define VCF_OVERLAP 32    // overlapping deletion, ALT=*
 
-typedef struct variant_t {
+typedef struct bcf_variant_t {
     int type, n;    // variant type and the number of bases affected, negative for deletions
-} variant_t;
+} bcf_variant_t;
 
 typedef struct bcf_fmt_t {
     int id;             // id: numeric tag id, the corresponding string is bcf_hdr_t::id[BCF_DT_ID][$id].key
@@ -183,7 +183,7 @@ typedef struct bcf_dec_t {
     char **allele;      // allele[0] is the REF (allele[] pointers to the als block); all null terminated
     bcf_info_t *info;   // INFO
     bcf_fmt_t *fmt;     // FORMAT and individual sample
-    variant_t *var;     // $var and $var_type set only when set_variant_types called
+    bcf_variant_t *var; // $var and $var_type set only when set_variant_types called
     int n_var, var_type;
     int shared_dirty;   // if set, shared.s must be recreated on BCF output
     int indiv_dirty;    // if set, indiv.s must be recreated on BCF output

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -85,7 +85,7 @@ extern "C" {
 #define BCF_DT_SAMPLE   2
 
 // Complete textual representation of a header line
-typedef struct {
+typedef struct bcf_hrec_t {
     int type;       // One of the BCF_HL_* type
     char *key;      // The part before '=', i.e. FILTER/INFO/FORMAT/contig/fileformat etc.
     char *value;    // Set only for generic lines, NULL for FILTER/INFO, etc.
@@ -93,20 +93,20 @@ typedef struct {
     char **keys, **vals;    // The key=value pairs
 } bcf_hrec_t;
 
-typedef struct {
+typedef struct bcf_idinfo_t {
     uint64_t info[3];  // stores Number:20, var:4, Type:4, ColType:4 in info[0..2]
                        // for BCF_HL_FLT,INFO,FMT and contig length in info[0] for BCF_HL_CTG
     bcf_hrec_t *hrec[3];
     int id;
 } bcf_idinfo_t;
 
-typedef struct {
+typedef struct bcf_idpair_t {
     const char *key;
     const bcf_idinfo_t *val;
 } bcf_idpair_t;
 
 // Note that bcf_hdr_t structs must always be created via bcf_hdr_init()
-typedef struct {
+typedef struct bcf_hdr_t {
     int32_t n[3];           // n:the size of the dictionary block in use, (allocated size, m, is below to preserve ABI)
     bcf_idpair_t *id[3];
     void *dict[3];          // ID dictionary, contig dict and sample dict
@@ -142,11 +142,11 @@ extern uint8_t bcf_type_shift[];
 #define VCF_BND     16    // breakend
 #define VCF_OVERLAP 32    // overlapping deletion, ALT=*
 
-typedef struct {
+typedef struct variant_t {
     int type, n;    // variant type and the number of bases affected, negative for deletions
 } variant_t;
 
-typedef struct {
+typedef struct bcf_fmt_t {
     int id;             // id: numeric tag id, the corresponding string is bcf_hdr_t::id[BCF_DT_ID][$id].key
     int n, size, type;  // n: number of values per-sample; size: number of bytes per-sample; type: one of BCF_BT_* types
     uint8_t *p;         // same as vptr and vptr_* in bcf_info_t below
@@ -154,7 +154,7 @@ typedef struct {
     uint32_t p_off:31, p_free:1;
 } bcf_fmt_t;
 
-typedef struct {
+typedef struct bcf_info_t {
     int key;        // key: numeric tag id, the corresponding string is bcf_hdr_t::id[BCF_DT_ID][$key].key
     int type;  // type: one of BCF_BT_* types
     union {
@@ -175,7 +175,7 @@ typedef struct {
 #define BCF1_DIRTY_FLT 4
 #define BCF1_DIRTY_INF 8
 
-typedef struct {
+typedef struct bcf_dec_t {
     int m_fmt, m_info, m_id, m_als, m_allele, m_flt; // allocated size (high-water mark); do not change
     int n_flt;  // Number of FILTER fields
     int *flt;   // FILTER keys in the dictionary
@@ -209,7 +209,7 @@ typedef struct {
     shared.s, indiv.s, etc.) are written directly by bcf_write, whereas a VCF
     line must be formatted in vcf_format.
  */
-typedef struct {
+typedef struct bcf1_t {
     hts_pos_t pos;  // POS
     hts_pos_t rlen; // length of REF
     int32_t rid;  // CHROM

--- a/htslib/vcf_sweep.h
+++ b/htslib/vcf_sweep.h
@@ -33,7 +33,7 @@ DEALINGS IN THE SOFTWARE.  */
 extern "C" {
 #endif
 
-typedef struct _bcf_sweep_t bcf_sweep_t;
+typedef struct bcf_sweep_t bcf_sweep_t;
 
 HTSLIB_EXPORT
 bcf_sweep_t *bcf_sweep_init(const char *fname);

--- a/sam.c
+++ b/sam.c
@@ -4140,7 +4140,7 @@ int bam_plp_insertion(const bam_pileup1_t *p, kstring_t *ins, int *del_len) {
 KHASH_MAP_INIT_STR(olap_hash, lbnode_t *)
 typedef khash_t(olap_hash) olap_hash_t;
 
-struct __bam_plp_t {
+struct bam_plp_s {
     mempool_t *mp;
     lbnode_t *head, *tail;
     int32_t tid, max_tid;
@@ -4163,7 +4163,7 @@ struct __bam_plp_t {
 bam_plp_t bam_plp_init(bam_plp_auto_f func, void *data)
 {
     bam_plp_t iter;
-    iter = (bam_plp_t)calloc(1, sizeof(struct __bam_plp_t));
+    iter = (bam_plp_t)calloc(1, sizeof(struct bam_plp_s));
     iter->mp = mp_init();
     iter->head = iter->tail = mp_alloc(iter->mp);
     iter->max_tid = iter->max_pos = -1;
@@ -4609,7 +4609,7 @@ void bam_plp_set_maxcnt(bam_plp_t iter, int maxcnt)
  *** Mpileup iterator ***
  ************************/
 
-struct __bam_mplp_t {
+struct bam_mplp_s {
     int n;
     int32_t min_tid, *tid;
     hts_pos_t min_pos, *pos;
@@ -4622,7 +4622,7 @@ bam_mplp_t bam_mplp_init(int n, bam_plp_auto_f func, void **data)
 {
     int i;
     bam_mplp_t iter;
-    iter = (bam_mplp_t)calloc(1, sizeof(struct __bam_mplp_t));
+    iter = (bam_mplp_t)calloc(1, sizeof(struct bam_mplp_s));
     iter->pos = (hts_pos_t*)calloc(n, sizeof(hts_pos_t));
     iter->tid = (int32_t*)calloc(n, sizeof(int32_t));
     iter->n_plp = (int*)calloc(n, sizeof(int));

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -56,7 +56,7 @@ typedef struct
 }
 region1_t;
 
-typedef struct _region_t
+typedef struct bcf_sr_region_t
 {
     region1_t *regs;            // regions will sorted and merged, redundant records marked for skipping have start>end
     int nregs, mregs, creg;     // creg: the current active region

--- a/vcf.c
+++ b/vcf.c
@@ -3915,7 +3915,7 @@ int bcf_is_snp(bcf1_t *v)
     return i == v->n_allele;
 }
 
-static void bcf_set_variant_type(const char *ref, const char *alt, variant_t *var)
+static void bcf_set_variant_type(const char *ref, const char *alt, bcf_variant_t *var)
 {
     if ( *alt == '*' && !alt[1] ) { var->n = 0; var->type = VCF_OVERLAP; return; }  // overlapping variant
 
@@ -3984,7 +3984,7 @@ static int bcf_set_variant_types(bcf1_t *b)
     bcf_dec_t *d = &b->d;
     if ( d->n_var < b->n_allele )
     {
-        d->var = (variant_t *) realloc(d->var, sizeof(variant_t)*b->n_allele);
+        d->var = (bcf_variant_t *) realloc(d->var, sizeof(bcf_variant_t)*b->n_allele);
         d->n_var = b->n_allele;
     }
     int i;

--- a/vcf_sweep.c
+++ b/vcf_sweep.c
@@ -33,7 +33,7 @@ DEALINGS IN THE SOFTWARE.  */
 #define SW_FWD 0
 #define SW_BWD 1
 
-struct _bcf_sweep_t
+struct bcf_sweep_t
 {
     htsFile *file;
     bcf_hdr_t *hdr;


### PR DESCRIPTION
This PR adds struct tags so it's possible to write e.g. `struct htsFile` to forward declare htsFile as an incomplete struct in circumstances when you'd rather not `#include <htslib/hts.h>`, thus fixes #1106.

Presented as separate commits in vaguely increasing order of theoretical API compatibility issues:

* Adds tags where there weren't any before — no issues.

* Removes `aux_key_t` which was accidentally added and never used in HTSlib.

* Renames reserved-to-the-compiler tags such as `typedef struct __bgzidx_t bgzidx_t` — third party code could conceivably have been using these tags but as they start with underscores users should have …uh… been expecting undefined results.

* Renames `variant_t` to `bcf_variant_t`. This struct is used only as the type of a field within `bcf_dec_t`, which itself is an internal field of `bcf1_t` and is unlikely to be used directly. So user code is very unlikely to be using this identifier directly.