### PR TITLE
Improve "CRAM version 3.1/4.0 is still draft" wording

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -5688,10 +5688,9 @@ int cram_set_voption(cram_fd *fd, enum hts_fmt_option opt, va_list args) {
 
         if (major > 3 || (major == 3 && minor > 0)) {
             hts_log_warning(
-                "CRAM version %s is still in draft and is subject to\n"
-                "change. Please consider this a technology demonstration "
-                "and do not use for\n"
-                "long term archival of data.", s);
+                "CRAM version %s is still a draft and subject to change.\n"
+                "This is a technology demonstration that should not be "
+                "used for archival data.", s);
         }
 
         fd->version = major*256 + minor;


### PR DESCRIPTION
Er… I only just got around to actually reading this message… :rofl:

I've long been vaguely squicked by the first line ending mid sentence (makes it hard to glance at the message and get the gist), and I've only just noticed the slightly unfortunate “archival of data”.

This changes

```
 ./test_view  -t auxf.fa -C -o VERSION=3.1 auxf#values.tmp.cram.cram > auxf#values.tmp.cram
[W::cram_set_voption] CRAM version 3.1 is still in draft and is subject to
change. Please consider this a technology demonstration and do not use for
long term archival of data.
```

to

```
 ./test_view  -t auxf.fa -C -o VERSION=3.1 auxf#values.tmp.cram.cram > auxf#values.tmp.cram
[W::cram_set_voption] CRAM version 3.1 is still a draft and subject to change.
This is a technology demonstration that should not be used for archival data.
```

But it doesn't much matter, except insofar as people will be looking at this message…