### PR TITLE
Change CI scripts to use "autoreconf -i" and update docs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ build_script:
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
   - git submodule update --init --recursive
-  - "sh -lc \"autoheader && autoconf && ./configure --enable-werror CFLAGS='-g -O3' && make -j2\""
+  - "sh -lc \"autoreconf -i && ./configure --enable-werror CFLAGS='-g -O3' && make -j2\""
 
 #build_script:
 #  - make

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ compile_template: &COMPILE
     fi
     if test "$USE_CONFIG" = "yes"; then
       MAKE_OPTS=
-      autoreconf
+      autoreconf -i
       eval ./configure --enable-plugins --enable-werror $CONFIG_OPTS CFLAGS=\"-g -O3 $CFLAGS\" || \
         ( cat config.log; false )
     else

--- a/INSTALL
+++ b/INSTALL
@@ -17,6 +17,7 @@ In addition, building the configure script requires:
 
     autoheader
     autoconf
+    autoreconf
 
 Running the configure script uses awk, along with a number of
 standard UNIX tools (cat, cp, grep, mv, rm, sed, among others).  Almost
@@ -79,12 +80,7 @@ This step is only needed if configure.ac has been changed, or if configure
 does not exist (for example, when building from a git clone).  The
 configure script and config.h.in can be built by running:
 
-    autoheader
-    autoconf
-
-If you have a full GNU autotools install, you can alternatively run:
-
-    autoreconf
+    autoreconf -i
 
 Basic Installation
 ==================

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ committed to this repository, so building the code from a Git repository
 requires extra steps:
 
 ```sh
-autoheader     # If using configure, generate the header template...
-autoconf       # ...and configure script (or use autoreconf to do both)
+autoreconf -i  # Build the configure script and install files it uses
 ./configure    # Optional but recommended, for choosing extra functionality
 make
 make install


### PR DESCRIPTION
autoconf 2.7 requires use of `autoreconf -i` for the AC_CANONICAL_HOST macro, which is pulled in by AC_FUNC_MMAP.

Update CI configuration to use this, and change the instructions in the INSTALL and README.md files to match.

Fixes AppVeyor builds, which have stopped working since they upgraded to autoconf 2.71