### PR TITLE
[index] Initialize the missing entries of the linear index in reverse order

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -2117,7 +2117,7 @@ static void update_loff(hts_idx_t *idx, int i, int free_lidx)
     int l;
     // the last entry is always valid
     for (l=lidx->n-2; l >= 0; l--) {
-	if (lidx->offset[l] == (uint64_t)-1)
+        if (lidx->offset[l] == (uint64_t)-1)
             lidx->offset[l] = lidx->offset[l+1];
     }
     if (bidx == 0) return;
@@ -2589,8 +2589,8 @@ static int idx_read_core(hts_idx_t *idx, BGZF *fp, int fmt)
             if (l->offset == NULL) return -2;
             if (bgzf_read(fp, l->offset, l->n << 3) != l->n << 3) return -1;
             if (is_be) for (j = 0; j < l->n; ++j) ed_swap_8p(&l->offset[j]);
-            for (j = 1; j < l->n; ++j) // fill missing values; may happen given older samtools and tabix
-                if (l->offset[j] == 0) l->offset[j] = l->offset[j-1];
+            for (j = l->n-1; j > 0; j--) // fill missing values; may happen given older samtools and tabix
+                if (l->offset[j-1] == 0) l->offset[j-1] = l->offset[j];
             update_loff(idx, i, 0);
         }
     }

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -1455,9 +1455,10 @@ static inline int hts_bin_level(int bin) {
     return l;
 }
 
-/// Compute the corresponding entry into the linear index of a given bin from
-/// a binning index
-/** @param bin    The bin number
+//! Compute the corresponding entry into the linear index of a given bin from
+//! a binning index
+/*!
+ *  @param bin    The bin number
  *  @param n_lvls The index depth (number of levels - 0 based)
  *  @return       The integer offset into the linear index
  *


### PR DESCRIPTION
For each contig, the linear index is an array of the smallest file offsets corresponding to alignments that cover a particular contig window, each 2<sup>min_shift</sup> bp wide. In case there are no alignments covering a particular genomic window, the linear index entries are filled from adjacent valid entries.
Whereas before, the empty linear index entries were filled with values of the nearest valid entry from the **left**, the current PR changes this procedure to use the nearest valid entry from the **right**, making the linear index values of empty windows slightly larger. This change has the potential to improve some reading operations by skipping over unnecessary data. However, in practice, most of HTSlib indexed reads use iterators, which rely on actual index chunks of existing alignments. So the linear index value is used as a starting point for searching valid chunks and not as an actual file offset. Since there are no valid chunks corresponding to the empty windows, there will be no change in performance for iterator reads.

The `dump_index` method has been renamed into `idx_dump` and a few new display capabilities have been added to it:

- showing the index level of a bin
- showing the genomic region covered by a bin

The `hts_idx_save_core` has been renamed into `idx_save_core` to reflect its static use and to match the reading equivalent `idx_read_core`.

The new `hts_bin_level` method has been added. It computes the index level of a bin.

Fixes #486 