### PR TITLE
Renable changing CRAM compression level via hts_set_opt.

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -1340,6 +1340,8 @@ int hts_set_opt(htsFile *fp, enum hts_fmt_option opt, ...) {
         va_end(args);
         if (fp->is_bgzf)
             fp->fp.bgzf->compress_level = level;
+        else if (fp->format.format == cram)
+            return cram_set_option(fp->fp.cram, opt, level);
         return 0;
     }
 


### PR DESCRIPTION
This bug was introduced during #1181 where the additional
HTS_OPT_FILTER meant the automatic fall-through from
HTS_OPT_COMPRESSION_LEVEL no longer applied.

I decided against continuing the previous obscurity of moving
HTS_OPT_COMPRESSION_LEVEL to the end of the switch and having no
return (thus falling into the cram_set_voption call), instead
favouring an explicit call.

An example command that demonstrated the problem was:

    samtools view -O cram,level=1 in.bam -o out.cram