### PR TITLE
Prevent assert() in bcf_sr_set_regions

### DIFF
--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -302,6 +302,9 @@ int bcf_sr_set_samples(bcf_srs_t *readers, const char *samples, int is_file);
  *  file are currently not supported.
  *  Targets (but not regions) can be prefixed with "^" to request logical complement,
  *  for example "^X,Y,MT" indicates that sequences X, Y and MT should be skipped.
+ *
+ *  API note: bcf_sr_set_regions/bcf_sr_set_targets MUST be called before the
+ *  first call to bcf_sr_add_reader().
  */
 HTSLIB_EXPORT
 int bcf_sr_set_targets(bcf_srs_t *readers, const char *targets, int is_file, int alleles);

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -171,13 +171,11 @@ static int *init_filters(bcf_hdr_t *hdr, const char *filters, int *nfilters)
 
 int bcf_sr_set_regions(bcf_srs_t *readers, const char *regions, int is_file)
 {
-    if ( readers->nreaders )
+    if ( readers->nreaders || readers->regions )
     {
         hts_log_error("Must call bcf_sr_set_regions() before bcf_sr_add_reader()");
         return -1;
     }
-
-    assert( !readers->regions );
 
     readers->regions = bcf_sr_regions_init(regions,is_file,0,1,-2);
     if ( !readers->regions ) return -1;
@@ -185,9 +183,14 @@ int bcf_sr_set_regions(bcf_srs_t *readers, const char *regions, int is_file)
     readers->require_index = REQUIRE_IDX_;
     return 0;
 }
+
 int bcf_sr_set_targets(bcf_srs_t *readers, const char *targets, int is_file, int alleles)
 {
-    assert( !readers->targets );
+    if ( readers->nreaders || readers->targets )
+    {
+        hts_log_error("Must call bcf_sr_set_targets() before bcf_sr_add_reader()");
+        return -1;
+    }
     if ( targets[0]=='^' )
     {
         readers->targets_exclude = 1;

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -171,12 +171,14 @@ static int *init_filters(bcf_hdr_t *hdr, const char *filters, int *nfilters)
 
 int bcf_sr_set_regions(bcf_srs_t *readers, const char *regions, int is_file)
 {
-    assert( !readers->regions );
     if ( readers->nreaders )
     {
         hts_log_error("Must call bcf_sr_set_regions() before bcf_sr_add_reader()");
         return -1;
     }
+
+    assert( !readers->regions );
+
     readers->regions = bcf_sr_regions_init(regions,is_file,0,1,-2);
     if ( !readers->regions ) return -1;
     readers->explicit_regs = 1;


### PR DESCRIPTION
It seems `bcf_sr_set_regions` ought be called before `bcf_sr_add_reader`. However, if a user unaware of this calls `bcf_sr_set_regions` **after** `bcf_sr_add_reader`, they are met with a failing `assert()`. This is particularly odd, as `bcf_sr_set_regions` already contains a useful error message about exactly this usage error.

This patch reorders the check for incorrect usage and the assert(), so that if an API user stuffs up the order of the calls, they get the nice message that already exists and not an assert().

I'm not sure if the assert() is even needed here, and probably is best replaced with a nice `hts_log_error()` in any case. I think
`readers->regions != NULL` only when either `bcf_sr_add_reader` or `bcf_sr_set_regions` has already been called, but I'll leave this in the maintainer's hands.