### PR TITLE
Pull in htscodecs changes and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,11 +380,11 @@ cram/pooled_alloc.o cram/pooled_alloc.pico: cram/pooled_alloc.c config.h cram/po
 cram/string_alloc.o cram/string_alloc.pico: cram/string_alloc.c config.h cram/string_alloc.h
 thread_pool.o thread_pool.pico: thread_pool.c config.h $(thread_pool_internal_h) $(htslib_hts_log_h)
 
-htscodecs/htscodecs/arith_dynamic.o htscodecs/htscodecs/arith_dynamic.pico: htscodecs/htscodecs/arith_dynamic.c config.h $(htscodecs_arith_dynamic_h) $(htscodecs_varint_h) $(htscodecs_pack_h) $(htscodecs_c_simple_model.h)
+htscodecs/htscodecs/arith_dynamic.o htscodecs/htscodecs/arith_dynamic.pico: htscodecs/htscodecs/arith_dynamic.c config.h $(htscodecs_arith_dynamic_h) $(htscodecs_varint_h) $(htscodecs_pack_h) $(htsodecs_utils_h) $(htscodecs_c_simple_model.h)
 htscodecs/htscodecs/fqzcomp_qual.o htscodecs/htscodecs/fqzcomp_qual.pico: htscodecs/htscodecs/fqzcomp_qual.c config.h $(htscodecs_fqzcomp_qual_h) $(htscodecs_varint_h) $(htscodecs_c_simple_model.h)
 htscodecs/htscodecs/pack.o htscodecs/htscodecs/pack.pico: htscodecs/htscodecs/pack.c config.h $(htscodecs_pack_h)
-htscodecs/htscodecs/rANS_static4x16pr.o htscodecs/htscodecs/rANS_static4x16pr.pico: htscodecs/htscodecs/rANS_static4x16pr.c config.h $(htscodecs_rANS_word_h) $(htscodecs_rANS_static4x16_h) $(htscodecs_varint_h) $(htscodecs_pack_h) $(htscodecs_rle_h)
-htscodecs/htscodecs/rANS_static.o htscodecs/htscodecs/rANS_static.pico: htscodecs/htscodecs/rANS_static.c config.h $(htscodecs_rANS_byte_h) $(htscodecs_rANS_static_h)
+htscodecs/htscodecs/rANS_static4x16pr.o htscodecs/htscodecs/rANS_static4x16pr.pico: htscodecs/htscodecs/rANS_static4x16pr.c config.h $(htscodecs_rANS_word_h) $(htscodecs_rANS_static4x16_h) $(htscodecs_varint_h) $(htscodecs_pack_h) $(htscodecs_rle_h) $(htscodecs_utils_h)
+htscodecs/htscodecs/rANS_static.o htscodecs/htscodecs/rANS_static.pico: htscodecs/htscodecs/rANS_static.c config.h $(htscodecs_rANS_byte_h) $(htscodecs_utils_h) $(htscodecs_rANS_static_h)
 htscodecs/htscodecs/rle.o htscodecs/htscodecs/rle.pico: htscodecs/htscodecs/rle.c config.h $(htscodecs_varint_h) $(htscodecs_rle_h)
 htscodecs/htscodecs/tokenise_name3.o htscodecs/htscodecs/tokenise_name3.pico: htscodecs/htscodecs/tokenise_name3.c config.h $(htscodecs_pooled_alloc_h) $(htscodecs_arith_dynamic_h) $(htscodecs_rANS_static4x16_h) $(htscodecs_tokenise_name3_h) $(htscodecs_varint_h)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for htslib, a C library for high-throughput sequencing data formats.
 #
-#    Copyright (C) 2013-2020 Genome Research Ltd.
+#    Copyright (C) 2013-2021 Genome Research Ltd.
 #
 #    Author: John Marshall <jm18@sanger.ac.uk>
 #

