### PR TITLE
+ introduce GCP requester pays bucket access

### DIFF
--- a/hfile_gcs.c
+++ b/hfile_gcs.c
@@ -42,10 +42,11 @@ static hFILE *
 gcs_rewrite(const char *gsurl, const char *mode, int mode_has_colon,
             va_list *argsp)
 {
-    const char *bucket, *path, *access_token;
+    const char *bucket, *path, *access_token, *requester_pays_project;
     kstring_t mode_colon = { 0, 0, NULL };
     kstring_t url = { 0, 0, NULL };
     kstring_t auth_hdr = { 0, 0, NULL };
+    kstring_t requester_pays_hdr = { 0, 0, NULL };
     hFILE *fp = NULL;
 
     // GCS URL format is gs[+SCHEME]://BUCKET/PATH
@@ -81,15 +82,35 @@ gcs_rewrite(const char *gsurl, const char *mode, int mode_has_colon,
         kputs(access_token, &auth_hdr);
     }
 
-    if (argsp || auth_hdr.l > 0 || mode_has_colon) {
+    requester_pays_project = getenv("GCS_REQUESTER_PAYS_PROJECT");
+
+    if (requester_pays_project) {
+        kputs("X-Goog-User-Project: ", &requester_pays_hdr);
+        kputs(requester_pays_project, &requester_pays_hdr);
+    }
+
+    if (argsp || mode_has_colon || auth_hdr.l > 0 || requester_pays_hdr.l > 0) {
         if (! mode_has_colon) {
             kputs(mode, &mode_colon);
             kputc(':', &mode_colon);
             mode = mode_colon.s;
         }
 
-        fp = hopen(url.s, mode, "va_list", argsp,
-                   "httphdr", (auth_hdr.l > 0)? auth_hdr.s : NULL, NULL);
+        if (auth_hdr.l > 0 && requester_pays_hdr.l > 0) {
+            fp = hopen(
+                url.s, mode, "va_list", argsp,
+                   "httphdr:l",
+                   auth_hdr.s,
+                   requester_pays_hdr.s,
+                   NULL,
+                   NULL
+            );
+
+        }
+        else {
+            fp = hopen(url.s, mode, "va_list", argsp,
+                       "httphdr", (auth_hdr.l > 0)? auth_hdr.s : NULL, NULL);
+        }
     }
     else
         fp = hopen(url.s, mode);
@@ -97,6 +118,7 @@ gcs_rewrite(const char *gsurl, const char *mode, int mode_has_colon,
     free(mode_colon.s);
     free(url.s);
     free(auth_hdr.s);
+    free(requester_pays_hdr.s);
     return fp;
 }
 


### PR DESCRIPTION
this is my attempt at introducing the ability for HTSLIB to access files in Google Cloud Storage buckets that have enabled [requester pays][0].

To enable requester pays, one will need to export the additional environment variable along with `GCS_OAUTH_TOKEN`:

    GCS_REQUESTER_PAYS_PROJECT=my-project-name

[0]: https://cloud.google.com/storage/docs/requester-pays