### PR TITLE
[vcf] Display only the duplicate sample name, not the entire list

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -129,7 +129,7 @@ static int bcf_hdr_add_sample_len(bcf_hdr_t *h, const char *s, size_t len)
         kh_val(d, k) = bcf_idinfo_def;
         kh_val(d, k).id = n;
     } else {
-        hts_log_error("Duplicated sample name '%s'", s);
+        hts_log_error("Duplicated sample name '%s'", sdup);
         free(sdup);
         return -1;
     }


### PR DESCRIPTION
When viewing a VCF file with a header containing duplicate sample names, the resulting error message prints the entire sample name list. This change limits the display to only the duplicate sample name.

Fixes  https://github.com/samtools/bcftools/issues/1451