### PR TITLE
Update Windows image version in .appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,9 @@ skip_tags: true
 #    - docs/*
 #    - '**/*.html'
 
+# Appveyor Windows images are based on Visual studio version
+image: Visual Studio 2019
+
 # We use Mingw/Msys, so use pacman for installs
 install:
   - set HOME=.


### PR DESCRIPTION
Mainly to fix pacman, which broke following changes to msys2 packaging (see https://www.msys2.org/news/#2020-06-29-new-packagers)

Prior to this we were using the default image (Visual Studio 2015) which has not had the necessary updates to make pacman work.

Replaces and closes #1166 