### PR TITLE
docs: fix simple typo, seperated -> separated

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -182,7 +182,7 @@ typedef struct bcf_dec_t {
     int m_fmt, m_info, m_id, m_als, m_allele, m_flt; // allocated size (high-water mark); do not change
     int n_flt;  // Number of FILTER fields
     int *flt;   // FILTER keys in the dictionary
-    char *id, *als;     // ID and REF+ALT block (\0-seperated)
+    char *id, *als;     // ID and REF+ALT block (\0-separated)
     char **allele;      // allele[0] is the REF (allele[] pointers to the als block); all null terminated
     bcf_info_t *info;   // INFO
     bcf_fmt_t *fmt;     // FORMAT and individual sample


### PR DESCRIPTION
There is a small typo in htslib/vcf.h.

Should read `separated` rather than `seperated`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md