### PR TITLE
improve compatibility for c++

### DIFF
--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -59,6 +59,8 @@ struct hFILE;
 struct hts_tpool;
 struct sam_hdr_t;
 
+size_t hts_realloc_or_die(size_t, size_t, size_t, size_t,
+                          int, void **, const char *);
 /**
  * @hideinitializer
  * Deprecated macro to expand a dynamic array of a given type
@@ -85,8 +87,6 @@ struct sam_hdr_t;
  */
 #define hts_expand(type_t, n, m, ptr) do {                              \
         if ((n) > (m)) {                                                \
-            size_t hts_realloc_or_die(size_t, size_t, size_t, size_t,   \
-                                      int, void **, const char *);      \
             (m) = hts_realloc_or_die((n) >= 1 ? (n) : 1, (m), sizeof(m), \
                                      sizeof(type_t),  0,                \
                                      (void **)&(ptr), __func__);        \
@@ -117,8 +117,6 @@ struct sam_hdr_t;
 
 #define hts_expand0(type_t, n, m, ptr) do {                             \
         if ((n) > (m)) {                                                \
-            size_t hts_realloc_or_die(size_t, size_t, size_t, size_t,   \
-                                      int, void **, const char *);      \
             (m) = hts_realloc_or_die((n) >= 1 ? (n) : 1, (m), sizeof(m), \
                                      sizeof(type_t), 1,                 \
                                      (void **)&(ptr), __func__);        \

--- a/htslib/klist.h
+++ b/htslib/klist.h
@@ -43,7 +43,7 @@
 		kmptype_t **buf;												\
 	} kmp_##name##_t;													\
 	SCOPE kmp_##name##_t *kmp_init_##name(void) {						\
-		return calloc(1, sizeof(kmp_##name##_t));						\
+		return (kmp_##name##_t *)calloc(1, sizeof(kmp_##name##_t));						\
 	}																	\
 	SCOPE void kmp_destroy_##name(kmp_##name##_t *mp) {					\
 		size_t k;														\
@@ -54,14 +54,14 @@
 	}																	\
 	SCOPE kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) {				\
 		++mp->cnt;														\
-		if (mp->n == 0) return calloc(1, sizeof(kmptype_t));			\
+		if (mp->n == 0) return (kmptype_t *)calloc(1, sizeof(kmptype_t));			\
 		return mp->buf[--mp->n];										\
 	}																	\
 	SCOPE void kmp_free_##name(kmp_##name##_t *mp, kmptype_t *p) {		\
 		--mp->cnt;														\
 		if (mp->n == mp->max) {											\
 			mp->max = mp->max? mp->max<<1 : 16;							\
-			mp->buf = realloc(mp->buf, sizeof(kmptype_t *) * mp->max);	\
+			mp->buf = (kmptype_t **)realloc(mp->buf, sizeof(kmptype_t *) * mp->max);	\
 		}																\
 		mp->buf[mp->n++] = p;											\
 	}
@@ -88,7 +88,7 @@
 		size_t size;													\
 	} kl_##name##_t;													\
 	SCOPE kl_##name##_t *kl_init_##name(void) {							\
-		kl_##name##_t *kl = calloc(1, sizeof(kl_##name##_t));			\
+		kl_##name##_t *kl = (kl_##name##_t *)calloc(1, sizeof(kl_##name##_t));			\
 		kl->mp = kmp_init(name);										\
 		kl->head = kl->tail = kmp_alloc(name, kl->mp);					\
 		kl->head->next = 0;												\

--- a/htslib/ksort.h
+++ b/htslib/ksort.h
@@ -88,7 +88,11 @@ typedef struct {
 	int depth;
 } ks_isort_stack_t;
 
+#ifndef __cplusplus
 #define KSORT_SWAP(type_t, a, b) { register type_t t=(a); (a)=(b); (b)=t; }
+#else
+#define KSORT_SWAP(type_t, a, b) { type_t t=(a); (a)=(b); (b)=t; }
+#endif
 
 #define KSORT_INIT(name, type_t, __sort_lt)	KSORT_INIT_(_ ## name, , type_t, __sort_lt)
 #define KSORT_INIT_STATIC(name, type_t, __sort_lt)	KSORT_INIT_(_ ## name, static klib_unused, type_t, __sort_lt)


### PR DESCRIPTION
Current header files of htslib cannot be included in c++ code without correction.
Function declarations in macro function are put out of "extern C" in c++ code, and they trigger linkage errors.
Implicit cast from void to typed pointer is forbidden.
"register" keyword is not recommended in c++ code.