### PR TITLE
Remove now unused ks_resize2 function.

### DIFF
--- a/kstring.c
+++ b/kstring.c
@@ -35,19 +35,6 @@
 #include <math.h>
 #include "htslib/kstring.h"
 
-HTSLIB_EXPORT
-int ks_resize2(kstring_t *s, size_t size)
-{
-	char *tmp;
-	kroundup_size_t(size);
-	tmp = (char*)realloc(s->s, size);
-	if (!tmp && size)
-		return -1;
-	s->s = tmp;
-	s->m = size;
-	return 0;
-}
-
 int kputd(double d, kstring_t *s) {
 	int len = 0;
 	char buf[21], *cp = buf+20, *ep;


### PR DESCRIPTION
NB: This never made it into a release so it isn't an ABI breaking change and nor does it need to be listed in the NEWS file.