### PR TITLE
Silence a gcc 11.1 warning with kseq.

### DIFF
--- a/htslib/kseq.h
+++ b/htslib/kseq.h
@@ -207,6 +207,7 @@
 		if (seq->seq.l + 1 >= seq->seq.m) { /* seq->seq.s[seq->seq.l] below may be out of boundary */ \
 			seq->seq.m = seq->seq.l + 2; \
 			kroundup32(seq->seq.m); /* rounded to the next closest 2^k */ \
+			if (seq->seq.l + 1 >= seq->seq.m) return -3; /* error: adjusting m overflowed */ \
 			seq->seq.s = (char*)realloc(seq->seq.s, seq->seq.m); \
 		} \
 		seq->seq.s[seq->seq.l] = 0;	/* null terminated string */ \


### PR DESCRIPTION
The new uninitialised memory checking in gcc 11 is tripped up as it thinks there may be overflow cases in ks_expand meaning the resized buffer still isn't large enough.  We have already fixed this in kroundup.h, but it's not sufficient to silence it.

However adding an explicit check to spot if kroundup32 has overflowed is enough to silence it.

NB: this gcc 11.1 issue wasn't visible from within Htslib, but Samtools tickled it in samtools/dict.c.

Fixes #1283