### PR TITLE
Spelling corrections [minor]

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -818,11 +818,11 @@ Release 1.4 (13 March 2017)
 * hts_idx_push() will report when trying to add a range to an index that
   is beyond the limits that the given index can handle.  This means trying
   to index chromosomes longer than 2^29 bases with a .bai or .tbi index
-  will report an error instead of apparantly working but creating an invalid
+  will report an error instead of apparently working but creating an invalid
   index entry.
 
 * VCF formatting is now approximately 4x faster.  (Whether this is
-  noticable depends on what was creating the VCF.)
+  noticeable depends on what was creating the VCF.)
 
 * CRAM lossy_names mode now works with TLEN of 0 or TLEN within +/- 1
   of the computed value.  Note in these situations TLEN will be
@@ -917,7 +917,7 @@ Noteworthy changes in release 1.2  (2 February 2015)
 
 * By default, reference sequences are fetched from the EBI CRAM Reference
   Registry and cached in your $HOME cache directory.  This behaviour can
-  be controlled by setting REF_PATH and REF_CACHE enviroment variables
+  be controlled by setting REF_PATH and REF_CACHE environment variables
   (see the samtools(1) man page for details)
 
 * Numerous CRAM improvements:
@@ -938,7 +938,7 @@ Noteworthy changes in release 1.2  (2 February 2015)
 * Optional iRODS file access, disabled by default.  Configure with --with-irods
   to enable accessing iRODS data objects directly via 'irods:DATAOBJ'
 
-* All occurences of 2^29 in the source have been eliminated, so indexing
+* All occurrences of 2^29 in the source have been eliminated, so indexing
   and querying against reference sequences larger than 512Mbp works (when
   using CSI indices)
 

--- a/bgzf.c
+++ b/bgzf.c
@@ -56,7 +56,7 @@
 #define BLOCK_FOOTER_LENGTH 8
 
 
