### PR TITLE
Account for underflow in kt_fisher_exact()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ shlib-exports-*.txt
 /test/test-bcf-translate
 /test/test_bgzf
 /test/test_index
+/test/test_kfunc
 /test/test_kstring
 /test/test-parse-reg
 /test/test_realn

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ BUILT_TEST_PROGRAMS = \
 	test/plugins-dlhts \
 	test/sam \
 	test/test_bgzf \
+	test/test_kfunc \
 	test/test_kstring \
 	test/test_realn \
 	test/test-regidx \
@@ -393,6 +394,7 @@ maintainer-check:
 #    MSYS2_ARG_CONV_EXCL="*" make check
 check test: $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS) $(BUILT_PLUGINS)
 	test/hts_endian
+	test/test_kfunc
 	test/test_kstring
 	test/test_str2int
 	test/fieldarith test/fieldarith.sam
@@ -430,6 +432,9 @@ test/sam: test/sam.o libhts.a
 
 test/test_bgzf: test/test_bgzf.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_bgzf.o libhts.a -lz $(LIBS) -lpthread
+
+test/test_kfunc: test/test_kfunc.o libhts.a
+	$(CC) $(LDFLAGS) -o $@ test/test_kfunc.o libhts.a -lz $(LIBS) -lpthread
 
 test/test_kstring: test/test_kstring.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_kstring.o libhts.a -lz $(LIBS) -lpthread
@@ -472,6 +477,7 @@ test/pileup.o: test/pileup.c config.h $(htslib_sam_h) $(htslib_kstring_h)
 test/plugins-dlhts.o: test/plugins-dlhts.c config.h
 test/sam.o: test/sam.c config.h $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_faidx_h) $(htslib_khash_h) $(htslib_hts_log_h)
 test/test_bgzf.o: test/test_bgzf.c config.h $(htslib_bgzf_h) $(htslib_hfile_h) $(hfile_internal_h)
+test/test_kfunc.o: test/test_kfunc.c config.h $(htslib_kfunc_h)
 test/test_kstring.o: test/test_kstring.c config.h $(htslib_kstring_h)
 test/test-parse-reg.o: test/test-parse-reg.c config.h $(htslib_hts_h) $(htslib_sam_h)
 test/test_realn.o: test/test_realn.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h)

--- a/kfunc.c
+++ b/kfunc.c
@@ -29,6 +29,7 @@
 
 #include <math.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include "htslib/kfunc.h"
 
 /* Log gamma function
@@ -255,6 +256,38 @@ double kt_fisher_exact(int n11, int n12, int n21, int n22, double *_left, double
     *two = *_left = *_right = 1.;
     if (min == max) return 1.; // no need to do test
     q = hypergeo_acc(n11, n1_, n_1, n, &aux); // the probability of the current table
+
+    if (q == 0.0) {
+        /*
+          If here, the calculated probablility is so small it can't be stored
+          in a double, which is possible when the table contains fairly large
+          numbers.  If this happens, most of the calculation can be skipped
+          as 'left', 'right' and '*two' will be (to a good approximation) 0.0.
+          The returned values '*_left' and '*_right' depend on which side
+          of the hypergeometric PDF 'n11' sits.  This can be found by
+          comparing with the mode of the distribution, the formula for which
+          can be found at:
+          https://en.wikipedia.org/wiki/Hypergeometric_distribution
+          Note that in the comparison we multiply through by the denominator
+          of the mode (n + 2) to avoid a division.
+        */
+        if ((int64_t) n11 * ((int64_t) n + 2) < ((int64_t) n_1 + 1) * ((int64_t) n1_ + 1)) {
+            // Peak to right of n11, so probability will be lower for all
+            // of the region from min to n11 and higher for at least some
+            // of the region from n11 to max; hence abs(i-n11) will be 0,
+            // abs(j-n11) will be > 0 and:
+            *_left = 0.0; *_right = 1.0; *two = 0.0;
+            return 0.0;
+        } else {
+            // Peak to left of n11, so probability will be lower for all
+            // of the region from n11 to max and higher for at least some
+            // of the region from min to n11; hence abs(i-n11) will be > 0,
+            // abs(j-n11) will be 0 and:
+            *_left = 1.0; *_right = 0.0; *two = 0.0;
+            return 0.0;
+        }
+    }
+
     // left tail
     p = hypergeo_acc(min, 0, 0, 0, &aux);
     for (left = 0., i = min + 1; p < 0.99999999 * q && i<=max; ++i) // loop until underflow
@@ -278,6 +311,3 @@ double kt_fisher_exact(int n11, int n12, int n21, int n22, double *_left, double
     *_left = left; *_right = right;
     return q;
 }
-
-
-

