### PR TITLE
Fix reading UTF-8 encoded sample names when char is signed

### DIFF
--- a/test/formatcols.vcf
+++ b/test/formatcols.vcf
@@ -2,5 +2,5 @@
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##contig=<ID=1>
 ##FORMAT=<ID=S,Number=1,Type=String,Description="Text">
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S²	S3
 1	100	a	A	T	.	.	.	S	a	bbbbbbb	ccccccccc

--- a/vcf.c
+++ b/vcf.c
@@ -150,7 +150,7 @@ int HTS_RESULT_USED bcf_hdr_parse_sample_line(bcf_hdr_t *h, const char *str)
     const char *p, *q;
     // add samples
     for (p = q = str;; ++q) {
-        if (*q > '\n') continue;
+        if ((unsigned char) *q > '\n') continue;
         if (++i > 9) {
             if ( bcf_hdr_add_sample_len(h, p, q - p) < 0 ) ret = -1;
         }


### PR DESCRIPTION
The trick used in bcf_hdr_parse_sample_line() to rapidly find tabs and newlines could be defeated by UTF-8 characters outside the Basic Latin range on platforms where "char" is signed (like x86).  It's currently not clear if VCF intends to allow these, but the [4.3 specification does allow UTF-8](https://samtools.github.io/hts-specs/VCFv4.3.pdf#subsection.1.2) and it's easy enough to support.  Fix by casting to unsigned when making the comparison.

Modifies formatcols.vcf to include a UTF-8 character for a round-trip test.

Fixes samtools/bcftools#1408