-/* BGZF/GZIP header (speciallized from RFC 1952; little endian):
+/* BGZF/GZIP header (specialized from RFC 1952; little endian):
  +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
  | 31|139|  8|  4|              0|  0|255|      6| 66| 67|      2|BLK_LEN|
  +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
@@ -1367,7 +1367,7 @@ static void *bgzf_mt_writer(void *vp) {
         /*
          * Periodically call hflush (which calls fsync when on a file).
          * This avoids the fsync being done at the bgzf_close stage,
-         * which can sometimes cause signficant delays.  As this is in
+         * which can sometimes cause significant delays.  As this is in
          * a separate thread, spreading the sync delays throughout the
          * program execution seems better.
          * Frequency of 1/512 has been chosen by experimentation
@@ -1743,7 +1743,7 @@ static int mt_destroy(mtaux_t *mt)
     ret = -(hts_tpool_process_is_shutdown(mt->out_queue) > 1);
     // Destroying the queue first forces the writer to exit.
     // mt->out_queue is reference counted, so destroy gets called in both
-    // ths and the IO threads.  The last to do it will clean up.
+    // this and the IO threads.  The last to do it will clean up.
     hts_tpool_process_destroy(mt->out_queue);
 
     // IO thread will now exit.  Wait for it and perform final clean-up.

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2121,7 +2121,7 @@ static int cram_decode_slice_xref(cram_slice *s, int required_fields) {
         }
 
         if (cr->tlen == INT_MIN)
-            cr->tlen = 0; // Just incase
+            cr->tlen = 0; // Just in case
     }
     return 0;
 }

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -2620,7 +2620,7 @@ static cram_container *cram_next_container(cram_fd *fd, bam_seq_t *b) {
     cram_container *c = fd->ctr;
     int i;
 
-    /* First occurence */
+    /* First occurrence */
     if (c->curr_ref == -2)
         c->curr_ref = bam_ref(b);
 

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -282,7 +282,7 @@ int cram_copy_slice(cram_fd *in, cram_fd *out, int32_t num_slice) {
  * the container, meaning multiple compression headers to manipulate.
  * Changing RG may change the size of the compression header and
  * therefore the length field in the container.  Hence we rewrite all
- * blocks just incase and also emit the adjusted container.
+ * blocks just in case and also emit the adjusted container.
  *
  * The current implementation can only cope with renumbering a single
  * RG (and only then if it is using HUFFMAN or BETA codecs).  In

--- a/cram/cram_index.h
+++ b/cram/cram_index.h
@@ -48,7 +48,7 @@ void cram_index_free(cram_fd *fd);
  * Searches the index for the first slice overlapping a reference ID
  * and position.
  *
- * Returns the cram_index pointer on sucess
+ * Returns the cram_index pointer on success
  *         NULL on failure
  */
 cram_index *cram_index_query(cram_fd *fd, int refid, hts_pos_t pos, cram_index *frm);

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1129,7 +1129,7 @@ int cram_uncompress_block(cram_block *b) {
         b->data = (unsigned char *)uncomp;
         b->alloc = usize;
         b->method = RAW;
-        b->uncomp_size = usize; // Just incase it differs
+        b->uncomp_size = usize; // Just in case it differs
         break;
     }
 #else
@@ -1172,7 +1172,7 @@ int cram_uncompress_block(cram_block *b) {
         b->data = (unsigned char *)uncomp;
         b->alloc = usize2;
         b->method = RAW;
-        b->uncomp_size = usize2; // Just incase it differs
+        b->uncomp_size = usize2; // Just in case it differs
         //fprintf(stderr, "Expanded %d to %d\n", b->comp_size, b->uncomp_size);
         break;
     }
@@ -1790,7 +1790,7 @@ static BGZF *bgzf_open_ref(char *fn, char *mode, int is_md5) {
  * Loads a FAI file for a reference.fasta.
  * "is_err" indicates whether failure to load is worthy of emitting an
  * error message. In some cases (eg with embedded references) we
- * speculatively load, just incase, and silently ignore errors.
+ * speculatively load, just in case, and silently ignore errors.
  *
  * Returns the refs_t struct on success (maybe newly allocated);
  *         NULL on failure
@@ -2245,7 +2245,7 @@ static const char *get_cache_basedir(const char **extra) {
  * Queries the M5 string from the header and attempts to populate the
  * reference from this using the REF_PATH environment.
  *
- * Returns 0 on sucess
+ * Returns 0 on success
  *        -1 on failure
  */
 static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
@@ -2302,7 +2302,7 @@ static int cram_populate_ref(cram_fd *fd, int id, ref_entry *r) {
     if (!local_path && (path2 = find_path(tag->str+3, ref_path))) {
         int len = snprintf(path, PATH_MAX, "%s", path2);
         free(path2);
-        if (len > 0 && len < PATH_MAX) // incase it's too long
+        if (len > 0 && len < PATH_MAX) // in case it's too long
             local_path = 1;
     }
 #endif

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -63,7 +63,7 @@ extern "C" {
 // Generic hash-map integer -> integer
 KHASH_MAP_INIT_INT64(m_i2i, int)
 
-// Generic hash-set integer -> (existance)
+// Generic hash-set integer -> (existence)
 KHASH_SET_INIT_INT(s_i2i)
 
 // For brevity
@@ -740,7 +740,7 @@ struct cram_fd {
     unsigned int cram_flag_swap[0x1000];// bam -> cram flags
     unsigned char L1[256];              // ACGT{*} ->0123{4}
     unsigned char L2[256];              // ACGTN{*}->01234{5}
-    char cram_sub_matrix[32][32];       // base substituion codes
+    char cram_sub_matrix[32][32];       // base substitution codes
 
     int         index_sz;
     cram_index *index;                  // array, sizeof index_sz

--- a/cram/mFILE.c
+++ b/cram/mFILE.c
@@ -258,7 +258,7 @@ mFILE *mfcreate_from(const char *path, const char *mode_str, FILE *fp) {
 
 /*
  * Converts a FILE * to an mFILE *.
- * Use this for wrapper functions to turn external prototypes requring
+ * Use this for wrapper functions to turn external prototypes requiring
  * FILE * as an argument into internal code using mFILE *.
  */
 mFILE *mfreopen(const char *path, const char *mode_str, FILE *fp) {

--- a/cram/string_alloc.c
+++ b/cram/string_alloc.c
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 /* creates the string pool. max_length is the initial size
-   a single string can be.  Tha max_length can grow as
+   a single string can be.  The max_length can grow as
    needed */
 
 string_alloc_t *string_pool_create(size_t max_length) {

--- a/header.c
+++ b/header.c
@@ -2027,7 +2027,7 @@ hts_pos_t sam_hdr_tid2len(const sam_hdr_t *h, int tid) {
 
 /*
  * Fixes any PP links in @PG headers.
- * If the entries are in order then this doesn't need doing, but incase
+ * If the entries are in order then this doesn't need doing, but in case
  * our header is out of order this goes through the hrecs->pg[] array
  * setting the prev_id field.
  *

--- a/hfile_s3_write.c
+++ b/hfile_s3_write.c
@@ -1,5 +1,5 @@
 /*
-    hfile_s3_write.c - Code to handle mulitpart uploading to S3.
+    hfile_s3_write.c - Code to handle multipart uploading to S3.
 
     Copyright (C) 2019 Genome Research Ltd.
 
@@ -40,7 +40,7 @@ Initiate the upload and get an upload ID.  This ID is used in all other steps.
 --------------
 
 Upload a part of the data.  5Mb minimum part size (except for the last part).
-Each part is numbered and a succesful upload returns an Etag header value that
+Each part is numbered and a successful upload returns an Etag header value that
 needs to used for the completion step.
 
 Step repeated till all data is uploaded.
@@ -591,10 +591,10 @@ static int initialise_upload(hFILE_s3_write *fp, kstring_t *head, kstring_t *res
     int ret = -1;
     struct curl_slist *headers = NULL;
     char http_request[] = "POST";
-    char delimeter = '?';
+    char delimiter = '?';
 
     if (user_query) {
-        delimeter = '&';
+        delimiter = '&';
     }
 
     if (fp->au->callback(fp->au->callback_data,  http_request, NULL, "uploads=",
@@ -602,7 +602,7 @@ static int initialise_upload(hFILE_s3_write *fp, kstring_t *head, kstring_t *res
         goto out;
     }
 
-    if (ksprintf(&url, "%s%cuploads", fp->url.s, delimeter) < 0) {
+    if (ksprintf(&url, "%s%cuploads", fp->url.s, delimiter) < 0) {
         goto out;
     }
 

--- a/hts.c
+++ b/hts.c
@@ -1976,7 +1976,7 @@ int hts_idx_push(hts_idx_t *idx, int tid, hts_pos_t beg, hts_pos_t end, uint64_t
 }
 
 // Needed for TBI only.  Ensure 'tid' with 'name' is in the index meta data.
-// idx->meta needs to have been initialsed first with an appropriate Tabix
+// idx->meta needs to have been initialised first with an appropriate Tabix
 // configuration via hts_idx_set_meta.
 //
 // NB number of references (first 4 bytes of tabix header) aren't in

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -150,7 +150,7 @@ typedef struct BGZF BGZF;
 
     /**
      * Write _length_ bytes from _data_ to the file, the index will be used to
-     * decide the amount of uncompressed data to be writen to each bgzip block.
+     * decide the amount of uncompressed data to be written to each bgzip block.
      * If no I/O errors occur, the complete _length_ bytes will be written (or
      * queued for writing).
      * @param fp     BGZF file handler
@@ -294,7 +294,7 @@ typedef struct BGZF BGZF;
      * Read one line from a BGZF file. It is faster than bgzf_getc()
      *
      * @param fp     BGZF file handler
-     * @param delim  delimitor
+     * @param delim  delimiter
      * @param str    string to write to; must be initialized
      * @return       length of the string; -1 on end-of-file; <= -2 on error
      */

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -196,7 +196,7 @@ uint32_t cram_block_size(cram_block *b);
  * the container, meaning multiple compression headers to manipulate.
  * Changing RG may change the size of the compression header and
  * therefore the length field in the container.  Hence we rewrite all
- * blocks just incase and also emit the adjusted container.
+ * blocks just in case and also emit the adjusted container.
  *
  * The current implementation can only cope with renumbering a single
  * RG (and only then if it is using HUFFMAN or BETA codecs).  In
@@ -470,7 +470,7 @@ int cram_set_header(cram_fd *fd, sam_hdr_t *hdr);
  *         2 if the file is a stream and thus unseekable
  *         1 if the file contains an EOF block
  *         0 if the file does not contain an EOF block
- *        -1 if an error occured whilst reading the file or we could not seek back to where we were
+ *        -1 if an error occurred whilst reading the file or we could not seek back to where we were
  *
  */
 HTSLIB_EXPORT

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -294,7 +294,7 @@ int faidx_seq_len(const faidx_t *fai, const char *seq);
     @param  beg   Returns the start of the region (0 based)
     @param  end   Returns the one past last of the region (0 based)
     @param  flags Parsing method, see HTS_PARSE_* in hts.h.
-    @return      pointer to end of parsed s if success, NULL if not.
+    @return       Pointer to end of parsed s if successful, NULL if not.
 
     To work around ambiguous parsing issues, eg both "chr1" and "chr1:100-200"
     are reference names, quote using curly braces.

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -948,7 +948,7 @@ int hts_idx_set_meta(hts_idx_t *idx, uint32_t l_meta, uint8_t *meta, int is_copy
     BAI and CSI indexes store information on the number of reads for each
     target that were mapped or unmapped (unmapped reads will generally have
     a paired read that is mapped to the target).  This function returns this
-    infomation if it is available.
+    information if it is available.
 
     @note Cram CRAI indexes do not include this information.
 */
@@ -1298,7 +1298,7 @@ int probaln_glocal(const uint8_t *ref, int l_ref, const uint8_t *query, int l_qu
     struct hts_md5_context;
     typedef struct hts_md5_context hts_md5_context;
 
-    /*! @abstract   Intialises an MD5 context.
+    /*! @abstract   Initialises an MD5 context.
      *  @discussion
      *    The expected use is to allocate an hts_md5_context using
      *    hts_md5_init().  This pointer is then passed into one or more calls

--- a/htslib/khash.h
+++ b/htslib/khash.h
@@ -604,7 +604,7 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key)
 		code;												\
 	} }
 
-/* More conenient interfaces */
+/* More convenient interfaces */
 
 /*! @function
   @abstract     Instantiate a hash set containing integer keys

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -384,7 +384,7 @@ static inline int kputl(long c, kstring_t *s) {
 
 /*
  * Returns 's' split by delimiter, with *n being the number of components;
- *         NULL on failue.
+ *         NULL on failure.
  */
 static inline int *ksplit(kstring_t *s, int delimiter, int *n)
 {

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1446,7 +1446,7 @@ static inline const uint8_t *sam_format_aux1(const uint8_t *key,
         uint8_t sub_type = *(s++);
         int sub_type_size;
 
-        // or externalise sam.c's aux_type2size fuction?
+        // or externalise sam.c's aux_type2size function?
         switch (sub_type) {
         case 'A': case 'c': case 'C':
             sub_type_size = 1;
@@ -1764,7 +1764,7 @@ int bam_aux_update_float(bam1_t *b, const char tag[2], float val);
 
    This function will not change the ordering of tags in the bam record.
    New tags will be appended to any existing aux records.  The bam record
-   will grow or shrink in order to accomodate the new data.
+   will grow or shrink in order to accommodate the new data.
 
    The data parameter must not point to any data in the bam record itself or
    undefined behaviour may result.

--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -65,7 +65,7 @@ extern "C" {
 #endif
 
 /*
-    When reading multiple files in paralel, duplicate records within each
+    When reading multiple files in parallel, duplicate records within each
     file will be reordered and offered in intuitive order. For example,
     when reading two files, each with unsorted SNP and indel record, the
     reader should return the SNP records together and the indel records
@@ -293,7 +293,7 @@ int bcf_sr_set_samples(bcf_srs_t *readers, const char *samples, int is_file);
  *  and merely skip unlisted positions.
  *
  *  Moreover, bcf_sr_set_targets() accepts an optional parameter $alleles which
- *  is intepreted as a 1-based column index in the tab-delimited file where
+ *  is interpreted as a 1-based column index in the tab-delimited file where
  *  alleles are listed. This in principle enables to perform the COLLAPSE_*
  *  logic also with tab-delimited files. However, the current implementation
  *  considers the alleles merely as a suggestion for prioritizing one of possibly
@@ -352,7 +352,7 @@ int bcf_sr_regions_seek(bcf_sr_regions_t *regions, const char *chr);
 /*
  *  bcf_sr_regions_next() - retrieves next region. Returns 0 on success and -1
  *  when all regions have been read. The fields reg->seq, reg->start and
- *  reg->end are filled with the genomic coordinates on succes or with
+ *  reg->end are filled with the genomic coordinates on success or with
  *  NULL,-1,-1 when no region is available. The coordinates are 0-based,
  *  inclusive.
  */

--- a/htslib/thread_pool.h
+++ b/htslib/thread_pool.h
@@ -186,7 +186,7 @@ int hts_tpool_dispatch2(hts_tpool *p, hts_tpool_process *q,
  * when pulled from the queue.
  *
  * job_cleanup() and result_cleanup() are only called when discarding jobs.
- * For jobs that are processed normally, it is the resposibility of
+ * For jobs that are processed normally, it is the responsibility of
  * exec_func() and / or consumers of any results to do any cleaning up
  * necessary.
  */

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -70,7 +70,7 @@ extern "C" {
 
 /* === Dictionary ===
 
-   The header keeps three dictonaries. The first keeps IDs in the
+   The header keeps three dictionaries. The first keeps IDs in the
    "FILTER/INFO/FORMAT" lines, the second keeps the sequence names and lengths
    in the "contig" lines and the last keeps the sample names. bcf_hdr_t::dict[]
    is the actual hash table, which is opaque to the end users. In the hash
@@ -397,7 +397,7 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     #define BCF_UN_INFO 4       // up to INFO
     #define BCF_UN_SHR  (BCF_UN_STR|BCF_UN_FLT|BCF_UN_INFO) // all shared information
     #define BCF_UN_FMT  8                           // unpack format and each sample
-    #define BCF_UN_IND  BCF_UN_FMT                  // a synonymo of BCF_UN_FMT
+    #define BCF_UN_IND  BCF_UN_FMT                  // a synonym of BCF_UN_FMT
     #define BCF_UN_ALL  (BCF_UN_SHR|BCF_UN_FMT)     // everything
     HTSLIB_EXPORT
     int bcf_unpack(bcf1_t *b, int which);
@@ -643,7 +643,7 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
      * @return bcf_hrec_t* on success;
      *         NULL on error or on end of header text.
      *         NB: to distinguish error from end-of-header, check *len:
-     *           *len == 0 indiciates @p line did not start with "##"
+     *           *len == 0 indicates @p line did not start with "##"
      *           *len == -1 indicates failure, likely due to out of memory
      *           *len > 0 indicates a malformed header line
      *

--- a/htslib/vcfutils.h
+++ b/htslib/vcfutils.h
@@ -55,7 +55,7 @@ int bcf_trim_alleles(const bcf_hdr_t *header, bcf1_t *line);
  *
  *  If you have more than 31 alleles, then the integer bit mask will
  *  overflow, so use bcf_remove_allele_set instead
- *  Returns 0 on sucess, <0 on error
+ *  Returns 0 on success, <0 on error
  */
 HTSLIB_EXPORT
 int bcf_remove_alleles(const bcf_hdr_t *header, bcf1_t *line, int mask) HTS_DEPRECATED("Please use bcf_remove_allele_set instead");
@@ -85,8 +85,7 @@ int bcf_remove_allele_set(const bcf_hdr_t *header, bcf1_t *line, const struct kb
  *  be determined.
  *
  *  The value of @which determines if existing INFO/AC,AN can be
- *  used (BCF_UN_INFO) and and if indv fields can be splitted
- *  (BCF_UN_FMT).
+ *  used (BCF_UN_INFO) and and if indv fields can be split (BCF_UN_FMT).
  */
 HTSLIB_EXPORT
 int bcf_calc_ac(const bcf_hdr_t *header, bcf1_t *line, int *ac, int which);

--- a/sam.5
+++ b/sam.5
@@ -37,7 +37,7 @@ nlbl.
 5	MAPQ	MAPping Quality (Phred-scaled)
 6	CIGAR	extended CIGAR string
 7	MRNM	Mate Reference sequence NaMe (`=' if same as RNAME)
-8	MPOS	1-based Mate POSistion
+8	MPOS	1-based Mate POSition
 9	TLEN	inferred Template LENgth (insert size)
 10	SEQ	query SEQuence on the same strand as the reference
 11	QUAL	query QUALity (ASCII-33 gives the Phred base quality)

--- a/sam.c
+++ b/sam.c
@@ -889,7 +889,7 @@ int sam_index_build(const char *fn, int min_shift)
     return sam_index_build3(fn, NULL, min_shift, 0);
 }
 
-// Provide bam_index_build() symbol for binary compability with earlier HTSlib
+// Provide bam_index_build() symbol for binary compatibility with earlier HTSlib
 #undef bam_index_build
 int bam_index_build(const char *fn, int min_shift)
 {
@@ -925,7 +925,7 @@ int sam_idx_init(htsFile *fp, sam_hdr_t *h, int min_shift, const char *fnidx) {
     return -1;
 }
 
-// Finishes an index. Call afer the last record has been written.
+// Finishes an index. Call after the last record has been written.
 // Returns 0 on success, <0 on failure.
 int sam_idx_save(htsFile *fp) {
     if (fp->format.format == bam || fp->format.format == bcf ||
@@ -2991,7 +2991,7 @@ int sam_read1(htsFile *fp, sam_hdr_t *h, bam1_t *b)
             sp_bams *gb = fd->curr_bam;
             if (!gb) {
                 if (fd->errcode) {
-                    // Incase reader failed
+                    // In case reader failed
                     errno = fd->errcode;
                     return -2;
                 }
@@ -3920,7 +3920,7 @@ static inline void mp_free(mempool_t *mp, lbnode_t *p)
 
 /* s->k: the index of the CIGAR operator that has just been processed.
    s->x: the reference coordinate of the start of s->k
-   s->y: the query coordiante of the start of s->k
+   s->y: the query coordinate of the start of s->k
  */
 static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
 {

--- a/tabix.c
+++ b/tabix.c
@@ -426,7 +426,7 @@ int reheader_file(const char *fname, const char *header, int ftype, tbx_conf_t *
         if ( ferror(hdr) ) error_errno("Failed to read \"%s\"", header);
         if ( fclose(hdr) ) error_errno("Closing \"%s\" failed", header);
 
-        // Output all remainig data read with the header block
+        // Output all remaining data read with the header block
         if ( fp->block_length - skip_until > 0 )
         {
             if (bgzf_write(bgzf_out, buffer+skip_until, fp->block_length-skip_until) < 0) error_errno("Write error %d",fp->errcode);

--- a/test/compare_sam.pl
+++ b/test/compare_sam.pl
@@ -85,8 +85,8 @@ while ($ln1 && $ln2) {
     # Validate MD and NM only if partialmd & 'file' set, otherwise
     # discard it.  Ie:
     #
-    # 1: if file 1 has NM/MD keep in file 2, othewise discard from file2
-    # 2: if file 2 has NM/MD keep in file 1, othewise discard from file1
+    # 1: if file 1 has NM/MD keep in file 2, otherwise discard from file2
+    # 2: if file 2 has NM/MD keep in file 1, otherwise discard from file1
     # 3: if file 1 and file 2 both have NM/MD keep, otherwise discard.
     if (exists $opts{partialmd}) {
         if ($opts{partialmd} & 2) {

--- a/test/sam.c
+++ b/test/sam.c
@@ -440,7 +440,7 @@ static int aux_fields1(void)
         // append a new array
         i = test_update_array(aln, "N4", 'c', NELE(n4v1), n4v1, "\0\0", 0, 0);
 
-        // Add a sentinal to check resizes work
+        // Add a sentinel to check resizes work
         if (i == 0) i = test_update_int(aln, "N5", 4242, 'S', "\0\0", 0, 0);
 
         // alter the array tag a few times

--- a/test/test-bcf-translate.c
+++ b/test/test-bcf-translate.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
     bcf_update_format_int32(hdr1, rec, "FMT2", NULL, 0);
 
     bcf_translate(hdr2, hdr1, rec);
-    if ( bcf_write(fp, hdr2, rec)!=0 ) error("Faild to write to %s\n", fname);
+    if ( bcf_write(fp, hdr2, rec)!=0 ) error("Failed to write to %s\n", fname);
 
     // Clean
     bcf_destroy1(rec);

--- a/test/test_str2int.c
+++ b/test/test_str2int.c
@@ -43,7 +43,7 @@ static int check_str2int(int verbose) {
     int64_t val;
     uint64_t num, uval;
     int failed = 0, efail, i, offset;
-    const char sentinal = '#';
+    const char sentinel = '#';
 
     // Positive value (unsigned)
     for (i = 1; i < 64; i++) {
@@ -51,11 +51,11 @@ static int check_str2int(int verbose) {
         for (offset = i < 5 ? -(1LL << (i - 1)) : -16; offset <= 30; offset++) {
             efail = (offset > 0);
             snprintf(buffer, sizeof(buffer), "%" PRIu64 "%c",
-                     num + offset, sentinal);
+                     num + offset, sentinel);
 
             uval = hts_str2uint(buffer, &end, i, &failed);
             if (failed != efail || uval != (!efail ? num + offset : num)
-                || *end != sentinal) {
+                || *end != sentinel) {
                 fprintf(stderr, "hts_str2uint failed: %d bit "
                         "%s %"PRIu64" '%c' %d (%d)\n",
                         i, buffer, uval, *end, failed, efail);
@@ -72,11 +72,11 @@ static int check_str2int(int verbose) {
         for (offset = i < 5 ? -(1LL << (i - 1)) : -16; offset <= 30; offset++) {
             efail = (offset > 0);
             snprintf(buffer, sizeof(buffer), "%" PRIu64 "%c",
-                     num + offset, sentinal);
+                     num + offset, sentinel);
 
             val = hts_str2int(buffer, &end, i + 1, &failed);
             if (failed != efail || val != (!efail ? num + offset : num)
-                || *end != sentinal) {
+                || *end != sentinel) {
                 fprintf(stderr,
                         "hts_str2int  failed: %d bit "
                         "%s %"PRId64" '%c' %d (%d)\n",
@@ -94,14 +94,14 @@ static int check_str2int(int verbose) {
         for (offset = i < 5 ? -(1LL << (i - 1)) : -16; offset <= 30; offset++) {
             efail = (offset > 0);
             snprintf(buffer, sizeof(buffer), "-%" PRIu64 "%c",
-                     num + offset + 1, sentinal);
+                     num + offset + 1, sentinel);
 
             val = hts_str2int(buffer, &end, i + 1, &failed);
             // Cast of val to unsigned in this comparison avoids undefined
             // behaviour when checking INT64_MIN.
             if (failed != efail
                 || -((uint64_t) val) != (!efail ? num + offset + 1 : num + 1)
-                || *end != sentinal) {
+                || *end != sentinel) {
                 fprintf(stderr,
                         "hts_str2int  failed: %d bit "
                         "%s %"PRId64" '%c' %d (%d)\n",
@@ -120,11 +120,11 @@ static int check_str2int(int verbose) {
     for (offset = 0; offset <= 999; offset++) {
         efail = offset > 615;
         snprintf(buffer, sizeof(buffer), "18446744073709551%03d%c",
-                 offset, sentinal);
+                 offset, sentinel);
         uval = hts_str2uint(buffer, &end, 64, &failed);
         if (failed != efail
             || uval != (efail ? UINT64_MAX : 18446744073709551000ULL + offset)
-            || *end != sentinal) {
+            || *end != sentinel) {
             fprintf(stderr, "hts_str2uint failed: 64 bit %s "
                     "%"PRIu64" '%c' %d (%d)\n",
                     buffer, uval, *end, failed, efail);

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -325,7 +325,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "-D: read CRAM format (mode 'c')\n");
         fprintf(stderr, "-S: read compressed BCF, BAM, FAI (mode 'b')\n");
         fprintf(stderr, "-I: ignore SAM parsing errors\n");
-        fprintf(stderr, "-t: fn_ref: load CRAM references from the specificed fasta file instead of @SQ headers when writing a CRAM file\n");
+        fprintf(stderr, "-t: fn_ref: load CRAM references from the specified fasta file instead of @SQ headers when writing a CRAM file\n");
         fprintf(stderr, "-i: option=value: set an option for CRAM input\n");
         fprintf(stderr, "\n");
         fprintf(stderr, "-b: write binary compressed BCF, BAM, FAI (mode 'b')\n");

--- a/textutils_internal.h
+++ b/textutils_internal.h
@@ -52,7 +52,7 @@ size_t hts_base64_decoded_length(size_t len);
 /// Decode base64-encoded data
 /** On input, _dest_ should be a sufficient buffer (see `hts_base64_length()`),
     and may be equal to _s_ to decode in place.  On output, the number of
-    bytes writen is stored in _destlen_.
+    bytes written is stored in _destlen_.
 */
 int hts_decode_base64(char *dest, size_t *destlen, const char *s);
 
@@ -70,7 +70,7 @@ hts_json_token *hts_json_alloc_token(void);
 /// Free a JSON token
 void hts_json_free_token(hts_json_token *token);
 
-/// Accessor funtion to get JSON token type
+/// Accessor function to get JSON token type
 /** @param  token Pointer to JSON token
     @return Character indicating the token type
 
@@ -87,7 +87,7 @@ as follows:
 */
 char hts_json_token_type(hts_json_token *token);
 
-/// Accessor funtion to get JSON token in string form
+/// Accessor function to get JSON token in string form
 /** @param  token Pointer to JSON token
     @return String representation of the JSON token; NULL if unset
 

--- a/thread_pool.c
+++ b/thread_pool.c
@@ -218,7 +218,7 @@ hts_tpool_result *hts_tpool_next_result_wait(hts_tpool_process *q) {
 
     pthread_mutex_lock(&q->p->pool_m);
     while (!(r = hts_tpool_next_result_locked(q))) {
-        /* Possible race here now avoided via _locked() call, but incase... */
+        /* Possible race here now avoided via _locked() call, but in case... */
         struct timeval now;
         struct timespec timeout;
 
@@ -586,7 +586,7 @@ static void *tpool_worker(void *arg) {
             // happening once (on the transition) rather than every time we
             // are below qsize.
             // (I wish I could remember why io_lib rev 3660 changed this from
-            //  == to >=, but keeping it just incase!)
+            //  == to >=, but keeping it just in case!)
             q->n_processing++;
             if (q->n_input-- >= q->qsize)
                 pthread_cond_broadcast(&q->input_not_full_c);
@@ -926,7 +926,7 @@ int hts_tpool_process_flush(hts_tpool_process *q) {
             pthread_cond_signal(&p->t[i].pending_c);
 
     // Ensure there is room for the final sprint.
-    // Shouldn't be possible to get here, but just incase.
+    // Shouldn't be possible to get here, but just in case.
     if (q->qsize < q->n_output + q->n_input + q->n_processing)
         q->qsize = q->n_output + q->n_input + q->n_processing;
 
@@ -1331,7 +1331,7 @@ int test_squareB(int n) {
  * Possible improvement: we only need the last stage to be ordered.  By
  * allocating our own serial numbers for the first job and manually setting
  * these serials in the last job, perhaps we can permit out of order execution
- * of all the inbetween stages.  (I doubt it'll affect speed much though.)
+ * of all the in-between stages.  (I doubt it'll affect speed much though.)
  */
 
 static void *pipe_input_thread(void *arg);

--- a/vcf.c
+++ b/vcf.c
@@ -3441,7 +3441,7 @@ int bcf_idx_init(htsFile *fp, bcf_hdr_t *h, int min_shift, const char *fnidx) {
     return 0;
 }
 
-// Finishes an index. Call afer the last record has been written.
+// Finishes an index. Call after the last record has been written.
 // Returns 0 on success, <0 on failure.
 //
 // NB: same format as SAM/BAM as it uses bgzf.
@@ -4311,7 +4311,7 @@ int bcf_update_format(const bcf_hdr_t *hdr, bcf1_t *line, const char *key, const
     }
     else
     {
-        // The tag is already present, check if it is big enough to accomodate the new block
+        // The tag is already present, check if it is big enough to accommodate the new block
         if ( str.l <= fmt->p_len + fmt->p_off )
         {
             // good, the block is big enough


### PR DESCRIPTION
First commit has typo and spelling corrections in NEWS, manual pages, and public header files (in comments only).

Second commit extends that to source files (mostly in comments). You might prefer to leave this to the start of the next development cycle to avoid this churn in all these files. Or contrarily, to squash them together.