### PR TITLE
Update to htscodecs release 1.0

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -73,6 +73,10 @@ either clone the project using "git clone --recurse-submodules", or run:
 
 to ensure the correct version of the submodule is present.
 
+It is also possible to link against an external libhtscodecs library
+by using the '--with-external-htscodecs' configure option.  When
+this is used, the submodule files will be ignored.
+
 Building Configure
 ==================
 
@@ -139,6 +143,10 @@ various features and specify further optional external requirements:
     By default, only the directory specified via --with-plugin-dir will be
     searched; you can use --with-plugin-path='DIR:$(plugindir):DIR' and so
     on to cause additional directories to be searched.
+
+--with-external-htscodecs
+    Build and link against an external copy of the htscodecs library
+    instead of using the source files in the htscodecs directory.
 
 --enable-libcurl
     Use libcurl (<http://curl.se/>) to implement network access to

--- a/htscodecs_bundled.mk
+++ b/htscodecs_bundled.mk
@@ -25,6 +25,7 @@
 
 HTSCODECS_SOURCES = $(HTSPREFIX)htscodecs/htscodecs/arith_dynamic.c \
         $(HTSPREFIX)htscodecs/htscodecs/fqzcomp_qual.c \
+        $(HTSPREFIX)htscodecs/htscodecs/htscodecs.c \
         $(HTSPREFIX)htscodecs/htscodecs/pack.c \
         $(HTSPREFIX)htscodecs/htscodecs/rANS_static4x16pr.c \
         $(HTSPREFIX)htscodecs/htscodecs/rANS_static.c \
@@ -36,6 +37,7 @@ HTSCODECS_OBJS = $(HTSCODECS_SOURCES:.c=.o)
 # htscodecs public headers
 htscodecs_arith_dynamic_h = htscodecs/htscodecs/arith_dynamic.h
 htscodecs_fqzcomp_qual_h = htscodecs/htscodecs/fqzcomp_qual.h
+htscodecs_htscodecs_h = htscodecs/htscodecs/htscodecs.h $(htscodecs_version_h)
 htscodecs_pack_h = htscodecs/htscodecs/pack.h
 htscodecs_rANS_static_h = htscodecs/htscodecs/rANS_static.h
 htscodecs_rANS_static4x16_h = htscodecs/htscodecs/rANS_static4x16.h
@@ -51,6 +53,7 @@ htscodecs_pooled_alloc_h = htscodecs/htscodecs/pooled_alloc.h
 htscodecs_rANS_byte_h = htscodecs/htscodecs/rANS_byte.h
 htscodecs_rANS_word_h = htscodecs/htscodecs/rANS_word.h $(htscodecs_htscodecs_endian_h)
 htscodecs_utils_h = htscodecs/htscodecs/utils.h
+htscodecs_version_h = htscodecs/htscodecs/version.h
 
 # Add htscodecs tests into the HTSlib test framework
 

--- a/htscodecs_external.mk
+++ b/htscodecs_external.mk
@@ -28,6 +28,7 @@ HTSCODECS_TEST_TARGETS =
 
 htscodecs_arith_dynamic_h =
 htscodecs_fqzcomp_qual_h =
+htscodecs_htscodecs_h =
 htscodecs_pack_h =
 htscodecs_rANS_static_h =
 htscodecs_rANS_static4x16_h =
@@ -42,3 +43,4 @@ htscodecs_pooled_alloc_h =
 htscodecs_rANS_byte_h =
 htscodecs_rANS_word_h =
 htscodecs_utils_h =
+htscodecs_version_h =

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -483,6 +483,7 @@ const char *hts_feature_string(void);
 #define HTS_FEATURE_LIBDEFLATE   (1u<<20)
 #define HTS_FEATURE_LZMA         (1u<<21)
 #define HTS_FEATURE_BZIP2        (1u<<22)
+#define HTS_FEATURE_HTSCODECS    (1u<<23) // htscodecs library version
 
 // Build params
 #define HTS_FEATURE_CC           (1u<<27)

--- a/test/test_introspection.c
+++ b/test/test_introspection.c
@@ -31,6 +31,8 @@ DEALINGS IN THE SOFTWARE.  */
 int main(void) {
     printf("Version string: %s\n", hts_version());
     printf("Version number: %d\n", HTS_VERSION);
+    printf("\nhtscodecs version: %s\n",
+           hts_test_feature(HTS_FEATURE_HTSCODECS));
 
     printf("\nCC:             %s\n", hts_test_feature(HTS_FEATURE_CC));
     printf("CPPFLAGS:       %s\n", hts_test_feature(HTS_FEATURE_CPPFLAGS));
@@ -55,6 +57,8 @@ int main(void) {
         printf("                HTS_FEATURE_LZMA\n");
     if (feat & HTS_FEATURE_BZIP2)
         printf("                HTS_FEATURE_BZIP2\n");
+    if (feat & HTS_FEATURE_HTSCODECS)
+        printf("                HTS_FEATURE_HTSCODECS\n");
 
     printf("\nFeature string: %s\n", hts_feature_string());
 


### PR DESCRIPTION
Updates the htscodecs submodule and updates dependencies for the new header files.

Adds Makefile infrastructure to build and clean up the htscodecs/htscodecs/version.h file, for git checkouts only. Release tarballs will ship with a pre-built copy of this file.

Fixes issue where the Makefile rules to test if the submodule is missing would cause missing source files to be silently ignored. They now run a recipe to check for the target, and suggest updating the submodule if it's missing.

Makes hts_version() report the submodule version along with its own.

Adds documentation for the '--with-external-htscodecs' configure option to INSTALL.