### PR TITLE
Reject VCF records where POS == 0

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -2901,6 +2901,10 @@ int vcf_parse(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v)
                 hts_log_error("Position value '%s' is too large", p);
                 goto err;
             } else {
+                if (v->pos < 1) {
+                    hts_log_error("Position must be greater than zero in VCF records");
+                    goto err;
+                }
                 v->pos -= 1;
             }
             if (v->pos >= INT32_MAX)


### PR DESCRIPTION
Which prevents problems caused by v->pos becoming negative when converting from 1-based VCF positions to 0-based internal/BCF.

Catches the bad input that gave rise to issue samtools/bcftools#1366 (bcftools: END (15195) smaller than POS) and caused a third-party tool using HTSlib to crash.