--- a/htscodecs_bundled.mk
+++ b/htscodecs_bundled.mk
@@ -8,6 +8,7 @@ HTSCODECS_SOURCES = $(HTSPREFIX)htscodecs/htscodecs/arith_dynamic.c \
 
 HTSCODECS_OBJS = $(HTSCODECS_SOURCES:.c=.o)
 
+# htscodecs public headers
 htscodecs_arith_dynamic_h = htscodecs/htscodecs/arith_dynamic.h
 htscodecs_fqzcomp_qual_h = htscodecs/htscodecs/fqzcomp_qual.h
 htscodecs_pack_h = htscodecs/htscodecs/pack.h
@@ -17,11 +18,14 @@ htscodecs_rle_h = htscodecs/htscodecs/rle.h
 htscodecs_tokenise_name3_h = htscodecs/htscodecs/tokenise_name3.h
 htscodecs_varint_h = htscodecs/htscodecs/varint.h
 
-htscodecs_rANS_byte_h = htscodecs/htscodecs/rANS_byte.h
-htscodecs_rANS_word_h = htscodecs/htscodecs/rANS_word.h
+# htscodecs internal headers
+htscodecs_htscodecs_endian_h = htscodecs/htscodecs/htscodecs_endian.h
 htscodecs_c_range_coder_h = htscodecs/htscodecs/c_range_coder.h
 htscodecs_c_simple_model_h = htscodecs/htscodecs/c_simple_model.h $(htscodecs_c_range_coder_h)
 htscodecs_pooled_alloc_h = htscodecs/htscodecs/pooled_alloc.h
+htscodecs_rANS_byte_h = htscodecs/htscodecs/rANS_byte.h
+htscodecs_rANS_word_h = htscodecs/htscodecs/rANS_word.h $(htscodecs_htscodecs_endian_h)
+htscodecs_utils_h = htscodecs/htscodecs/utils.h
 
 # Add htscodecs tests into the HTSlib test framework
 

--- a/htscodecs_bundled.mk
+++ b/htscodecs_bundled.mk
@@ -1,3 +1,28 @@
+# Makefile fragment to add settings needed when bundling htscodecs functions
+#
+#    Copyright (C) 2021 Genome Research Ltd.
+#
+#    Author: Rob Davies <rmd@sanger.ac.uk>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+
 HTSCODECS_SOURCES = $(HTSPREFIX)htscodecs/htscodecs/arith_dynamic.c \
         $(HTSPREFIX)htscodecs/htscodecs/fqzcomp_qual.c \
         $(HTSPREFIX)htscodecs/htscodecs/pack.c \

--- a/htscodecs_external.mk
+++ b/htscodecs_external.mk
@@ -1,3 +1,27 @@
+# Makefile fragment for use when linking to an external libhtscodecs
+#
+#    Copyright (C) 2021 Genome Research Ltd.
+#
+#    Author: Rob Davies <rmd@sanger.ac.uk>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
 HTSCODECS_SOURCES =
 HTSCODECS_OBJS =
 HTSCODECS_TEST_TARGETS =

--- a/htscodecs_external.mk
+++ b/htscodecs_external.mk
@@ -11,7 +11,10 @@ htscodecs_rle_h =
 htscodecs_tokenise_name3_h =
 htscodecs_varint_h =
 
-htscodecs_rANS_byte_h =
+htscodecs_htscodecs_endian_h =
 htscodecs_c_range_coder_h =
 htscodecs_c_simple_model_h =
 htscodecs_pooled_alloc_h =
+htscodecs_rANS_byte_h =
+htscodecs_rANS_word_h =
+htscodecs_utils_h =


### PR DESCRIPTION
- Fix an overflow bug in the unstripe function
  Credit to OSS-Fuzz
  Fixes oss-fuzz 30087

- Move some duplicated code to a new htscodecs/utils.h header

- Updates htslib Makefile infrastructure for the new htscodecs header