### PR TITLE
Pkg config fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ config.h:
 # on htslib.pc.in listed, as if that file is newer the usual way to regenerate
 # this target is via configure or config.status rather than this rule.
 htslib.pc.tmp:
-	sed -e '/^static_libs=/s/@static_LIBS@/$(htslib_default_libs)/;s#@[^-][^@]*@##g' $(srcprefix)htslib.pc.in > $@
+	sed -e '/^static_libs=/s/@static_LIBS@/$(htslib_default_libs)/;s/@private_LIBS@/$(htslib_default_libs)/;s#@[^-][^@]*@##g' $(srcprefix)htslib.pc.in > $@
 
 # Create a makefile fragment listing the libraries and LDFLAGS needed for
 # static linking.  This can be included by projects that want to build

--- a/configure.ac
+++ b/configure.ac
@@ -388,6 +388,7 @@ dnl -lcurl is only needed for static linking if hfile_libcurl is not a plugin
   if test "$libcurl" = enabled ; then
     if test "$enable_plugins" != yes ; then
       static_LIBS="$static_LIBS -lcurl"
+      private_LIBS="$private_LIBS -lcurl"
     fi
   fi
 fi

--- a/htslib.pc.in
+++ b/htslib.pc.in
@@ -11,5 +11,5 @@ Description: C library for high-throughput sequencing data formats
 Version: @-PACKAGE_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lhts
-Libs.private: -L${libdir} @private_LIBS@ -lhts -lm -lpthread
+Libs.private: -L${libdir} @private_LIBS@ -lm -lpthread
 Requires.private: zlib @pc_requires@


### PR DESCRIPTION
This has two comits - please see the commit messages for the gory details.

The first commit is a trivial fix to make `pkg-config --static --libs` work, but only with autoconf builds.  It adds `-lcurl` and removes a duplicate `-lhts` which trips up libtool.

The second commit takes a different direction and completely removes the `private_LIBS` concept added in 57c71055.  (I strongly suspect that commit never actually worked with static libs anyway.)  This fixes non-autoconf builds too, as well as considerably  simplifying the process.  It does however mean we get some duplication in the library list, but it appears harmless (as far as the test systems are concerned).

We need to decide whether we wish to continue supporting non-autoconf setups, and if so whether we care about pkg-config in such environments.  If not then maybe the first commit alone is sufficient and ditch the second.  Otherwise I'd suggest squashing both together unless we can find some overwhelming reason why we need to keep the concept of private_LIBS.