### PR TITLE
Add back assert.h to vcf.h.

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -41,6 +41,9 @@ DEALINGS IN THE SOFTWARE.  */
 #include "hts_defs.h"
 #include "hts_endian.h"
 
+/* Included only for backwards compatibility with e.g. bcftools 1.10 */
+#include <assert.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This undoes a change in #1060.

It's a philosphical point.  On one hand we have an inclusion of a
spurious file that we do not utilise ourselves.  On the other hand we
have an API breakage where old software (in this case bcftools 1.10)
attemting to compile against current htslib no longer succeeds because
we've changed which symbols we declare.

This is unclean, but I think backwards compatibity trumps tidyness in
this case.