### PR TITLE
One of the examples in the header of bcf_get_format_*() didn't work.

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -1023,7 +1023,7 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
      *      int max_ploidy = ngt/nsmpl;
      *      for (i=0; i<nsmpl; i++)
      *      {
-     *        int32_t *ptr = gt + i*max_ploidy;
+     *        int32_t *ptr = ngt + i*max_ploidy;
      *        for (j=0; j<max_ploidy; j++)
      *        {
      *           // if true, the sample has smaller ploidy


### PR DESCRIPTION
Fixed typo in example of bcf_get_format_*() functions.

The line:

`int32_t *ptr = gt + i*max_ploidy;`

was not working properly, because `gt` should b `ngt`.