### PR TITLE
Fix configure.ac buglet when used with autoconf 2.70

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,15 @@
 
 autom4te.cache
 config.cache
+config.guess
 config.h
 config.h.in
 config.log
 config.mk
 config.status
+config.sub
 configure
+install-sh
 
 hfile_*.bundle
 hfile_*.cygdll

--- a/configure.ac
+++ b/configure.ac
@@ -137,9 +137,9 @@ AC_ARG_ENABLE([s3],
                   [support Amazon AWS S3 URLs])],
   [], [enable_s3=check])
 
-test -n "$host_alias" || host_alias=unknown-`uname -s`
-AC_MSG_CHECKING([shared library type for $host_alias])
-case $host_alias in
+basic_host=${host_alias:-unknown-`uname -s`}
+AC_MSG_CHECKING([shared library type for $basic_host])
+case $basic_host in
   *-cygwin* | *-CYGWIN*)
     host_result="Cygwin DLL"
     PLATFORM=CYGWIN


### PR DESCRIPTION
As detected in [Debian bug 978835](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=978835), HTSlib's _./configure_ fails when built with autoconf 2.70 (released in December). It is a byproduct of [autoconf 2.70 being more careful about cross compilation](https://lists.gnu.org/archive/html/autoconf/2020-12/msg00002.html):

> *** More macros use config.sub and config.guess internally.
>
> As a consequence of improved support for cross compilation [snip]

Using the standard `$host_alias` variable name in our shared library check was fun and intended to be mostly already correct if we moved to using `AC_CANONICAL_HOST` at the top of the configure script, but causes problems when autoconf 2.70 implicitly uses `AC_CANONICAL_HOST` below our check. The simple fix is to use a variable name that's not used by autoconf, as there are reasons not to move to using `AC_CANONICAL_HOST` just yet.

As autoconf 2.70 implicitly uses `AC_CANONICAL_HOST`, it requires (and its `autoreconf --install` installs) _config.guess_ and _config.sub_. Ignore those, and ignore _install-sh_ as well for good measure.