### PR TITLE
Make version.sh work from a separate build directory

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -27,10 +27,11 @@
 VERSION=1.12
 
 # If we have a git clone, then check against the current tag
-if [ -e .git ]
+srcdir=${0%/version.sh}
+if [ -e $srcdir/.git ]
 then
     # If we ever get to 10.x this will need to be more liberal
-    VERSION=`git describe --match '[0-9].[0-9]*' --dirty`
+    VERSION=`cd $srcdir && git describe --match '[0-9].[0-9]*' --dirty`
 fi
 
 # Numeric version is for use in .dylib or .so libraries


### PR DESCRIPTION
Fix a bug in the separate build directory handling: `version.sh` reported the master release version rather than a git commit description when run from a separate build directory.