### PR TITLE
Variable name used by dlsym in load_plugin corrected.

### DIFF
--- a/plugin.c
+++ b/plugin.c
@@ -153,7 +153,7 @@ plugin_void_func *load_plugin(void **pluginp, const char *filename, const char *
         const char *basename = slash? slash+1 : filename;
         kputsn(basename, strcspn(basename, ".-+"), &symbolg);
 
-        *(void **) &sym = dlsym(lib, symbol);
+        *(void **) &sym = dlsym(lib, symbolg.s);
         free(symbolg.s);
         if (sym == NULL) goto error;
     }


### PR DESCRIPTION
The hfile irods plugin depends on a constructed symbol name which was no longer being used.  This is a small fix to changes made in #1072.