### PR TITLE
Replace the indexing range check error message.

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -1865,26 +1865,16 @@ int hts_idx_check_range(hts_idx_t *idx, int tid, hts_pos_t beg, hts_pos_t end)
     int64_t maxpos = (int64_t) 1 << (idx->min_shift + idx->n_lvls * 3);
     if (tid < 0 || (beg <= maxpos && end <= maxpos))
         return 0;
-    int64_t max = end > beg ? end : beg, s = 1 << 14;
-    int n_lvls = 0;
-    while (max > s) {
-        n_lvls++;
-        s <<= 3;
-    }
 
     if (idx->fmt == HTS_FMT_CSI) {
-        hts_log_error("Region %"PRIhts_pos"..%"PRIhts_pos" cannot be stored in a csi index "
-                      "with min_shift = %d, n_lvls = %d. Try using "
-                      "min_shift = 14, n_lvls >= %d",
-                      beg, end,
-                      idx->min_shift, idx->n_lvls,
-                      n_lvls);
+        hts_log_error("Region %"PRIhts_pos"..%"PRIhts_pos
+                      " cannot be stored in a csi index. "
+                      "Please check headers match the data",
+                      beg, end);
     } else {
-        hts_log_error("Region %"PRIhts_pos"..%"PRIhts_pos" cannot be stored in a %s index. "
-                      "Try using a csi index with min_shift = 14, "
-                      "n_lvls >= %d",
-                      beg, end, idx_format_name(idx->fmt),
-                      n_lvls);
+        hts_log_error("Region %"PRIhts_pos"..%"PRIhts_pos
+                      " cannot be stored in a %s index. Try using a csi index",
+                      beg, end, idx_format_name(idx->fmt));
     }
     errno = ERANGE;
     return -1;


### PR DESCRIPTION
This code detects when the end positioni s too large for the current
index.  It then computes an adjusted n_lvls parameter and tells the
user to switch to CSI with this parameter.

That has numerous failings though.

1. The only user-adjustable parameter is min-shift, not levels, so
the advice is impossible to follow.

2. CSI auto-scales based on SQ headers, so we don't need to be
explicit anyway (assuming we currently have a BAI index that doesn't
fit).

3. If we already were using CSI index and if we did have the
configuration options to do what it asks, it wouldn't fix the problem.
Given CSI auto-scales, if we see this message it's because of the
alignments don't match the headers; either the header has been
replaced by something inappropriate or there are bugs in the aligner
that has emittede rogue POS fields.  There is no fix to the index that
actually fixes the data; it's simply brushing the problem under the carpet.