### PR TITLE
Improve compression metrics for unsorted files.

### DIFF
--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -289,6 +289,7 @@ struct cram_metrics {
 
     // aggregate sizes during trials
     int sz[CRAM_MAX_METHOD];
+    int input_avg_sz, input_avg_delta;
 
     // resultant method from trials
     int method, revised_method;


### PR DESCRIPTION
Unsorted data is recognised by the rapid change in reference ID giving
rise to many tiny slices.  A flurry of this switches to unsorted mode
where we use the RI data series to store sequences from multiple
references in the same slice.

Unfortunately this also skews the cram data series metrics, which look
at average compression ratios for a variety of codecs, as the first
few slices may be tiny and the optimal codec isn't chosen
(initially).  Eg picking rANS0 for qualities as the buffers are tiny,
while rANS1 would be better.

Io_lib/scramble has a solution which resets the compression metrics on
detection of unsorted data.  This works, but here I try a more general
and hopefully stable approach which is to look for unusually very
large fluctuations in data series sizes.