### PR TITLE
Fix to make samtools cat work on CRAMs again.

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -3931,6 +3931,7 @@ int cram_codec_decoder2encoder(cram_fd *fd, cram_codec *c) {
         // unify this.
         cram_codec *t = malloc(sizeof(*t));
         if (!t) return -1;
+        t->vv     = c->vv;
         t->codec = E_HUFFMAN;
         t->free = cram_huffman_encode_free;
         t->store = cram_huffman_encode_store;
@@ -4017,6 +4018,7 @@ int cram_codec_decoder2encoder(cram_fd *fd, cram_codec *c) {
         // {len,val}_{encoding,dat} are undefined, but unused.
         // Leaving them unset here means we can test that assertion.
         *c = *t;
+        free(t);
         break;
     }
 

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -107,12 +107,14 @@ cram_block *cram_encode_compression_header(cram_fd *fd, cram_container *c,
         }
     }
 
-    if (h->preservation_map)
+    if (h->preservation_map) {
         kh_destroy(map, h->preservation_map);
+        h->preservation_map = NULL;
+    }
 
     /* Create in-memory preservation map */
     /* FIXME: should create this when we create the container */
-    if (h->num_records > 0) {
+    if (c->num_records > 0) {
         khint_t k;
         int r;
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -5368,6 +5368,8 @@ int cram_write_eof_block(cram_fd *fd) {
             cram_free_block(c.comp_hdr_block);
             return -1;
         }
+        if (ch.preservation_map)
+            kh_destroy(map, ch.preservation_map);
         cram_free_block(c.comp_hdr_block);
 
         // V2.1 bytes


### PR DESCRIPTION
Samtools cat utilises low level APIs to turn codecs from a read cram_fd to codecs sutiable for a write cram_fd.  This had a missing initialisation in the HUFFMAN code and a small memory leak, caused by the addition of the CRAM v4 code (but affecting CRAM v3).

Also while adding CRAM v4, the EOF block was changed from being a literal string of bytes into simply encoding an empty container and letting the code auto-generate the correct byte stream.  There were bugs in cram_encode_compression_header for empty blocks, which affected cram blocks that had gone through this read/write transcode process.  Specifically the compression header's num_record check is invalid as this is only populated for CRAM v1.0.  We check the container instead, which is always correct and permits us to find the empty EOF blocks.

Note this EOF writing change also affected more than samtools cat. All CRAM files being output contained a slightly larger EOF block, containing an unused preservation map.  It is debateable whether this is within the spec or not.  The spec states both the meaning of the EOF block (an empty container with a specific ref seq id and alignment start) as well as listing what this encodes to in hex.  The former worked, but the latter differed.  (Note this byte stream difference doesn't cause issues for htslib nor htsjdk as both check the meaning rather than a specific encoding.)

Fixes samtools/samtools#1420