### PR TITLE
On MinGW-i686, testing for recv() requires the system header

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,16 @@ AC_SEARCH_LIBS([recv], [socket ws2_32], [
 if test "$ac_cv_search_recv" != "none required"
 then
   static_LIBS="$static_LIBS $ac_cv_search_recv"
-fi], [MSG_ERROR([unable to find the recv() function])])
+fi],
+  dnl on MinGW-i686, checking recv() linking requires an annotated declaration
+  [AC_MSG_CHECKING([for library containing recv using declaration])
+   LIBS="-lws2_32 $LIBS"
+   AC_LINK_IFELSE(
+     [AC_LANG_PROGRAM([[#include <winsock2.h>]], [[recv(0, 0, 0, 0);]])],
+     [AC_MSG_RESULT([-lws2_32])
+      static_LIBS="$static_LIBS -lws2_32"],
+     [AC_MSG_RESULT([no])
+      MSG_ERROR([unable to find the recv() function])])])
 
 if test "$enable_bz2" != no; then
   bz2_devel=ok


### PR DESCRIPTION
MinGW's 32-bit version of `<winsock2.h>` declares `recv()` as `__stdcall__`. When `AC_SEARCH_LIBS` does a trial link without declaring `recv()` at all, linking fails due to the mismatch of calling conventions — as seen in msys2/MINGW-packages#8207.

To fix this the non-intrusive way: Before reporting the error with `MSG_ERROR`, try again to link against ws2_32 this time including the system header to get the annotated declaration. This produces the right `$LIBS` on MinGW-i686, and leaves the `MSG_ERROR` failure unchanged on other platforms.

I considered adding an `HTS_SEARCH_LIBS` function that would be like `AC_SEARCH_LIBS` but take `AC_LANG_PROGRAM` output instead of just a function name, but that would be a more intrusive change.