### PR TITLE
Undefined behaviour fixes

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -3494,8 +3494,8 @@ int cram_byte_array_stop_decode_block(cram_slice *slice, cram_codec *c,
                                       int *out_size) {
     cram_block *b;
     cram_block *out = (cram_block *)out_;
-    char *cp, *out_cp, *cp_end;
-    char stop;
+    unsigned char *cp, *cp_end;
+    unsigned char stop;
 
     b = cram_get_block_by_id(slice, c->u.byte_array_stop.content_id);
     if (!b)
@@ -3503,25 +3503,25 @@ int cram_byte_array_stop_decode_block(cram_slice *slice, cram_codec *c,
 
     if (b->idx >= b->uncomp_size)
         return -1;
-    cp = (char *)b->data + b->idx;
-    cp_end = (char *)b->data + b->uncomp_size;
-    out_cp = (char *)BLOCK_END(out);
+    cp = b->data + b->idx;
+    cp_end = b->data + b->uncomp_size;
 
     stop = c->u.byte_array_stop.stop;
     if (cp_end - cp < out->alloc - out->byte) {
+        unsigned char *out_cp = BLOCK_END(out);
         while (cp != cp_end && *cp != stop)
             *out_cp++ = *cp++;
-        BLOCK_SIZE(out) = out_cp - (char *)BLOCK_DATA(out);
+        BLOCK_SIZE(out) = out_cp - BLOCK_DATA(out);
     } else {
-        char *cp_start;
+        unsigned char *cp_start;
         for (cp_start = cp; cp != cp_end && *cp != stop; cp++)
             ;
         BLOCK_APPEND(out, cp_start, cp - cp_start);
         BLOCK_GROW(out, cp - cp_start);
     }
 
-    *out_size = cp - (char *)(b->data + b->idx);
-    b->idx = cp - (char *)b->data + 1;
+    *out_size = cp - (b->data + b->idx);
+    b->idx = cp - b->data + 1;
 
     return 0;
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2080,7 +2080,7 @@ int cram_compress_block2(cram_fd *fd, cram_slice *s,
                     1.04, // 6  arithpr (O0)
                     1.05, // 7  fqz
                     1.05, // 8  tok3 (rans)
-                    9, 9, // 9,10 reserved
+                    1.00, 1.00, // 9,10 reserved
 
                     // Paramterised versions of above
                     1.01, // gzip rle
@@ -2123,6 +2123,9 @@ int cram_compress_block2(cram_fd *fd, cram_slice *s,
                     for (m = 0; m < CRAM_MAX_METHOD; m++)
                         metrics->sz[m] *= 1+(meth_cost[m]-1)/3;
                 } // else cost is ignored
+
+                // Ensure these are never used
+                metrics->sz[9] = metrics->sz[10] = INT_MAX;
 
                 for (m = 0; m < CRAM_MAX_METHOD; m++) {
                     if ((!metrics->sz[m]) || (!(method & (1u<<m))))
@@ -4395,8 +4398,8 @@ cram_slice *cram_new_slice(enum cram_content_type type, int nrecs) {
     s->block_by_id = NULL;
     s->last_apos = 0;
     if (!(s->crecs = malloc(nrecs * sizeof(cram_record))))  goto err;
-    s->cigar = NULL;
-    s->cigar_alloc = 0;
+    s->cigar_alloc = 1024;
+    if (!(s->cigar = malloc(s->cigar_alloc * sizeof(*s->cigar)))) goto err;
     s->ncigar = 0;
 
     if (!(s->seqs_blk = cram_new_block(EXTERNAL, 0)))       goto err;
@@ -4499,8 +4502,8 @@ cram_slice *cram_read_slice(cram_fd *fd) {
     }
 
     /* Initialise encoding/decoding tables */
-    s->cigar = NULL;
-    s->cigar_alloc = 0;
+    s->cigar_alloc = 1024;
+    if (!(s->cigar = malloc(s->cigar_alloc * sizeof(*s->cigar)))) goto err;
     s->ncigar = 0;
 
     if (!(s->seqs_blk = cram_new_block(EXTERNAL, 0)))      goto err;

--- a/hts_expr.c
+++ b/hts_expr.c
@@ -1,6 +1,6 @@
 /*  hts_expr.c -- filter expression parsing and processing.
 
-    Copyright (C) 2020 Genome Research Ltd.
+    Copyright (C) 2020-2021 Genome Research Ltd.
 
     Author: James Bonfield <jkb@sanger.ac.uk>
 
@@ -413,7 +413,7 @@ static int bitand_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
                 hts_expr_val_free(&val);
                 return -1;
             }
-            res->is_true = res->d = (int64_t)res->d & (int64_t)val.d;
+            res->is_true = (res->d = ((int64_t)res->d & (int64_t)val.d)) != 0;
         } else {
             break;
         }
@@ -441,7 +441,7 @@ static int bitxor_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
                 hts_expr_val_free(&val);
                 return -1;
             }
-            res->is_true = res->d = (int64_t)res->d ^ (int64_t)val.d;
+            res->is_true = (res->d = ((int64_t)res->d ^ (int64_t)val.d)) != 0;
         } else {
             break;
         }
@@ -469,7 +469,7 @@ static int bitor_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
                 hts_expr_val_free(&val);
                 return -1;
             }
-            res->is_true = res->d = (int64_t)res->d | (int64_t)val.d;
+            res->is_true = (res->d = ((int64_t)res->d | (int64_t)val.d)) != 0;
         } else {
             break;
         }

--- a/kstring.c
+++ b/kstring.c
@@ -1,7 +1,7 @@
 /* The MIT License
 
    Copyright (C) 2011 by Attractive Chaos <attractor@live.co.uk>
-   Copyright (C) 2013-2018, 2020 Genome Research Ltd.
+   Copyright (C) 2013-2018, 2020-2021 Genome Research Ltd.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -151,6 +151,15 @@ int kvsprintf(kstring_t *s, const char *fmt, va_list ap)
 		l = kputd(d, s);
 		va_end(args);
 		return l;
+	}
+
+	if (!s->s) {
+		const size_t sz = 64;
+		s->s = malloc(sz);
+		if (!s->s)
+			return -1;
+		s->m = sz;
+		s->l = 0;
 	}
 
 	l = vsnprintf(s->s + s->l, s->m - s->l, fmt, args); // This line does not work with glibc 2.0. See `man snprintf'.

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -46,6 +46,65 @@ void error(const char *format, ...)
 #define STRINGIFY(x) #x
 #define check0(x) ((x) == 0 ? (void) 0 : error("Failed: %s", STRINGIFY(x)))
 
+static int check_alleles(bcf1_t *rec, const char **alleles, int num) {
+    int i;
+    if (rec->n_allele !=  num) {
+        fprintf(stderr, "Wrong number of alleles - expected %d, got %d\n",
+                num, rec->n_allele);
+        return -1;
+    }
+    if (bcf_unpack(rec, BCF_UN_STR) != 0)
+        return -1;
+    for (i = 0; i < num; i++) {
+        if (0 != strcmp(alleles[i], rec->d.allele[i])) {
+            fprintf(stderr,
+                    "Mismatch for allele %d : expected '%s' got '%s'\n",
+                    i, alleles[i], rec->d.allele[i]);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static void test_update_alleles(bcf_hdr_t *hdr, bcf1_t *rec)
+{
+    // Exercise bcf_update_alleles() a bit
+    const char *alleles1[2] = { "G", "A" };
+    const char *alleles2[3] = { "C", "TGCA", "CATG" };
+#define rep10(x) x x x x x x x x x x
+    const char *alleles3[3] = { rep10("ATTCTAGATC"), "TGCA",
+                                rep10("CTATTATCTCTAATGACATG") };
+#undef rep10
+    const char *alleles4[3] = { alleles3[2], NULL, alleles3[0] };
+    // Add some alleles
+    check0(bcf_update_alleles(hdr, rec, alleles1, 2));
+    check0(check_alleles(rec, alleles1, 2));
+    // Erase them
+    check0(bcf_update_alleles(hdr, rec, NULL, 0));
+    check0(check_alleles(rec, NULL, 0));
+    // Expand to three
+    check0(bcf_update_alleles(hdr, rec, alleles2, 3));
+    check0(check_alleles(rec, alleles2, 3));
+    // Now try some bigger ones (should force a realloc)
+    check0(bcf_update_alleles(hdr, rec, alleles3, 3));
+    check0(check_alleles(rec, alleles3, 3));
+    // Ensure it works even if one of the alleles points into the
+    // existing structure
+    alleles4[1] = rec->d.allele[1];
+    check0(bcf_update_alleles(hdr, rec, alleles4, 3));
+    alleles4[1] = alleles3[1]; // Will have been clobbered by the update
+    check0(check_alleles(rec, alleles4, 3));
+    // Ensure it works when the alleles point into the existing data,
+    // rec->d.allele is used to define the input array and the
+    // order of the entries is changed.  The result of this should
+    // be the same as alleles2.
+    char *tmp = rec->d.allele[0] + strlen(rec->d.allele[0]) - 4;
+    rec->d.allele[0] = rec->d.allele[2] + strlen(rec->d.allele[2]) - 1;
+    rec->d.allele[2] = tmp;
+    check0(bcf_update_alleles(hdr, rec, (const char **) rec->d.allele, 3));
+    check0(check_alleles(rec, alleles2, 3));
+}
+
 void write_bcf(char *fname)
 {
     // Init
@@ -114,10 +173,10 @@ void write_bcf(char *fname)
     // .. ID
     check0(bcf_update_id(hdr, rec, "rs6054257"));
     // .. REF and ALT
+    test_update_alleles(hdr, rec);
     const char *alleles[2] = { "G", "A" };
-    check0(bcf_update_alleles(hdr, rec, alleles, 2));
-    check0(bcf_update_alleles(hdr, rec, NULL, 0));
     check0(bcf_update_alleles_str(hdr, rec, "G,A"));
+    check0(check_alleles(rec, alleles, 2));
     // .. QUAL
     rec->qual = 29;
     // .. FILTER

--- a/test/test-vcf-sweep.c
+++ b/test/test-vcf-sweep.c
@@ -63,7 +63,7 @@ int main(int argc, char **argv)
     {
         // get copy of the PL vectors
         nPLs = bcf_get_format_int32(hdr, rec, "PL", &PLs, &mPLs);
-        if ( !nPLs ) continue;  // PL not present
+        if ( nPLs <= 0 ) continue;  // PL not present
 
         // how many values are there per sample
         int nvals = nPLs / bcf_hdr_nsamples(hdr);
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
     while ( (rec = bcf_sweep_bwd(sw)) )
     {
         nPLs = bcf_get_format_int32(hdr, rec, "PL", &PLs, &mPLs);
-        if ( !nPLs ) continue;
+        if ( nPLs <= 0 ) continue;
         int nvals = nPLs / bcf_hdr_nsamples(hdr);
         int32_t *ptr = PLs;
         for (i=0; i<bcf_hdr_nsamples(hdr); i++)

--- a/vcf.c
+++ b/vcf.c
@@ -1236,9 +1236,9 @@ static inline int bcf_read1_core(BGZF *fp, bcf1_t *v)
     shared_len = le_to_u32(x);
     if (shared_len < 24) return -2;
     shared_len -= 24; // to exclude six 32-bit integers
-    if (ks_resize(&v->shared, shared_len) != 0) return -2;
+    if (ks_resize(&v->shared, shared_len ? shared_len : 1) != 0) return -2;
     indiv_len = le_to_u32(x + 4);
-    if (ks_resize(&v->indiv, indiv_len) != 0) return -2;
+    if (ks_resize(&v->indiv, indiv_len ? indiv_len : 1) != 0) return -2;
     v->rid  = le_to_i32(x + 8);
     v->pos  = le_to_u32(x + 12);
     v->rlen = le_to_i32(x + 16);


### PR DESCRIPTION
Fixes a number of warnings from running the tests on HTSlib built with clang 10.0.1 and -fsanitize=address,undefined

These fix "runtime error: applying zero offset to null pointer" warnings:
- Make `kvsprintf()` allocate some memory before trying to write a string into it
- In CRAM, always allocate memory for CIGAR data in slices
- Rearrange `cram_byte_array_stop_decode_block()` so it won't try to do maths on a NULL pointer
- Fix check on `bcf_get_format_int32()` return value in test-vcf-sweep so it doesn't try to work on a non-existent tag
- Fix dubious pointer comparisons in `bcf_update_alleles()`
- Ensure `bcf_read1_core()` always allocates memory for `rec->indiv.s` and `rec->shared.s`

Fixes for integer overflows:
- Prevent overflow of some elements in the `cram_metrics::sz` array
- Fix truncation bug in filtering expression bitwise operators, which could cause `is_true` to have the wrong value for some results