### PR TITLE
Fix undefined behaviour in cram_xdelta_encode_char.

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1900,9 +1900,10 @@ int cram_xdelta_encode_int(cram_slice *slice, cram_codec *c,
 
 int cram_xdelta_encode_char(cram_slice *slice, cram_codec *c,
                            char *in, int in_size) {
-    char *dat = malloc(in_size*5), *cp = dat, *cp_end = dat + in_size*5;
+    char *dat = malloc(in_size*5);
     if (!dat)
         return -1;
+    char *cp = dat, *cp_end = dat + in_size*5;
 
     c->u.e_xdelta.last = 0; // reset for each new array
     switch(c->u.e_xdelta.word_size) {


### PR DESCRIPTION
Assumption: this is a gcc-11 warning, but I cannot be sure as I don't
have a local install.

    cram/cram_codecs.c:1916:19: error: 'cp_end' may be used uninitialized [-Werror=maybe-uninitialized]
     1916 |             cp += c->vv->varint_put32(cp, cp_end, zigzag16(c->u.e_xdelta.last));
          |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

cp_end is initialised, but due to the malloc potentially returning
NULL, the initialisation of cp_end will have undefined behaviour if
the malloc fails.  The code does then check for NULL malloc and exits,
but the compiler generated code appears to have at least one path
which doesn't initialise cp_end due to this undefined behaviour.
(Unknown if a reachable path, but it's unlikely.)