### PR TITLE
Fix more OSS fuzz reported issues.

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -964,7 +964,7 @@ cram_codec *cram_const_decode_init(cram_block_compression_hdr *hdr,
     c->size   = cram_const_decode_size;
     c->get_block = NULL;
 
-    c->u.xconst.val = vv->varint_get64s(&cp, NULL, NULL);
+    c->u.xconst.val = vv->varint_get64s(&cp, data+size, NULL);
 
     if (cp - data != size) {
         fprintf(stderr, "Malformed const header stream\n");
@@ -2118,7 +2118,7 @@ cram_codec *cram_xrle_decode_init(cram_block_compression_hdr *hdr,
     char *endp = data+size;
     int err = 0;
 
-    if (!(c = malloc(sizeof(*c))))
+    if (!(c = calloc(1, sizeof(*c))))
         return NULL;
 
     c->codec  = E_XRLE;
@@ -2175,7 +2175,7 @@ cram_codec *cram_xrle_decode_init(cram_block_compression_hdr *hdr,
 
  malformed:
     fprintf(stderr, "Malformed xrle header stream\n");
-    free(c);
+    cram_xrle_decode_free(c);
     return NULL;
 }
 


### PR DESCRIPTION
Credit to OSS-Fuzz

- Add bounds check in cram_const_decode_init.

  I've checked and this is the only use of the varint decoders that
  didn't have a bounds check.  Suitably sniffed out by the fuzzer.
  Good fuzzer!

  Fixes oss-fuzz 30012

- Free the sub-encoding when initialising XRLE encoding fails due to
  malformed streams.  This removes a tiny memory leak.

  Fixes oss-fuzz 30014