### PR TITLE
Recognise legacy RAZF compression

### DIFF
--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -209,7 +209,7 @@ enum htsExactFormat {
 };
 
 enum htsCompression {
-    no_compression, gzip, bgzf, custom, bzip2_compression,
+    no_compression, gzip, bgzf, custom, bzip2_compression, razf_compression,
     compression_maximum = 32767
 };
 


### PR DESCRIPTION
Diagnosing samtools/samtools#1387 was hindered by `htsfile` identifying what was actually an obsolete RAZF-compressed file as plain gzipped. This patch adds basic support for recognising RAZF, similarly to how ef0b40d673bf3c3a0fe2080c448b4981c4784bae added basic recognition for bzip2 compression.

```
$ htsfile human_g1k_v37.fasta.gz 
human_g1k_v37.fasta.gz:	FASTA legacy-RAZF-compressed data
```

(RAZF is an obsolete predecessor to BGZF, and is similarly a variant of GZIP using an extra header field. It also adds a trailing index table.)

Adding this `htsCompression` value does not affect `bgzf_read_init()`'s detection of BGZF vs plain-GZIP; RAZF remains treated as `is_gzip` and the trailing index table is not handled well, leading to problems
if you try to decompress such a legacy file with e.g. `bgzip -d` — as the OP on that issue discovered.