### PR TITLE
Minor build infrastructure: introduce $(ALL_CPPFLAGS) and use it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ BUILT_THRASH_PROGRAMS = \
 all: lib-static lib-shared $(BUILT_PROGRAMS) plugins $(BUILT_TEST_PROGRAMS) \
      htslib_static.mk htslib-uninstalled.pc
 
+ALL_CPPFLAGS = -I. $(CPPFLAGS)
+
 HTSPREFIX =
 include htslib_vars.mk
 
@@ -133,10 +135,10 @@ show-version:
 .SUFFIXES: .bundle .c .cygdll .dll .o .pico .so
 
 .c.o:
-	$(CC) $(CFLAGS) -I. $(CPPFLAGS) -c -o $@ $<
+	$(CC) $(CFLAGS) $(ALL_CPPFLAGS) -c -o $@ $<
 
 .c.pico:
-	$(CC) $(CFLAGS) -I. $(CPPFLAGS) $(EXTRA_CFLAGS_PIC) -c -o $@ $<
+	$(CC) $(CFLAGS) $(ALL_CPPFLAGS) $(EXTRA_CFLAGS_PIC) -c -o $@ $<
 
 
 LIBHTS_OBJS = \

--- a/config.mk.in
+++ b/config.mk.in
@@ -94,7 +94,7 @@ pluginpath = @pluginpath@
 LIBHTS_OBJS += plugin.o
 PLUGIN_OBJS += $(plugin_OBJS)
 
-plugin.o plugin.pico: CPPFLAGS += -DPLUGINPATH=\"$(pluginpath)\"
+plugin.o plugin.pico: ALL_CPPFLAGS += -DPLUGINPATH=\"$(pluginpath)\"
 
 # When built as separate plugins, these record their version themselves.
 hfile_gcs.o hfile_gcs.pico: version.h

--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ case $host_alias in
     # This also sets __USE_MINGW_ANSI_STDIO which in turn makes PRId64,
     # %lld and %z printf formats work.  It also enforces the snprintf to
     # be C99 compliant so it returns the correct values (in kstring.c).
-    CPPFLAGS="$CPPCFLAGS -D_XOPEN_SOURCE=600"
+    CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=600"
     ;;
   *)
     host_result="plain .so"


### PR DESCRIPTION
This extra level of indirection, similar to that used in samtools's _Makefile_, simplifies making additions to the CPPFLAGS used during compilation (and simplifies ensuring that it's done without interfering with the user's setting for `$CPPFLAGS`).

e.g. this will let #1170 add `-DHTS_CPPFLAGS=\"$(CPPFLAGS)\"` to `ALL_CPPFLAGS` without needing any `TMP_CPPFLAGS := $(CPPFLAGS)` trickery or questions about `:=` vs `::=`.

Also fix related typo in the MSYS/MinGW part of configure.ac.