### PR TITLE
Work around GCC 11.1 problem by removing `const` from `varint_putNN()` `endp` parameters

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1898,11 +1898,6 @@ int cram_xdelta_encode_int(cram_slice *slice, cram_codec *c,
     return -1;
 }
 
-#if __GNUC__ == 11 && __GNUC_MINOR__ == 1
-// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100417
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 int cram_xdelta_encode_char(cram_slice *slice, cram_codec *c,
                             char *in, int in_size) {
     char *dat = malloc(in_size*5);
@@ -1937,9 +1932,6 @@ int cram_xdelta_encode_char(cram_slice *slice, cram_codec *c,
     free(dat);
     return 0;
 }
-#if __GNUC__ == 11 && __GNUC_MINOR__ == 1
-#pragma GCC diagnostic pop
-#endif
 
 void cram_xdelta_encode_free(cram_codec *c) {
     if (!c) return;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -739,15 +739,15 @@ static int64_t safe_ltf8_get(char **cp, const char *endp, int *err) {
 }
 
 // Wrapper for now
-int safe_itf8_put(char *cp, const char *cp_end, int32_t val) {
+static int safe_itf8_put(char *cp, char *cp_end, int32_t val) {
     return itf8_put(cp, val);
 }
 
-int safe_ltf8_put(char *cp, const char *cp_end, int64_t val) {
+static int safe_ltf8_put(char *cp, char *cp_end, int64_t val) {
     return ltf8_put(cp, val);
 }
 
-int itf8_size(int64_t v) {
+static int itf8_size(int64_t v) {
     return ((!((v)&~0x7f))?1:(!((v)&~0x3fff))?2:(!((v)&~0x1fffff))?3:(!((v)&~0xfffffff))?4:5);
 }
 
@@ -796,20 +796,20 @@ static int64_t sint7_get_64(char **cp, const char *endp, int *err) {
     return val;
 }
 
-static int uint7_put_32(char *cp, const char *endp, int32_t val) {
-    return var_put_u32((uint8_t *)cp, (const uint8_t *)endp, val);
+static int uint7_put_32(char *cp, char *endp, int32_t val) {
+    return var_put_u32((uint8_t *)cp, (uint8_t *)endp, val);
 }
 
-static int sint7_put_32(char *cp, const char *endp, int32_t val) {
-    return var_put_s32((uint8_t *)cp, (const uint8_t *)endp, val);
+static int sint7_put_32(char *cp, char *endp, int32_t val) {
+    return var_put_s32((uint8_t *)cp, (uint8_t *)endp, val);
 }
 
-static int uint7_put_64(char *cp, const char *endp, int64_t val) {
-    return var_put_u64((uint8_t *)cp, (const uint8_t *)endp, val);
+static int uint7_put_64(char *cp, char *endp, int64_t val) {
+    return var_put_u64((uint8_t *)cp, (uint8_t *)endp, val);
 }
 
-static int sint7_put_64(char *cp, const char *endp, int64_t val) {
-    return var_put_s64((uint8_t *)cp, (const uint8_t *)endp, val);
+static int sint7_put_64(char *cp, char *endp, int64_t val) {
+    return var_put_s64((uint8_t *)cp, (uint8_t *)endp, val);
 }
 
 // Put direct to to cram_block

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -753,10 +753,10 @@ typedef struct varint_vec {
     int64_t (*varint_get64s)(char **cp, const char *endp, int *err);
 
     // Returns the number of bytes written, <= 0 on error.
-    int (*varint_put32) (char *cp, const char *endp, int32_t val_p);
-    int (*varint_put32s)(char *cp, const char *endp, int32_t val_p);
-    int (*varint_put64) (char *cp, const char *endp, int64_t val_p);
-    int (*varint_put64s)(char *cp, const char *endp, int64_t val_p);
+    int (*varint_put32) (char *cp, char *endp, int32_t val_p);
+    int (*varint_put32s)(char *cp, char *endp, int32_t val_p);
+    int (*varint_put64) (char *cp, char *endp, int64_t val_p);
+    int (*varint_put64s)(char *cp, char *endp, int64_t val_p);
 
     // Returns the number of bytes written, <= 0 on error.
     int (*varint_put32_blk) (cram_block *blk, int32_t val_p);


### PR DESCRIPTION
If anyone can face revisiting #1280 again… it turns out that removing the `const` from `const char *endp` in  the `varint_putNN()` functions is a less invasive change than I feared. In particular, no htscodecs update is immediately needed.

The underlying htscodecs `var_put_u32()` etc functions still take a const pointer for their `endp` parameters, but it's fine for callers to pass a non-const pointer to that as the types are compatible in that direction. So we can remove `const` here to avoid the spurious GCC 11.1 warning and leave the corresponding htscodecs change for later (if at all).

As `endp` points to the same array as `cp`, it might as well be `char *` as well, which avoids the spurious warning. As partially noted in _htscodecs/varint.h_, the ideal signatures for the getters and putters would be

```c
int64_t (*varint_get32)(const char **cp, const char *endp, int *err);
int (*varint_put32)(char *cp, char *endp, int32_t val_p);
/* etc */
```

If it was going to be done at all, adding `const` to the getters' `cp` arguments would have to occur after htscodecs had been updated correspondingly and requires rather larger changes in htslib's CRAM code. OTOH happily removing `const` from the putter callers can be done in advance of any corresponding htscodecs change.

While in the neighbourhood, make the "for now" wrappers `static`.