### PR TITLE
Improve cross-compilation support [once autoconf 2.70 is widespread]

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -64,12 +64,17 @@ This step is only needed if configure.ac has been changed, or if configure
 does not exist (for example, when building from a git clone).  The
 configure script and config.h.in can be built by running:
 
+    ...copy config.guess, config.sub, and install-sh from elsewhere
     autoheader
     autoconf
 
 If you have a full GNU autotools install, you can alternatively run:
 
-    autoreconf
+    autoreconf -i
+
+(With autoconf 2.70 or later, autoreconf -i/--install will create the
+config.guess, etc files; with earlier versions you will need to copy them
+from Gnulib, Autoconf, or elsewhere yourself.)
 
 Basic Installation
 ==================

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ committed to this repository, so building the code from a Git repository
 requires extra steps:
 
 ```sh
+cp ..etc.. .   # Copy config.guess, config.sub, and install-sh from elsewhere
 autoheader     # If using configure, generate the header template...
 autoconf       # ...and configure script (or use autoreconf to do both)
 ./configure    # Optional but recommended, for choosing extra functionality

--- a/config.mk.in
+++ b/config.mk.in
@@ -37,8 +37,9 @@ libexecdir   = @libexecdir@
 datarootdir  = @datarootdir@
 mandir       = @mandir@
 
-CC     = @CC@
-RANLIB = @RANLIB@
+CC       = @CC@
+INSTALL  = @INSTALL@
+RANLIB   = @RANLIB@
 
 CPPFLAGS = @CPPFLAGS@
 CFLAGS   = @CFLAGS@

--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,9 @@ endif
 EOF
    AC_MSG_ERROR([$1], [$2])])
 
+AC_CANONICAL_HOST
 AC_PROG_CC
+AC_PROG_INSTALL
 AC_PROG_RANLIB
 
 dnl Turn on compiler warnings, if possible
@@ -137,9 +139,8 @@ AC_ARG_ENABLE([s3],
                   [support Amazon AWS S3 URLs])],
   [], [enable_s3=check])
 
-basic_host=${host_alias:-unknown-`uname -s`}
-AC_MSG_CHECKING([shared library type for $basic_host])
-case $basic_host in
+AC_MSG_CHECKING([shared library type${host_alias:+ for $host_alias}])
+case $host in
   *-cygwin* | *-CYGWIN*)
     host_result="Cygwin DLL"
     PLATFORM=CYGWIN


### PR DESCRIPTION
As noted in PR #1198, autoconf 2.70 is more careful about cross compilation and with this autoconf version using `AC_FUNC_MMAP` implicitly pulls in `AC_CANONICAL_HOST` and the cross-compilation infrastructure. So we might as well use `AC_CANONICAL_HOST` explicitly and improve our "shared library type" check (using the formal platform triplet rather than our own ad hoc `uname` invocation), regardless of autoconf version.

However using `AC_CANONICAL_HOST` causes autoconf 2.69 or earlier to search for _install-sh_ unconditionally. So we might as well also add `AC_PROG_INSTALL` and use `@INSTALL@` (though this loses `-p`).

All this requires the _config.guess_, _config.sub_, and _install-sh_ support scripts. With autoconf 2.70 `autoreconf -i/--install` creates these files. However this is not the case for previous versions of autoconf, so with those users would have to copy these files into their Git checkout from elsewhere themselves. Hence making this change is **not worthwhile** until autoconf 2.70 is a lot more widespread than it is at present. (At that point, our hand will have been forced w.r.t. these support files as _config.guess_ and _config.sub_ will be implicitly required anyway.)

Alternatives would be to:

* Check these three scripts into the repository instead of git-ignoring them, but it's preferable not to check in these externally-supplied scripts. (OTOH the release tarball-making scripts will have to take steps to ensure they are present in the generated tarballs.)

* Not use `AC_FUNC_MMAP`, which is currently the only thing causing the cross-compilation machinery to be activated in autoconf 2.70. But I suspect the writing is on the wall and in future even just checking for C header files will activate this machinery too.


This draft adds notes about these support scripts to the instructions. Probably it's about time the _README.md_ instructions were reformatted more like those in _INSTALL_ to emphasise use of `autoreconf`.

As CI environments are updated to use autoconf 2.70, they also will need to start using `autoreconf --install` or similar to ensure the support scripts are present.