### PR TITLE
Removal the bgzf_idx_flush assertion.

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -273,7 +273,7 @@ static int bgzf_idx_flush(BGZF *fp) {
     hts_idx_cache_entry *e = mt->idx_cache.e;
     int i;
 
-    assert(mt->idx_cache.nentries == 0 || mt->block_written >= e[0].block_number);
+    assert(mt->idx_cache.nentries == 0 || mt->block_written <= e[0].block_number);
 
     for (i = 0; i < mt->idx_cache.nentries && e[i].block_number == mt->block_written; i++) {
         if (hts_idx_push(mt->hts_idx, e[i].tid, e[i].beg, e[i].end,


### PR DESCRIPTION
The assumption is that we call bgzf_idx_flush once per outgoing multi-threaded block, and the block numbers will match.  The assertion is to validate we're not indexing out of order.

However, very long records (eg with huge aux tags or long seqs) can mean a single record spans multiple blocks and we inherently then skip blocks in bgzf_idx_push calls.  Hence the assertion is simply wrong.

Fixes samtools/samtools#1328