### PR TITLE
Remove small memory leak when decoding malform slice header.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1032,6 +1032,7 @@ cram_block_slice_hdr *cram_decode_slice_header(cram_fd *fd, cram_block *b) {
     if (!err)
         return hdr;
 
+    free(hdr->block_content_ids);
     free(hdr);
     return NULL;
 }


### PR DESCRIPTION
This is an old bug, but only recently picked up by the fuzzer.

Credit to OSS-Fuzz
Fixes oss-fuzz 30105