### PR TITLE
Add mostlyclean-htslib and testclean-htslib targets to htslib.mk

### DIFF
--- a/htslib.mk
+++ b/htslib.mk
@@ -188,8 +188,8 @@ $(HTSDIR)/htslib.pc.tmp:
 #
 #	clean: clean-htslib
 
-all-htslib check-htslib clean-htslib distclean-htslib install-htslib plugins-htslib test-htslib:
+all-htslib check-htslib clean-htslib distclean-htslib install-htslib mostlyclean-htslib plugins-htslib test-htslib testclean-htslib:
 	+cd $(HTSDIR) && $(MAKE) $(@:-htslib=)
 
 .PHONY: all-htslib check-htslib clean-htslib distclean-htslib install-htslib
-.PHONY: plugins-htslib test-htslib
+.PHONY: mostlyclean-htslib plugins-htslib test-htslib testclean-htslib


### PR DESCRIPTION
I noticed these were still missing when adding more `*-all` targets to SAMtools following #1230.  With them, it will be possible to access most of the useful `*clean` targets when building HTSlib at the same time as SAMtools/BCFtools.