### PR TITLE
Fix the iteration over the CIGAR segments

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -4816,14 +4816,14 @@ static inline int cigar_iref2iseq_next(uint32_t **cigar, uint32_t *cigar_max, ht
 
         if ( cig==BAM_CMATCH || cig==BAM_CEQUAL || cig==BAM_CDIFF )
         {
-            if ( *icig >= ncig - 1 ) { *icig = 0;  (*cigar)++; continue; }
+            if ( *icig >= ncig - 1 ) { *icig = -1;  (*cigar)++; continue; }
             (*iseq)++; (*icig)++; (*iref)++;
             return BAM_CMATCH;
         }
-        if ( cig==BAM_CDEL || cig==BAM_CREF_SKIP ) { (*cigar)++; (*iref) += ncig; *icig = 0; continue; }
-        if ( cig==BAM_CINS ) { (*cigar)++; *iseq += ncig; *icig = 0; continue; }
-        if ( cig==BAM_CSOFT_CLIP ) { (*cigar)++; *iseq += ncig; *icig = 0; continue; }
-        if ( cig==BAM_CHARD_CLIP || cig==BAM_CPAD ) { (*cigar)++; *icig = 0; continue; }
+        if ( cig==BAM_CDEL || cig==BAM_CREF_SKIP ) { (*cigar)++; (*iref) += ncig; *icig = -1; continue; }
+        if ( cig==BAM_CINS ) { (*cigar)++; *iseq += ncig; *icig = -1; continue; }
+        if ( cig==BAM_CSOFT_CLIP ) { (*cigar)++; *iseq += ncig; *icig = -1; continue; }
+        if ( cig==BAM_CHARD_CLIP || cig==BAM_CPAD ) { (*cigar)++; *icig = -1; continue; }
         hts_log_error("Unexpected cigar %d", cig);
         return -2;
     }


### PR DESCRIPTION
When encountering a new CIGAR segment, the index `icig`, which indicates the position of a base inside the current segment, has to be reset. This fix changes the reset value to **-1** (instead of **0**), so that the next first matching base starts from `icig=0` in the calling method (`tweak_overlap_quality`).

Replaces #1196
Fixes #1195