### PR TITLE
Fix AppVeyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,13 +18,25 @@ skip_tags: true
 #    - docs/*
 #    - '**/*.html'
 
-# We use Mingw/Msys, so use pacman for installs
+# We use Mingw/Msys, so use pacman for installs.
+# Note if we want faster builds, all of the pacman bits can be removed.
+# The base image has sufficient support to compile and pass, although it's
+# not testing building with libcurl as that is absent.
 install:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
   - set MINGWPREFIX=x86_64-w64-mingw32
-  - "sh -lc \"pacman -S --noconfirm --needed base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-zlib mingw-w64-x86_64-bzip2 mingw-w64-x86_64-xz mingw-w64-x86_64-curl\""
+# Update keys as MSYS upstream have revised them but this image is out of date
+  - "sh -lc \"wget http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz\""
+  - "sh -lc \"wget http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig\""
+  - "sh -lc \"pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig\""
+# Newer MSYS packages are bundled using zstd instead of xz, but the pacman
+# version we have is too old to cope.  Explicitly upgrade this first
+  - "sh -lc \"pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz\""
+# Now we can update compiler and packages.
+  - "sh -lc \"pacman -Sy --noconfirm --needed pacman\""
+  - "sh -lc \"pacman -Sy --noconfirm --needed base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-zlib mingw-w64-x86_64-bzip2 mingw-w64-x86_64-xz mingw-w64-x86_64-curl\""
 
 build_script:
   - set HOME=.


### PR DESCRIPTION
The keys used to sign MSYS package have changed, so we have to update the key store first.

The next problem is that newer MSYS packages are compressed with zstd, but the installed pacman cannot handle these.  We  eed to explicitly update pacman first.

Then finally we can install our build system.

Note none of this is strictly necessary.  The alternative solution is to comment out all pacman updates as the base image has sufficient compilers and libraries to build and pass the test harness.

The main difference is the lack of libcurl, which then means we don't test compilation of the components that depend on it.  We don't test these anyway, but it's useful to know they build at least.  However if we hit problems in the future due to the explicit path of those key files then that's a viable temporary workaround.

(It may be that AppVeyor also updates their base image at some point, in which case the key shenanigans can be deleted.)