### PR TITLE
[index] New methods and a linear index fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,9 @@ Noteworthy changes in release a.b
 Features and Updates
 --------------------
 
+* New method `hts_idx_nseq` returns the number of contigs covered by reads
+  from an index structure.
+
 * In case a PG header line has multiple ID tags supplied by other applications,
   the header API now selects the first one encountered as the identifying tag
   and issues a warning when detecting subsequent ID tags.

--- a/hts.c
+++ b/hts.c
@@ -2577,7 +2577,7 @@ static int idx_read_core(hts_idx_t *idx, BGZF *fp, int fmt)
             if (is_be) swap_bins(p);
         }
         if (fmt != HTS_FMT_CSI) { // load linear index
-            int j;
+            int j, k;
             uint32_t x;
             if (bgzf_read(fp, &x, 4) != 4) return -1;
             if (is_be) ed_swap_4p(&x);
@@ -2589,7 +2589,8 @@ static int idx_read_core(hts_idx_t *idx, BGZF *fp, int fmt)
             if (l->offset == NULL) return -2;
             if (bgzf_read(fp, l->offset, l->n << 3) != l->n << 3) return -1;
             if (is_be) for (j = 0; j < l->n; ++j) ed_swap_8p(&l->offset[j]);
-            for (j = l->n-1; j > 0; j--) // fill missing values; may happen given older samtools and tabix
+            for (k = j = 0; j < l->n && l->offset[j] == 0; k = ++j); // stop at the first non-zero entry
+            for (j = l->n-1; j > k; j--) // fill missing values; may happen given older samtools and tabix
                 if (l->offset[j-1] == 0) l->offset[j-1] = l->offset[j];
             update_loff(idx, i, 0);
         }

--- a/hts.c
+++ b/hts.c
@@ -2723,6 +2723,18 @@ const char **hts_idx_seqnames(const hts_idx_t *idx, int *n, hts_id2name_f getid,
     return names;
 }
 
+int hts_idx_nseq(const hts_idx_t *idx) {
+    int tid = 0, i;
+    for (i=0; i < idx->n; i++)
+    {
+        bidx_t *bidx = idx->bidx[i];
+        if ( !bidx ) continue;
+        tid++;
+    }
+
+    return tid;
+}
+
 int hts_idx_get_stat(const hts_idx_t* idx, int tid, uint64_t* mapped, uint64_t* unmapped)
 {
     if ( idx->fmt == HTS_FMT_CRAI ) {
@@ -4372,11 +4384,11 @@ static hts_idx_t *idx_find_and_load(const char *fn, int fmt, int flags)
 
     if (hts_idx_check_local(fn, fmt, &fnidx) == 0 && hisremote(fn)) {
         if (flags & HTS_IDX_SAVE_REMOTE) {
-            fnidx = hts_idx_getfn(fn, ".csi");
+            fnidx = idx_filename(fn, ".csi", HTS_IDX_SAVE_REMOTE);
             if (!fnidx) {
                 switch (fmt) {
-                case HTS_FMT_BAI: fnidx = hts_idx_getfn(fn, ".bai"); break;
-                case HTS_FMT_TBI: fnidx = hts_idx_getfn(fn, ".tbi"); break;
+                case HTS_FMT_BAI: fnidx = idx_filename(fn, ".bai", HTS_IDX_SAVE_REMOTE); break;
+                case HTS_FMT_TBI: fnidx = idx_filename(fn, ".tbi", HTS_IDX_SAVE_REMOTE); break;
                 default: break;
                 }
             }

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -1252,6 +1252,13 @@ int hts_itr_next(BGZF *fp, hts_itr_t *iter, void *r, void *data) HTS_RESULT_USED
 HTSLIB_EXPORT
 const char **hts_idx_seqnames(const hts_idx_t *idx, int *n, hts_id2name_f getid, void *hdr); // free only the array, not the values
 
+/// Return the number targets covered by reads from an index
+/** @param      idx    Index
+    @return The number of targets
+ */
+HTSLIB_EXPORT
+int hts_idx_nseq(const hts_idx_t *idx);
+
 /**********************************
  * Iterator with multiple regions *
  **********************************/


### PR DESCRIPTION
Adds new method `hts_idx_nseq`, which returns the number of covered contigs from an index structure.
~~Exports methods `hts_idx_getfn` and `hts_idx_locatefn`, which were previously internal.~~
Fixes a bug introduced by 18305510d010aab54706fe4abec4d90cd6462ecc. Older indices might encode missing entries with a 0, but the entries at the beginning of the linear index could contain 0 as a valid offset and, as such, are no longer considered missing. Thus, the linear index update from right to left stops at the first non-0 entry.