### PR TITLE
[vcf] Improve method `bcf_remove_allele_set`

### DIFF
--- a/vcfutils.c
+++ b/vcfutils.c
@@ -258,6 +258,8 @@ int bcf_remove_allele_set(const bcf_hdr_t *header, bcf1_t *line, const struct kb
 
     // create map of indexes from old to new ALT numbering and modify ALT
     kstring_t str = {0,0,0};
+    if (!line->d.allele)
+        bcf_unpack(line, BCF_UN_STR);
     kputs(line->d.allele[0], &str);
 
     int nrm = 0, i,j;  // i: ori alleles, j: new alleles
@@ -507,8 +509,8 @@ int bcf_remove_allele_set(const bcf_hdr_t *header, bcf1_t *line, const struct kb
     }
 
     // Update GT fields, the allele indexes might have changed
-    for (i=1; i<line->n_allele; i++) if ( map[i]!=i ) break;
-    if ( i<line->n_allele )
+    for (i=1; i<nR_ori; i++) if ( map[i]!=i ) break;
+    if ( i<nR_ori )
     {
         mdat = mdat_bytes / 4;  // sizeof(int32_t)
         nret = bcf_get_genotypes(header,line,(void**)&dat,&mdat);

--- a/vcfutils.c
+++ b/vcfutils.c
@@ -532,7 +532,9 @@ int bcf_remove_allele_set(const bcf_hdr_t *header, bcf1_t *line, const struct kb
                             bcf_seqname_safe(header,line), line->pos+1, al, nR_ori, map[al]);
                         goto err;
                     }
-                    ptr[j] = (map[al]+1)<<1 | (ptr[j]&1);
+                    // if an allele other than the reference is mapped to 0, it has been removed,
+                    // so translate it to 'missing', while preserving the phasing bit
+                    ptr[j] = ((al>0 && !map[al]) ? bcf_gt_missing : (map[al]+1)<<1) | (ptr[j]&1);
                 }
                 ptr += nret;
             }


### PR DESCRIPTION
1. Fixes a bug, which caused the iteration over the alleles to stop too early, due to a hidden updated of allele number.
2. Marks removed alleles as proper 'missing'.
3. Does the lazy unpack automatically, in case the user forgot to do it beforehand.

Fixes #1259 