### PR TITLE
Use bcf_itr_destroy() with bcf_itr_querys() [minor]

### DIFF
--- a/tabix.c
+++ b/tabix.c
@@ -263,7 +263,7 @@ static int query_regions(args_t *args, tbx_conf_t *conf, char *fname, char **reg
                 if (ret < -1) {
                     error_errno("Reading \"%s\" failed", fname);
                 }
-                tbx_itr_destroy(itr);
+                bcf_itr_destroy(itr);
             }
             bcf_destroy(rec);
         }


### PR DESCRIPTION
Extremely minor clarification I noticed while [answering this question](https://bioinformatics.stackexchange.com/questions/15842/use-htslib-to-extract-specific-region-of-vcf-file).

Both `tbx_itr_destroy()` and `bcf_itr_destroy()` are currently just aliases for `hts_itr_destroy()`, so this doesn't matter much except insofar as this code is useful example code.