### PR TITLE
Prevent corruption of the ID value of a PG line

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,13 @@
 Noteworthy changes in release a.b
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Features and Updates
+--------------------
+
+* In case a PG header line has multiple ID tags supplied by other applications,
+  the header API now selects the first one encountered as the identifying tag
+  and issues a warning when detecting subsequent ID tags.
+
 Noteworthy changes in release 1.12 (17th March 2021)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/header.c
+++ b/header.c
@@ -330,9 +330,14 @@ static int sam_hrecs_update_hashes(sam_hrecs_t *hrecs,
 
         while (tag) {
             if (tag->str[0] == 'I' && tag->str[1] == 'D') {
-                assert(tag->len >= 3);
-                hrecs->pg[npg].name = tag->str + 3;
-                hrecs->pg[npg].name_len = tag->len - 3;
+                /* Avoid duplicate ID tags coming from other applications */
+                if (!hrecs->pg[npg].name) {
+                    assert(tag->len >= 3);
+                    hrecs->pg[npg].name = tag->str + 3;
+                    hrecs->pg[npg].name_len = tag->len - 3;
+                } else {
+                    hts_log_warning("PG line with multiple ID tags. The first encountered was preferred - ID:%s", hrecs->pg[npg].name);
+                }
             } else if (tag->str[0] == 'P' && tag->str[1] == 'P') {
                 // Resolve later if needed
                 khint_t k;


### PR DESCRIPTION
Some applications add supplementary **ID** tags to a header `@PG` line. This change prevents the corruption of the proper (first) **ID** value of a `@PG` line, when other unrelated **ID** tags are present.

Fixes   https://github.com/samtools/samtools/issues/1393