### PR TITLE
[vcf] Do not download the index file by default, when reading the VCF header

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -1916,7 +1916,7 @@ bcf_hdr_t *vcf_hdr_read(htsFile *fp)
     if ( bcf_hdr_parse(h, txt.s) < 0 ) goto error;
 
     // check tabix index, are all contigs listed in the header? add the missing ones
-    idx = tbx_index_load3(fp->fn, NULL, HTS_IDX_SAVE_REMOTE|HTS_IDX_SILENT_FAIL);
+    idx = tbx_index_load3(fp->fn, NULL, HTS_IDX_SILENT_FAIL);
     if ( idx )
     {
         int i, n, need_sync = 0;


### PR DESCRIPTION
The method that reads the VCF header (`vcf_hdr_read`) checks for missing contings and, if it detects any, tries to add them to the header from the index. However, a side effect of this operation was the unnecessary downloading of a remote index file. With the current change, the index file is only streamed into the memory.

Fixes #380 