### PR TITLE
Have realloc and free in the same layer of kstring

### DIFF
--- a/htslib/kroundup.h
+++ b/htslib/kroundup.h
@@ -32,7 +32,7 @@
 /*
   Macro with value 1 if the highest bit in x is set for any integer type
 
-  This is written avoiding conditionals (?: operator) to reduce the liklihood
+  This is written avoiding conditionals (?: operator) to reduce the likelihood
   of gcc attempting jump thread optimisations for code paths where (x) is
   large.  These optimisations can cause gcc to issue warnings about excessively
   large memory allocations when the kroundup64() macro below is used with

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -144,9 +144,15 @@ static inline void ks_initialize(kstring_t *s)
 /// Resize a kstring to a given capacity
 static inline int ks_resize(kstring_t *s, size_t size)
 {
-	extern HTSLIB_EXPORT int ks_resize2(kstring_t *s, size_t size);
-
-	if (s->m < size) return ks_resize2(s, size);
+	if (s->m < size) {
+	    char *tmp;
+	    size = (size > (SIZE_MAX>>2)) ? SIZE_MAX>>1 : size + (size >> 1);
+	    tmp = (char*)realloc(s->s, size);
+	    if (!tmp && size)
+	        return -1;
+	    s->s = tmp;
+	    s->m = size;
+	}
 	return 0;
 }
 

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -146,9 +146,9 @@ static inline int ks_resize(kstring_t *s, size_t size)
 {
 	if (s->m < size) {
 	    char *tmp;
-	    size = (size > (SIZE_MAX>>2)) ? SIZE_MAX>>1 : size + (size >> 1);
+	    size = (size > (SIZE_MAX>>2)) ? size : size + (size >> 1);
 	    tmp = (char*)realloc(s->s, size);
-	    if (!tmp && size)
+	    if (!tmp)
 	        return -1;
 	    s->s = tmp;
 	    s->m = size;


### PR DESCRIPTION
This PR is an alternative solution to https://github.com/samtools/htslib/pull/1119. Instead of pushing the `free` call inside the HTSlib compiled code, this solution brings `realloc` back to the inline function `ks_resize`, so that it can be directly called by the upper layer.
To minimize the number of CPU instructions generated for `ks_resize`, the round-up to a power of two has been replaced with a simpler approach to increase the string size with 1.5 X requested size. It's the same strategy used by the MS C++ runtime when increasing the capacity of a `vector`.

Fixes #1114