### PR TITLE
Prevent switch/case statement "fall through" warnings [trivial]

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -202,20 +202,20 @@ static inline unsigned int get_bits_MSB(cram_block *block, int nbits) {
     }
 
     switch(nbits) {
-//  case 15: GET_BIT_MSB(block, val);
-//  case 14: GET_BIT_MSB(block, val);
-//  case 13: GET_BIT_MSB(block, val);
-//  case 12: GET_BIT_MSB(block, val);
-//  case 11: GET_BIT_MSB(block, val);
-//  case 10: GET_BIT_MSB(block, val);
-//  case  9: GET_BIT_MSB(block, val);
-    case  8: GET_BIT_MSB(block, val);
-    case  7: GET_BIT_MSB(block, val);
-    case  6: GET_BIT_MSB(block, val);
-    case  5: GET_BIT_MSB(block, val);
-    case  4: GET_BIT_MSB(block, val);
-    case  3: GET_BIT_MSB(block, val);
-    case  2: GET_BIT_MSB(block, val);
+//  case 15: GET_BIT_MSB(block, val); // fall through
+//  case 14: GET_BIT_MSB(block, val); // fall through
+//  case 13: GET_BIT_MSB(block, val); // fall through
+//  case 12: GET_BIT_MSB(block, val); // fall through
+//  case 11: GET_BIT_MSB(block, val); // fall through
+//  case 10: GET_BIT_MSB(block, val); // fall through
+//  case  9: GET_BIT_MSB(block, val); // fall through
+    case  8: GET_BIT_MSB(block, val); // fall through
+    case  7: GET_BIT_MSB(block, val); // fall through
+    case  6: GET_BIT_MSB(block, val); // fall through
+    case  5: GET_BIT_MSB(block, val); // fall through
+    case  4: GET_BIT_MSB(block, val); // fall through
+    case  3: GET_BIT_MSB(block, val); // fall through
+    case  2: GET_BIT_MSB(block, val); // fall through
     case  1: GET_BIT_MSB(block, val);
         break;
 

--- a/cram/rANS_static.c
+++ b/cram/rANS_static.c
@@ -157,9 +157,9 @@ unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
     RansEncInit(&rans3);
 
     switch (i=(in_size&3)) {
-    case 3: RansEncPutSymbol(&rans2, &ptr, &syms[in[in_size-(i-2)]]);
-    case 2: RansEncPutSymbol(&rans1, &ptr, &syms[in[in_size-(i-1)]]);
-    case 1: RansEncPutSymbol(&rans0, &ptr, &syms[in[in_size-(i-0)]]);
+    case 3: RansEncPutSymbol(&rans2, &ptr, &syms[in[in_size-(i-2)]]); // fall through
+    case 2: RansEncPutSymbol(&rans1, &ptr, &syms[in[in_size-(i-1)]]); // fall through
+    case 1: RansEncPutSymbol(&rans0, &ptr, &syms[in[in_size-(i-0)]]); // fall through
     case 0:
         break;
     }
@@ -348,10 +348,13 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
     switch(out_sz&3) {
     case 3:
         out_buf[out_end+2] = D.R[RansDecGet(&R[2], TF_SHIFT)];
+        // fall through
     case 2:
         out_buf[out_end+1] = D.R[RansDecGet(&R[1], TF_SHIFT)];
+        // fall through
     case 1:
         out_buf[out_end] = D.R[RansDecGet(&R[0], TF_SHIFT)];
+        // fall through
     default:
         break;
     }

--- a/hts.c
+++ b/hts.c
@@ -784,8 +784,8 @@ int hts_opt_add(hts_opt **opts, const char *c_arg) {
         // NB: Doesn't support floats, eg 1.5g
         // TODO: extend hts_parse_decimal? See also samtools sort.
         switch (*endp) {
-        case 'g': case 'G': o->val.i *= 1024;
-        case 'm': case 'M': o->val.i *= 1024;
+        case 'g': case 'G': o->val.i *= 1024; // fall through
+        case 'm': case 'M': o->val.i *= 1024; // fall through
         case 'k': case 'K': o->val.i *= 1024; break;
         case '\0': break;
         default:
@@ -2731,6 +2731,7 @@ int hts_itr_multi_bam(const hts_idx_t *idx, hts_itr_t *iter)
                 switch (tid) {
                 case HTS_IDX_NONE:
                     iter->finished = 1;
+                    // fall through
                 case HTS_IDX_START:
                 case HTS_IDX_REST:
                     iter->curr_off = t_off;

--- a/tabix.c
+++ b/tabix.c
@@ -52,7 +52,8 @@ typedef struct
 }
 args_t;
 
-HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) static void error(const char *format, ...)
+static void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) HTS_NORETURN
+error(const char *format, ...)
 {
     va_list ap;
     fflush(stdout);
@@ -63,7 +64,8 @@ HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) static void error(const char *format, ...)
     exit(EXIT_FAILURE);
 }
 
-HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) static void error_errno(const char *format, ...)
+static void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) HTS_NORETURN
+error_errno(const char *format, ...)
 {
     va_list ap;
     int eno = errno;

--- a/test/test_index.c
+++ b/test/test_index.c
@@ -29,7 +29,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "../htslib/sam.h"
 #include "../htslib/vcf.h"
 
-void usage(FILE *fp) {
+void HTS_NORETURN usage(FILE *fp) {
     fprintf(fp, "Usage: test_index [opts] in.{sam.gz,bam,cram}|in.{vcf.gz,bcf}\n\n");
     fprintf(fp, "  -b       Use BAI index (BAM, SAM)\n");
     fprintf(fp, "  -c       Use CSI index (BAM, SAM, VCF, BCF)\n");

--- a/textutils_internal.h
+++ b/textutils_internal.h
@@ -355,7 +355,7 @@ static inline double hts_str2dbl(const char *in, char **end, int *failed) {
 
     case '0':
         if (v[1] != 'x' && v[1] != 'X') break;
-        // else fall through (hex number)
+        // else fall through - hex number
 
     default:
         // Non numbers, like NaN, Inf


### PR DESCRIPTION
[A trivial one that's been in a holding pattern since before the 1.11 release…]

Add comments indicating intentional fall-throughs, so that `gcc -Wextra` builds don't need `-Wno-implicit-fallthrough` as well.

(Clang understands only not-yet-standard attributes and annotations, not comment text, so there's little point in catering to its `-Wimplicit-fallthrough` warning, which isn't included in `‑Wall`/ `‑Wextra` in Clang.)