### PR TITLE
Compile ks_free() with HTSlib

### DIFF
--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -122,6 +122,10 @@ extern "C" {
     HTSLIB_EXPORT
 	int kgetline2(kstring_t *s, kgets_func2 *fgets, void *fp);
 
+    // Safely free the underlying buffer in a kstring.
+    HTSLIB_EXPORT
+    void ks_free(kstring_t *s);
+
 #ifdef __cplusplus
 }
 #endif
@@ -204,15 +208,6 @@ static inline char *ks_release(kstring_t *s)
 	s->l = s->m = 0;
 	s->s = NULL;
 	return ss;
-}
-
-/// Safely free the underlying buffer in a kstring.
-static inline void ks_free(kstring_t *s)
-{
-    if (s) {
-        free(s->s);
-        ks_initialize(s);
-    }
 }
 
 static inline int kputsn(const char *p, size_t l, kstring_t *s)

--- a/kstring.c
+++ b/kstring.c
@@ -48,6 +48,15 @@ int ks_resize2(kstring_t *s, size_t size)
 	return 0;
 }
 
+HTSLIB_EXPORT
+void ks_free(kstring_t *s)
+{
+    if (s) {
+        free(s->s);
+        ks_initialize(s);
+    }
+}
+
 int kputd(double d, kstring_t *s) {
 	int len = 0;
 	char buf[21], *cp = buf+20, *ep;


### PR DESCRIPTION
Since the memory allocation of **kstring**s is managed by the C runtime HTSlib is built with, the deallocation should be managed by the same runtime. For this purpose, `ks_free()` is now compiled together with HTSlib and not inlined in the calling application.

Fixes #1114 
