### PR TITLE
Add unistd.h include to hts.c now that it used R_OK

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>


### PR DESCRIPTION
Include unistd to guarantee access to R_OK definition.

On a mac (Xcode 11) - **when compiling via rust-htslib** - I get a compile error about missing R_OK. As far as I can tell R_OK is defined officially in unistd.h, but probably comes in via other includes.

htslib by itself compiles fine on my mac - so I realise this is not specifically a htslib problem - presumably papered over a bit by the autoconf system.

The only other spot in htslib that used R_OK does include unistd (cram/cram_io.c)