### PR TITLE
remove a strange gcc10 warning.

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -3067,9 +3067,10 @@ cram_codec *cram_huffman_encode_init(cram_stats *st,
                                      enum cram_external_type option,
                                      void *dat,
                                      int version, varint_vec *vv) {
-    int *vals = NULL, *freqs = NULL, vals_alloc = 0, *lens = NULL, code, len;
+    int *vals = NULL, *freqs = NULL, *lens = NULL, code, len;
     int *new_vals, *new_freqs;
-    int nvals, i, ntot = 0, max_val = 0, min_val = INT_MAX, k;
+    int i, ntot = 0, max_val = 0, min_val = INT_MAX, k;
+    size_t nvals, vals_alloc = 0;
     cram_codec *c;
     cram_huffman_code *codes;
 


### PR DESCRIPTION
Gcc 10 when using -O and -fsanitize=address produces a warning about
mallocing some insanely large amount of memory.

This is an impossibility given the limits on the sizes of some data
values, but gcc doesn't know this and is assuimng variables may wrap
around and go negative.  Using an unsigned type stops it from
exploring the inaccessible data ranges.