### PR TITLE
Use the sover-bumping version number for -compatibility_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,10 @@ include htslib_vars.mk
 # into here.
 PACKAGE_VERSION := $(shell ./version.sh)
 
+# The current library soversion, and the package release in which
+# this soversion first appeared.
 LIBHTS_SOVERSION = 3
-MACH_O_COMPATIBILITY_VERSION = $(LIBHTS_SOVERSION)
+LIBHTS_SOBUMP_VERSION = 1.10
 
 # $(NUMERIC_VERSION) is for items that must have a numeric X.Y.Z string
 # even if this is a dirty or untagged Git working tree.
@@ -293,7 +295,7 @@ libhts.so: $(LIBHTS_OBJS:.o=.pico)
 # includes this project's build directory).
 
 libhts.dylib: $(LIBHTS_OBJS)
-	$(CC) -dynamiclib -install_name $(libdir)/libhts.$(LIBHTS_SOVERSION).dylib -current_version $(NUMERIC_VERSION) -compatibility_version $(MACH_O_COMPATIBILITY_VERSION) $(LDFLAGS) -o $@ $(LIBHTS_OBJS) $(LIBS)
+	$(CC) -dynamiclib -install_name $(libdir)/libhts.$(LIBHTS_SOVERSION).dylib -current_version $(NUMERIC_VERSION) -compatibility_version $(LIBHTS_SOBUMP_VERSION) $(LDFLAGS) -o $@ $(LIBHTS_OBJS) $(LIBS)
 	ln -sf $@ libhts.$(LIBHTS_SOVERSION).dylib
 
 cyghts-$(LIBHTS_SOVERSION).dll libhts.dll.a: $(LIBHTS_OBJS)


### PR DESCRIPTION
See #1144 for background. Closes #1144.

It seems that `-compatibility_version` checking has to date been ineffective on macOS, which could explain why it seemed that compatibility_version was not intended to be compared to current_version. Switch to a more orthodox scheme of using the version number of the HTSlib release that bumped the soversion as the compatibility_version.

The Makefile now hard-codes `LIBHTS_SOVERSION` and `LIBHTS_SOBUMP_VERSION`, both of which should be updated when the soversion is bumped. As well as being embedded in the macOS _libhts.dylib_, `LIBHTS_SOBUMP_VERSION` is a useful record in the Makefile.

Ideally perhaps this would be merged during an ABI-breaking release concurrent with a soversion bump. However as it seems that this macOS check has to date not worked anyway, this PR can probably be merged at any time.