### PR TITLE
Add "endpos" filter expression

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -1166,6 +1166,14 @@ static int bam_sym_lookup(void *data, char *str, char **end,
         }
         break;
 
+    case 'e':
+        if (memcmp(str, "endpos", 6) == 0) {
+            *end = str+6;
+            res->d = bam_endpos(b);
+            return 0;
+        }
+        break;
+
     case 'f':
         if (memcmp(str, "flag", 4) == 0) {
             str = *end = str+4;


### PR DESCRIPTION
For your amusement at this time, here is a PR that implements `endpos` as a filter expression, in response to <https://twitter.com/gringene_bio/status/1412686733225857024>.

See also the companion documentation PR samtools/samtools#1464.

"endpos" is the (1-based inclusive) position of the rightmost mapped base of the read, as measured using the CIGAR string. (`bam_endpos()` returns 0-based exclusive, which is the same thing.) For unmapped reads, it is the same as "pos".