### PR TITLE
Ignore errors when closing the input file in the fuzzer

### DIFF
--- a/test/fuzz/hts_open_fuzzer.c
+++ b/test/fuzz/hts_open_fuzzer.c
@@ -147,6 +147,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         default:
             break;
     }
-    hts_close_or_abort(ht_file);
+    hts_close(ht_file);
     return 0;
 }


### PR DESCRIPTION
Since 3855184b, hts_close() returns non-zero if earlier errors were detected on the file handle.  As this frequently
happens with fuzz input, it should not be treated as a fuzzing failure.

Credit to OSS-Fuzz
Fixes oss-fuzz 25037
