### PR TITLE
Fix crash in knet_open() etc stubs and minor memory leak

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1728,8 +1728,10 @@ cram_codec *cram_xdelta_decode_init(cram_block_compression_hdr *hdr,
     else if (option == E_BYTE_ARRAY_BLOCK) {
         option = E_BYTE_ARRAY;
         c->decode = cram_xdelta_decode_block;
-    } else
+    } else {
+        free(c);
         return NULL;
+    }
     c->free = cram_xdelta_decode_free;
     c->size = cram_xdelta_decode_size;
     c->get_block = cram_xdelta_get_block;

--- a/hfile.c
+++ b/hfile.c
@@ -1359,7 +1359,7 @@ knetFile *knet_open(const char *fn, const char *mode) {
     if (!fp) return NULL;
     if (!(fp->hf = hopen(fn, mode))) {
         free(fp);
-        fp = NULL;
+        return NULL;
     }
 
     // FD backend is the only one implementing knet_fileno
@@ -1376,7 +1376,7 @@ knetFile *knet_dopen(int fd, const char *mode) {
     if (!fp) return NULL;
     if (!(fp->hf = hdopen(fd, mode))) {
         free(fp);
-        fp = NULL;
+        return NULL;
     }
     fp->fd = fd;
     return fp;


### PR DESCRIPTION
Fixes for a couple of issues detected via cppcheck:

* Knet Must Die, but until it does the new `knet_open()` and `knet_dopen()` stubs probably shouldn't crash every time the underlying open fails;

* Fix `cram_xdelta_decode_init()` error handling memory leak. I assume passing in `option` as `E_SINT` or `E_SLONG` is not supposed to happen…