### PR TITLE
Fix a long-standing typo in hts_lrand48.

### DIFF
--- a/hts_os.c
+++ b/hts_os.c
@@ -49,7 +49,7 @@ HTSLIB_EXPORT
 double hts_drand48(void) { return drand48(); }
 
 HTSLIB_EXPORT
-double hts_lrand48(void) { return lrand48(); }
+long hts_lrand48(void) { return lrand48(); }
 #endif
 
 // // On Windows when using the MSYS or Cygwin terminals, isatty fails


### PR DESCRIPTION
Note: this function is never used.  It was only added for reasons of completeness when we were putting in hts_drand48, used by htslib/ksort.h.