--- a/test/test_kfunc.c
+++ b/test/test_kfunc.c
@@ -1,0 +1,88 @@
+/*  test_kfunc.c -- kt_fisher_exact() unit tests
+
+    Copyright (C) 2020 University of Glasgow.
+
+    Author: John Marshall <John.W.Marshall@glasgow.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <config.h>
+
+#include <math.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "../htslib/kfunc.h"
+
+int differ(double obs, double expected)
+{
+    return fabs(obs - expected) > 1e-8;
+}
+
+int nfailed = 0;
+
+void fail(const char *test, double obs, double expected,
+          int n11, int n12, int n21, int n22)
+{
+    fprintf(stderr, "[%d %d | %d %d] %s: %g (expected %g)\n",
+            n11, n12, n21, n22, test, obs, expected);
+    nfailed++;
+}
+
+void test_fisher(int n11, int n12, int n21, int n22,
+                 double eleft, double eright, double etwo, double eprob)
+{
+    double prob, left, right, two;
+    prob = kt_fisher_exact(n11, n12, n21, n22, &left, &right, &two);
+    if (differ(left, eleft)) fail("LEFT", left, eleft, n11, n12, n21, n22);
+    if (differ(right, eright)) fail("RIGHT", right, eright, n11, n12, n21, n22);
+    if (differ(two, etwo)) fail("TWO-TAIL", two, etwo, n11, n12, n21, n22);
+    if (differ(prob, eprob)) fail("RESULT", prob, eprob, n11, n12, n21, n22);
+}
+
+int main(int argc, char **argv)
+{
+    test_fisher(2, 1, 0, 31,   1.0, 0.005347593583, 0.005347593583, 0.005347593583);
+    test_fisher(2, 1, 0, 1,    1.0, 0.5, 1.0, 0.5);
+    test_fisher(3, 1, 0, 0,    1.0, 1.0, 1.0, 1.0);
+    test_fisher(3, 15, 37, 45, 0.021479750169, 0.995659202564, 0.033161943699, 0.017138952733);
+    test_fisher(12, 5, 29, 2,  0.044554737835, 0.994525206022, 0.080268552074, 0.039079943857);
+
+    test_fisher(781, 23171, 4963, 2455001,   1.0, 0.0, 0.0, 0.0);
+    test_fisher(333, 381, 801722, 7664285,   1.0, 0.0, 0.0, 0.0);
+    test_fisher(4155, 4903, 805463, 8507517, 1.0, 0.0, 0.0, 0.0);
+    test_fisher(4455, 4903, 805463, 8507517, 1.0, 0.0, 0.0, 0.0);
+    test_fisher(5455, 4903, 805463, 8507517, 1.0, 0.0, 0.0, 0.0);
+
+    test_fisher(1, 1, 100000, 1000000, 0.991735477166, 0.173555146661, 0.173555146661, 0.165290623827);
+    test_fisher(1000, 1000, 100000, 1000000, 1.0, 0.0, 0.0, 0.0);
+    test_fisher(1000, 1000, 1000000, 100000, 0.0, 1.0, 0.0, 0.0);
+
+    test_fisher(49999, 10001,  90001, 49999, 1.0, 0.0, 0.0, 0.0);
+    test_fisher(50000, 10000,  90000, 50000, 1.0, 0.0, 0.0, 0.0);
+    test_fisher(50001,  9999,  89999, 50001, 1.0, 0.0, 0.0, 0.0);
+    test_fisher(10000, 50000, 130000, 10000, 0.0, 1.0, 0.0, 0.0);
+
+    if (nfailed > 0) {
+        const char *plural = (nfailed == 1)? "" : "s";
+        fprintf(stderr, "Failed %d test case%s\n", nfailed, plural);
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
As reported in arq5x/bedtools2#855 (bedtools contains a lightly-modified copy of htslib's _kfunc.c_). This backports PR arq5x/bedtools2#856 and adds test cases.

When some of `kt_fisher_exact()`'s input arguments are very large, `hypergeo(…)` is dominated by the subtracted `lbinom()` so returns `exp(≤ -750)`, which underflows, hence `hypergeo()` returns 0.0.

When `q` is 0.0, `kt_fisher_exact()`'s loops never execute and which of `i` and `j` is closer to `n11` is indeterminate. Hence we handle the adjustment of `left`/`right` separately in this case.

The `n11 + n22 < n12 + n21` test in that additional handling is motivated by [this description of left/right](https://www.langsrud.com/fisher.htm#INTRO) and agrees with the implementations in R and SciPy for various test cases, but this function's code is rather opaque so who really knows…

In any case, the patch only makes a difference when `q` is (exactly) 0.0, so does not affect the result for the “usual” range of inputs.