### PR TITLE
Add curl/curl.h configure check and improve INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -150,7 +150,10 @@ various features and specify further optional external requirements:
 
 --enable-libcurl
     Use libcurl (<http://curl.se/>) to implement network access to
-    remote files via FTP, HTTP, HTTPS, etc.
+    remote files via FTP, HTTP, HTTPS, etc.  By default or with
+    --enable-libcurl=check, configure will probe for libcurl and include
+    this functionality if libcurl is available.  Use --disable-libcurl
+    to prevent this.
 
 --enable-gcs
     Implement network access to Google Cloud Storage.  By default or with
@@ -175,6 +178,12 @@ various features and specify further optional external requirements:
     and decompression.  It also includes a fast crc32 implementation.
     By default, ./configure will probe for libdeflate and use it if
     available.  To prevent this, use --without-libdeflate.
+
+Each --enable-FEATURE/--disable-FEATURE/--with-PACKAGE/--without-PACKAGE
+option listed also has an opposite, e.g., --without-external-htscodecs
+or --disable-plugins.  However, apart from those options for which the
+default is to probe for related facilities, using these opposite options
+is mostly unnecessary as they just select the default configure behaviour.
 
 The configure script also accepts the usual options and environment variables
 for tuning installation locations and compilers: type './configure --help'

--- a/configure.ac
+++ b/configure.ac
@@ -351,15 +351,20 @@ HTSlib.])])])])
 
 libcurl=disabled
 if test "$enable_libcurl" != no; then
-  AC_CHECK_LIB([curl], [curl_easy_pause],
-    [AC_DEFINE([HAVE_LIBCURL], 1, [Define if libcurl file access is enabled.])
-     libcurl=enabled],
+  libcurl_devel=ok
+  AC_CHECK_HEADER([curl/curl.h], [], [libcurl_devel="headers not found"], [;])
+  AC_CHECK_LIB([curl], [curl_easy_pause], [:],
     [AC_CHECK_LIB([curl], [curl_easy_init],
-       [message="library is too old (7.18+ required)"],
-       [message="library not found"])
-     case "$enable_libcurl" in
-       check) AC_MSG_WARN([libcurl not enabled: $message]) ;;
-       *) MSG_ERROR([libcurl $message
+       [libcurl_devel="library is too old (7.18+ required)"],
+       [libcurl_devel="library not found"])])
+
+  if test "$libcurl_devel" = ok; then
+    AC_DEFINE([HAVE_LIBCURL], 1, [Define if libcurl file access is enabled.])
+    libcurl=enabled
+  elif test "$enable_libcurl" = check; then
+    AC_MSG_WARN([libcurl not enabled: $libcurl_devel])
+  else
+    MSG_ERROR([libcurl $libcurl_devel
 
 Support for HTTPS and other SSL-based URLs requires routines from the libcurl
 library <http://curl.se/libcurl/>.  Building HTSlib with libcurl enabled
@@ -369,8 +374,8 @@ Debian or Ubuntu Linux) or libcurl-devel (on RPM-based Linux distributions
 or Cygwin) is installed.
 
 Either configure with --disable-libcurl or resolve this error to build HTSlib.])
-       ;;
-     esac])
+  fi
+
 dnl -lcurl is only needed for static linking if hfile_libcurl is not a plugin
   if test "$libcurl" = enabled ; then
     if test "$enable_plugins" != yes ; then


### PR DESCRIPTION
This addresses a _configure_ issue and configure option documentation omissions from _INSTALL_ uncovered by #1261:

* Unlike the checks for other libraries, the libcurl check validated only that the link library _libcurl.so/.dylib/etc_ is available, but did not validate that the headers are available. In the #1261 case, inconsistent LDFLAGS and CPPFLAGS settings meant that the link library was available to the linker but the headers were not available to the compiler, which should have been detected at configure time.

   (It's not recorded in the commit messages, but I think the other `AC_CHECK_HEADER`/`AC_CHECK_LIB` checks may have been written thus precisely so that such environment variable problems could be detected.)

* The default behaviour of `--enable-libcurl` was not documented in _INSTALL_, and it was not clear that
`--enable`/`--disable` and `--with`/`--without` options come in pairs.