### PR TITLE
Bug fix to the pileup constructor.

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -4577,7 +4577,8 @@ int bam_plp_push(bam_plp_t iter, const bam1_t *b)
                 return -1;
             }
             if (iter->plp_construct)
-                iter->plp_construct(iter->data, b, &iter->tail->cd);
+                iter->plp_construct(iter->data, &iter->tail->b,
+                                    &iter->tail->cd);
             if (overlap_push(iter, iter->tail) < 0) {
                 mp_free(iter->mp, next);
                 iter->error = 1;


### PR DESCRIPTION
We call constructor and destructor for each new bam object that is added to and removed from the pileup.  Pileup also takes its own copy of the bam1_t struct as sam_read1 loops may be using the same structure over and over again.

However the constructor was called with the passed in bam1_t instead of pileups own copy of it (unlike destructor).  Hence anything the constructor attempts to cache, such as the location of an aux tag, may get written over.