### PR TITLE
Add options to force S3 address style.

### DIFF
--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -29,6 +29,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 
 #include <errno.h>
@@ -503,6 +504,7 @@ static s3_auth_data * setup_auth_data(const char *s3url, const char *mode,
     ptrdiff_t bucket_len;
     int is_https = 1, dns_compliant;
     char *query_start;
+    enum {s3_auto, s3_virtual, s3_path} address_style = s3_auto;
 
     if (!ad)
         return NULL;
@@ -555,29 +557,73 @@ static s3_auth_data * setup_auth_data(const char *s3url, const char *mode,
         if ((v = getenv("AWS_DEFAULT_PROFILE")) != NULL) kputs(v, &profile);
         else if ((v = getenv("AWS_PROFILE")) != NULL) kputs(v, &profile);
         else kputs("default", &profile);
+
+        if ((v = getenv("HTS_S3_ADDRESS_STYLE")) != NULL) {
+            if (strcasecmp(v, "virtual") == 0) {
+                address_style = s3_virtual;
+            } else if (strcasecmp(v, "path") == 0) {
+                address_style = s3_path;
+            }
+        }
     }
 
     if (ad->id.l == 0) {
+        kstring_t url_style = KS_INITIALIZE;
         const char *v = getenv("AWS_SHARED_CREDENTIALS_FILE");
         parse_ini(v? v : "~/.aws/credentials", profile.s,
                   "aws_access_key_id", &ad->id,
                   "aws_secret_access_key", &ad->secret,
                   "aws_session_token", &ad->token,
-                  "region", &ad->region, NULL);
+                  "region", &ad->region,
+                  "addressing_style", &url_style, NULL);
+
+        if (url_style.l) {
+            if (strcmp(url_style.s, "virtual") == 0) {
+                address_style = s3_virtual;
+            } else if (strcmp(url_style.s, "path") == 0) {
+                address_style = s3_path;
+            } else {
+                address_style = s3_auto;
+            }
+        }
+
+        ks_free(&url_style);
     }
 
     if (ad->id.l == 0) {
+        kstring_t url_style = KS_INITIALIZE;
         const char *v = getenv("HTS_S3_S3CFG");
         parse_ini(v? v : "~/.s3cfg", profile.s, "access_key", &ad->id,
                   "secret_key", &ad->secret, "access_token", &ad->token,
                   "host_base", &ad->host,
-                  "bucket_location", &ad->region, NULL);
+                  "bucket_location", &ad->region,
+                  "host_bucket", &url_style, NULL);
+
+        if (url_style.l) {
+            // Conforming to s3cmd's GitHub PR#416, host_bucket without the "%(bucket)s" string
+            // indicates use of path style adressing.
+            if (strstr(url_style.s, "%(bucket)s") == NULL) {
+                address_style = s3_path;
+            } else {
+                address_style = s3_auto;
+            }
+        }
+
+        ks_free(&url_style);
     }
 
     if (ad->id.l == 0)
         parse_simple("~/.awssecret", &ad->id, &ad->secret);
 
-    dns_compliant = is_dns_compliant(bucket, path, is_https);
+
+    // if address_style is set, force the dns_compliant setting
+    if (address_style == s3_virtual) {
+        dns_compliant = 1;
+    } else if (address_style == s3_path) {
+        dns_compliant = 0;
+    } else {
+        dns_compliant = is_dns_compliant(bucket, path, is_https);
+    }
 
     if (ad->host.l == 0)
         kputs("s3.amazonaws.com", &ad->host);

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -575,7 +575,8 @@ static s3_auth_data * setup_auth_data(const char *s3url, const char *mode,
                   "aws_secret_access_key", &ad->secret,
                   "aws_session_token", &ad->token,
                   "region", &ad->region,
-                  "addressing_style", &url_style, NULL);
+                  "addressing_style", &url_style,
+                  NULL);
 
         if (url_style.l) {
             if (strcmp(url_style.s, "virtual") == 0) {
@@ -597,7 +598,8 @@ static s3_auth_data * setup_auth_data(const char *s3url, const char *mode,
                   "secret_key", &ad->secret, "access_token", &ad->token,
                   "host_base", &ad->host,
                   "bucket_location", &ad->region,
-                  "host_bucket", &url_style, NULL);
+                  "host_bucket", &url_style,
+                  NULL);
 
         if (url_style.l) {
             // Conforming to s3cmd's GitHub PR#416, host_bucket without the "%(bucket)s" string

--- a/htslib-s3-plugin.7
+++ b/htslib-s3-plugin.7
@@ -2,7 +2,7 @@
 .SH NAME
 s3 plugin \- htslib AWS S3 plugin
 .\"
-.\" Copyright (C) 2019 Genome Research Ltd.
+.\" Copyright (C) 2021 Genome Research Ltd.
 .\"
 .\" Author: Andrew Whitwham <aw7@sanger.ac.uk>
 .\"
@@ -105,15 +105,32 @@ Sets the upload part size in Mb, the minimum being 5Mb.
 By default the part size starts at 5Mb and expands at regular intervals to
 accommodate bigger files (up to 2.5 Tbytes with the current rate).
 Using this setting disables the automatic part size expansion.
+.TP
+.B HTS_S3_ADDRESS_STYLE
+Sets the URL style.  Options are auto (default), virtual or path.  
 .LP
 In the absence of an ID from the previous two methods the credential/config
 files will be used.  The default file locations are either
 \fI~/.aws/credentials\fR or \fI~/.s3cfg\fR (in that order).
+
+Entries used in aws style credentials file are aws_access_key_id, 
+aws_secret_access_key, aws_session_token, region and addressing_style.  Only the
+first two are usually needed.
+
+Entries used in s3cmd style config files are access_key, secret_key,
+access_token, host_base, bucket_location and host_bucket. Again only the first
+two are usually needed. The host_bucket option is only used to set a path-style
+URL, see below.
+
 .SH NOTES
 In most cases this plugin transforms the given URL into a virtual host-style
 format e.g. \fIhttps://bucket.host/path/to/file\fR.  A path-style format is used
 where the URL is not DNS compliant or the bucket name contains a dot e.g.
 \fIhttps://host/bu.cket/path/to/file\fR.
+
+Path-style can be forced by setting one either HTS_S3_ADDRESS_STYLE,
+addressing_style or host_bucket.  The first two can be set to \fBpath\fR while
+host_bucket must \fBnot\fR include the \fB%(bucket).s\fR string.
 
 .SH "SEE ALSO"
 .BR htsfile (1)


### PR DESCRIPTION
There are now three ways to force the URL style in the S3 plugin.  By setting addressing_style in the aws credentials file, by setting host_bucket in .s3cfg to anything not containing %(bucket).s (this is how s3cmd works) or by setting the  HTS_S3_ADDRESS_STYLE env variable to **path**.

Should fix samtools/samtools#1377.


