### PR TITLE
Include <unistd.h> and <errno.h> directly where needed

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef HTSLIB_SAM_H
 #define HTSLIB_SAM_H
 
+#include <errno.h>
 #include <stdint.h>
 #include "hts.h"
 #include "hts_endian.h"

--- a/sam.c
+++ b/sam.c
@@ -35,6 +35,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <assert.h>
 #include <signal.h>
 #include <inttypes.h>
+#include <unistd.h>
 
 // Suppress deprecation message for cigar_tab, which we initialise
 #include "htslib/hts_defs.h"

--- a/test/plugins-dlhts.c
+++ b/test/plugins-dlhts.c
@@ -37,9 +37,9 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <dlfcn.h>
 #include <errno.h>
-#include <getopt.h>
 #include <stdarg.h>
 #include <string.h>
+#include <unistd.h>
 
 #ifndef EPROTONOSUPPORT
 #define EPROTONOSUPPORT ENOSYS

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -24,7 +24,9 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <config.h>
 
+#include <errno.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "../htslib/hts.h"
 #include "../htslib/vcf.h"

--- a/test/test_index.c
+++ b/test/test_index.c
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <config.h>
 #include <stdio.h>
-#include <getopt.h>
+#include <unistd.h>
 
 #include "../htslib/sam.h"
 #include "../htslib/vcf.h"

--- a/test/test_kstring.c
+++ b/test/test_kstring.c
@@ -29,7 +29,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <limits.h>
 #include <stdint.h>
 #include <inttypes.h>
-#include <getopt.h>
+#include <unistd.h>
 
 #include "../htslib/kstring.h"
 

--- a/test/test_realn.c
+++ b/test/test_realn.c
@@ -28,8 +28,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
-#include <getopt.h>
 #include <limits.h>
+#include <unistd.h>
 
 #include "../htslib/sam.h"
 #include "../htslib/hts.h"

--- a/test/test_str2int.c
+++ b/test/test_str2int.c
@@ -29,7 +29,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
-#include <getopt.h>
+#include <unistd.h>
 
 #include "../textutils_internal.h"
 

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -29,7 +29,6 @@ DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-#include <getopt.h>
 #include <stdint.h>
 
 #include "../cram/cram.h"


### PR DESCRIPTION
Similarly to PR #1143, _sam.c_ also needs `<unistd.h>` explicitly for environments in which it doesn't get it via `<zlib.h>` or similar.

Both _htslib/sam.h_ and _test/test-vcf-api.c_ use `errno` but get it only semi-accidentally via _htslib/kstring.h_. Include `<errno.h>` explicitly, and similarly `<string.h>` for `strerror()`.

Various _test/*.c_ programs that use `getopt()` need include only `<unistd.h>` rather than `<getopt.h>`, which is needed only for `getopt_long()`.

All uncovered by building in an environment with dummy `<zlib.h>` and `<getopt.h>` headers that don't `#include` any other headers or define anything extraneous, and temporarily commenting out `#include <errno.h>` and other `errno` usage in _htslib/*.h_.