### PR TITLE
Assorted build updates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,7 @@
 # Omit these files from release tarballs.
 /.appveyor.yml  export-ignore
 .git*           export-ignore
-/.travis.yml    export-ignore
+/.cirrus.yml    export-ignore
 README.md       export-ignore
 
 # Remove the text attribute from reference files, so that git doesn't convert

--- a/Makefile
+++ b/Makefile
@@ -422,10 +422,10 @@ htscodecs/htscodecs/%.h: | htscodecs/htscodecs
 	;
 htscodecs/htscodecs:
 	@if test -e .git ; then \
-	printf "\\n\\nError: htscodecs submodule files not present.\\n\
+	printf "\\n\\nError: htscodecs submodule files not present for htslib.\\n\
 	Try running: \\n\
 	    git submodule update --init --recursive\\n\
-	and then re-run make.\\n\\n\\n" ; \
+	in the top-level htslib directory and then re-run make.\\n\\n\\n" ; \
 	else \
 	  printf "\\n\\nError: htscodecs submodule files not present and this is not a git checkout.\\n\
 	  You have an incomplete distribution.  Please try downloading one of the\\n\

--- a/configure.ac
+++ b/configure.ac
@@ -319,7 +319,7 @@ included as a submodule.  Try running:
 
   git submodule update --init --recursive
 
-to update it, and then re-run configure.
+in  the top-level htslib directory to update it, and then re-run configure.
 ])],
         [MSG_ERROR([htscodecs submodule files not present.
 

--- a/htslib.mk
+++ b/htslib.mk
@@ -188,7 +188,8 @@ $(HTSDIR)/htslib.pc.tmp:
 #
 #	clean: clean-htslib
 
-all-htslib clean-htslib install-htslib plugins-htslib:
+all-htslib check-htslib clean-htslib distclean-htslib install-htslib plugins-htslib test-htslib:
 	+cd $(HTSDIR) && $(MAKE) $(@:-htslib=)
 
-.PHONY: all-htslib clean-htslib install-htslib plugins-htslib
+.PHONY: all-htslib check-htslib clean-htslib distclean-htslib install-htslib
+.PHONY: plugins-htslib test-htslib


### PR DESCRIPTION
Small updates for build / release:

- Update `.gitattributes` to keep `.cirrus.yml` out of release tar files
- Add targets to `htslib.mk` so HTSlib's `distclean` and `check / test` can be run from packages that embed it (e.g. SAMtools / BCFtools).
- Clarify that the htscodecs submodule is part of htslib in messages printed when it's missing, so it's easier to see what needs to be updated when building SAMtools / BCFtools with HTSlib embedded.  Fixes samtools/samtools#1364.