### PR TITLE
Remove compressBound assertions.

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -491,7 +491,6 @@ fail:
 BGZF *bgzf_open(const char *path, const char *mode)
 {
     BGZF *fp = 0;
-    assert(compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE);
     if (strchr(mode, 'r')) {
         hFILE *fpr;
         if ((fpr = hopen(path, mode)) == 0) return 0;
@@ -514,7 +513,6 @@ BGZF *bgzf_open(const char *path, const char *mode)
 BGZF *bgzf_dopen(int fd, const char *mode)
 {
     BGZF *fp = 0;
-    assert(compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE);
     if (strchr(mode, 'r')) {
         hFILE *fpr;
         if ((fpr = hdopen(fd, mode)) == 0) return 0;
@@ -537,7 +535,6 @@ BGZF *bgzf_dopen(int fd, const char *mode)
 BGZF *bgzf_hopen(hFILE *hfp, const char *mode)
 {
     BGZF *fp = NULL;
-    assert(compressBound(BGZF_BLOCK_SIZE) < BGZF_MAX_BLOCK_SIZE);
     if (strchr(mode, 'r')) {
         fp = bgzf_read_init(hfp, NULL);
         if (fp == NULL) return NULL;
@@ -617,6 +614,7 @@ int bgzf_compress(void *_dst, size_t *dlen, const void *src, size_t slen, int le
     uint8_t *dst = (uint8_t*)_dst;
 
     if (level == 0) {
+    uncomp:
         // Uncompressed data
         if (*dlen < slen+5 + BLOCK_HEADER_LENGTH + BLOCK_FOOTER_LENGTH) return -1;
         dst[BLOCK_HEADER_LENGTH] = 1; // BFINAL=1, BTYPE=00; see RFC1951
@@ -638,9 +636,17 @@ int bgzf_compress(void *_dst, size_t *dlen, const void *src, size_t slen, int le
             return -1;
         }
         if ((ret = deflate(&zs, Z_FINISH)) != Z_STREAM_END) {
-            hts_log_error("Deflate operation failed: %s", bgzf_zerr(ret, ret == Z_DATA_ERROR ? &zs : NULL));
+            if (ret == Z_OK && zs.avail_out == 0)
+                goto uncomp;
+            else
+                hts_log_error("Deflate operation failed: %s", bgzf_zerr(ret, ret == Z_DATA_ERROR ? &zs : NULL));
             return -1;
         }
+        // If we used up the entire output buffer, then we either ran out of
+        // room or we *just* fitted, but either way we may as well store
+        // uncompressed for faster decode.
+        if (zs.avail_out == 0)
+            goto uncomp;
         if ((ret = deflateEnd(&zs)) != Z_OK) {
             hts_log_error("Call to deflateEnd failed: %s", bgzf_zerr(ret, NULL));
             return -1;

--- a/bgzf.c
+++ b/bgzf.c
@@ -636,17 +636,21 @@ int bgzf_compress(void *_dst, size_t *dlen, const void *src, size_t slen, int le
             return -1;
         }
         if ((ret = deflate(&zs, Z_FINISH)) != Z_STREAM_END) {
-            if (ret == Z_OK && zs.avail_out == 0)
+            if (ret == Z_OK && zs.avail_out == 0) {
+                deflateEnd(&zs);
                 goto uncomp;
-            else
+            } else {
                 hts_log_error("Deflate operation failed: %s", bgzf_zerr(ret, ret == Z_DATA_ERROR ? &zs : NULL));
+            }
             return -1;
         }
         // If we used up the entire output buffer, then we either ran out of
         // room or we *just* fitted, but either way we may as well store
         // uncompressed for faster decode.
-        if (zs.avail_out == 0)
+        if (zs.avail_out == 0) {
+            deflateEnd(&zs);
             goto uncomp;
+        }
         if ((ret = deflateEnd(&zs)) != Z_OK) {
             hts_log_error("Call to deflateEnd failed: %s", bgzf_zerr(ret, NULL));
             return -1;


### PR DESCRIPTION
These trip on with zlib-ng as the worse case expansion is 9-bits per byte (at level 1 only).  The test is done on opening a file, which seems strange.

We could do the check on opening for write only, but it seems more productive to error only when we actually can't fit the data rather than just incase it may if given truely random input.  Our real data doesn't seem to trigger this.

TODO: if we ever actually find genuine data that trips this up, then consider resetting level to above 1 and trying again, so the error is handled rather than exiting.

The worst case I could find on any of our data files was an ONT BAM file with high randomness in quality values, leading to 57k blocks at level 1.

Fixes #1257