### PR TITLE
Speed up BAM, CRAM 3.1 and 4.0 testing in test/test.pl's test_view.

### DIFF
--- a/test/test.pl
+++ b/test/test.pl
@@ -520,6 +520,32 @@ sub test_view
     my ($opts, $nthreads) = @_;
     my $tv_args = $nthreads ? "-\@$nthreads" : "";
 
+    # Files appropriate for CRAM V3.1 and V4.0 testing
+    my %cram31 = ("auxf#values.sam"   => 1,
+                  "c1#pad3.sam"       => 1,
+                  "ce#5.sam"          => 1,
+                  "ce#1000.sam",      => 1,
+                  "ce#large_seq.sam", => 1,
+                  "ce#supp.sam",      => 1,
+                  "xx#MD.sam",        => 1,
+                  "xx#blank.sam",     => 1,
+                  "xx#large_aux.sam", => 1,
+                  "xx#pair.sam",      => 1,
+                  "xx#tlen.sam"       => 1);
+
+    # Files appropriate for CRAM multi-ref containers
+    my %cram_ms = ("ce#1000.sam"      => 1,
+                   "ce#5.sam"         => 1,
+                   "ce#5b.sam"        => 1,
+                   "ce#unmap.sam"     => 1,
+                   "ce#unmap1.sam"    => 1,
+                   "ce#unmap2.sam"    => 1,
+                   "xx#blank.sam"     => 1,
+                   "xx#minimal.sam"   => 1,
+                   "xx#tlen.sam"      => 1,
+                   "xx#tlen2.sam"     => 1,
+                   "xx#triplet.sam"   => 1);
+
     foreach my $sam (glob("*#*.sam")) {
         my ($base, $ref) = ($sam =~ /((.*)#.*)\.sam/);
         $ref .= ".fa";
@@ -536,9 +562,11 @@ sub test_view
         $test_view_failures = 0;
 
         # SAM -> BAM -> SAM
-        testv $opts, "./test_view $tv_args -S -b $sam > $bam";
-        testv $opts, "./test_view $tv_args $bam > $bam.sam_";
-        testv $opts, "./compare_sam.pl $sam $bam.sam_";
+        if ($sam eq "ce#1000.sam") {
+            testv $opts, "./test_view $tv_args -S -b $sam > $bam";
+            testv $opts, "./test_view $tv_args $bam > $bam.sam_";
+            testv $opts, "./compare_sam.pl $sam $bam.sam_";
+        }
 
         # SAM -> BAMu -> SAM
         testv $opts, "./test_view $tv_args -S -l0 -b $sam > $bam";
@@ -550,93 +578,52 @@ sub test_view
         testv $opts, "./test_view $tv_args -D $cram > $cram.sam_";
         testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
 
-        # BAM -> CRAM2 -> BAM -> SAM
-        $cram = "$bam.cram";
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=2.1 $bam > $cram";
-        testv $opts, "./test_view $tv_args -b -D $cram > $cram.bam";
-        testv $opts, "./test_view $tv_args $cram.bam > $cram.bam.sam_";
-        testv $opts, "./compare_sam.pl $md $sam $cram.bam.sam_";
-
         # SAM -> CRAM3u -> SAM
-        $cram = "$base.tmp.cram";
-        testv $opts, "./test_view $tv_args -t $ref -S -l0 -C -o VERSION=3.0 $sam > $cram";
-        testv $opts, "./test_view $tv_args -D $cram > $cram.sam_";
-        testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
+        if ($sam eq "ce#1000.sam") {
+            $cram = "$base.tmp.cram";
+            testv $opts, "./test_view $tv_args -t $ref -S -l0 -C -o VERSION=3.0 $sam > $cram";
+            testv $opts, "./test_view $tv_args -D $cram > $cram.sam_";
+            testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
+        }
 
-        # BAM -> CRAM3 -> BAM -> SAM
+        # BAM -> CRAM3 -> SAM
         $cram = "$bam.cram";
         testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.0 $bam > $cram";
-        testv $opts, "./test_view $tv_args -b -D $cram > $cram.bam";
-        testv $opts, "./test_view $tv_args $cram.bam > $cram.bam.sam_";
+        testv $opts, "./test_view $tv_args $cram > $cram.bam.sam_";
         testv $opts, "./compare_sam.pl $md $sam $cram.bam.sam_";
-
-        # CRAM3 -> CRAM2
-        $cram = "$base.tmp.cram";
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=2.1 $cram > $cram.cram";
-
-        # CRAM2 -> CRAM3
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.0 $cram.cram > $cram";
 
         # CRAM3 -> CRAM3 + multi-slice
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.0 -o seqs_per_slice=7 -o slices_per_container=5 $cram.cram > $cram";
-        testv $opts, "./test_view $tv_args $cram > $cram.sam_";
-        testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
-
-        ## Experimental CRAM 3.1 support.
-        # SAM -> CRAM31u -> SAM
-        foreach my $profile (qw/fast normal small archive/) {
-            $cram = "$base.tmp.cram";
-            testv $opts, "./test_view $tv_args -t $ref -S -l7 -C -o VERSION=3.1 -o $profile $sam > $cram";
-            testv $opts, "./test_view $tv_args -D $cram > $cram.sam_";
+        if (exists($cram_ms{$sam}) && $nthreads > 0) {
+            testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.0 -o seqs_per_slice=7 -o slices_per_container=5 $cram > $cram.ms";
+            testv $opts, "./test_view $tv_args $cram.ms > $cram.sam_";
             testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
         }
 
-        # BAM -> CRAM31 -> BAM -> SAM
-        $cram = "$bam.cram";
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.1 $bam > $cram";
-        testv $opts, "./test_view $tv_args -b -D $cram > $cram.bam";
-        testv $opts, "./test_view $tv_args $cram.bam > $cram.bam.sam_";
-        testv $opts, "./compare_sam.pl $md $sam $cram.bam.sam_";
+        if (exists($cram31{$sam}) && $nthreads > 0) {
+            ## Experimental CRAM 3.1 support.
+            # SAM -> CRAM31 -> SAM
+            my @p = $sam eq "ce#1000.sam"
+                ? (qw/fast normal small archive/)
+                : (qw/archive/);
+            foreach my $profile (@p) {
+                $cram = "$base.tmp.cram";
+                testv $opts, "./test_view $tv_args -t $ref -S -l7 -C -o VERSION=3.1 -o $profile $sam > $cram";
+                testv $opts, "./test_view $tv_args -D $cram > $cram.sam_";
+                testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
+            }
 
-        # CRAM31 -> CRAM30
-        $cram = "$base.tmp.cram";
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.0 $cram > $cram.cram";
-
-        # CRAM30 -> CRAM31
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.1 $cram.cram > $cram";
-
-        # CRAM31 -> CRAM31 + multi-slice
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.1 -o seqs_per_slice=7 -o slices_per_container=5 $cram.cram > $cram";
-        testv $opts, "./test_view $tv_args $cram > $cram.sam_";
-        testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
-
-        ## Experimental CRAM 4.0 support.
-        # SAM -> CRAM40u -> SAM
-        foreach my $profile (qw/fast normal small archive/) {
-            $cram = "$base.tmp.cram";
-            testv $opts, "./test_view $tv_args -t $ref -S -l7 -C -o VERSION=4.0 -o $profile $sam > $cram";
-            testv $opts, "./test_view $tv_args -D $cram > $cram.sam_";
-            testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
+            ## Experimental CRAM 4.0 support.
+            # SAM -> CRAM40 -> SAM
+            my @p = $sam eq "ce#large_seq.sam" || $sam eq "xx#large_aux.sam"
+                ? (qw/fast normal small archive/)
+                : (qw/archive/);
+            foreach my $profile (@p) {
+                $cram = "$base.tmp.cram";
+                testv $opts, "./test_view $tv_args -t $ref -S -l7 -C -o VERSION=4.0 -o $profile $sam > $cram";
+                testv $opts, "./test_view $tv_args -D $cram > $cram.sam_";
+                testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
+            }
         }
-
-        # BAM -> CRAM40 -> BAM -> SAM
-        $cram = "$bam.cram";
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=4.0 $bam > $cram";
-        testv $opts, "./test_view $tv_args -b -D $cram > $cram.bam";
-        testv $opts, "./test_view $tv_args $cram.bam > $cram.bam.sam_";
-        testv $opts, "./compare_sam.pl $md $sam $cram.bam.sam_";
-
-        # CRAM40 -> CRAM30
-        $cram = "$base.tmp.cram";
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=3.0 $cram > $cram.cram";
-
-        # CRAM30 -> CRAM40
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=4.0 $cram.cram > $cram";
-
-        # CRAM40 -> CRAM40 + multi-slice
-        testv $opts, "./test_view $tv_args -t $ref -C -o VERSION=4.0 -o seqs_per_slice=7 -o slices_per_container=5 $cram.cram > $cram";
-        testv $opts, "./test_view $tv_args $cram > $cram.sam_";
-        testv $opts, "./compare_sam.pl $md $sam $cram.sam_";
 
         # Java pre-made CRAM -> SAM
         my $jcram = "${base}_java.cram";


### PR DESCRIPTION
Many of the SAM test files cover corner cases that don't change with 3.1 or 4.0, so we don't need to rerun every test in every format variation.  Additionally we don't need to use compression for every test using BAM.

These have been tested using gcov to validate the total code coverage doesn't change beyond about 5 lines of code.

- Only run 3.1/4.0 tests on a subset of SAM files.

- Only test 3.1/4.0 when running with threads. (Second call to test_view).  TODO: Likely this could be applied to 3.0 tests too to
  limit which files are tested in a threaded environment.

- Drop some of the 2.1 tests.  If we can go from SAM -> 2.1 -> SAM then it's good enough to validate encode and decode, with no need for 2.1 to 3 interchange checks.

- Drop some of the 3.0/3.1/4.0 interchange tests.  As with 2.1, we only need to know we can go to/from a common SAM format to test the code paths.

- Don't test compressed BAM on all files.  1 is enough, and then uncompressed for the rest (lvl 1).

- Don't test uncompressed CRAM on all files.  Just do it for 1.  We do want compressed mostly though as CRAM has a lot of codecs to explore.

- No Point in BAM -> CRAM -> BAM -> SAM when BAM -> CRAM -> SAM is sufficient.

- Drop the multi-ref CRAM testing for v3.1 and v4.0 as it's the same code path tested in v3.0 anyway.  This does change coverage marginally, but it's trivial (3 lines reallocing MD in cram_decode.c).

- Only do multi-ref CRAM testing on CRAM files with > 1 ref and when threaded. (Albeit with a minor 2 line testing difference to cram_io.c.)

- Reduce the number of CRAM profiles tested.  Do full 4 profiles on one file per v3.1 and v4.0.  Otherwise a single profile.

The inpact of this is time spent in the test_view subroute drops from

    real    2m3.525s
    user    1m20.362s
    sys     0m26.804s

to

    real    0m21.618s
    user    0m12.925s
    sys     0m4.148s

This single function dominated all testing (which on the same system took 2m37s for the entire test suite), so the impact on overall time is considerable.