### PR TITLE
Update NEWS to add CVE number for 1.11's VCF parser fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -522,7 +522,7 @@ Bug fixes
 
 * Fixed potential integer overflows in the VCF parser and ensured that
   the total length of FORMAT fields cannot go over 2Gbytes. [fuzz] (#1044,
-  #1104)
+  #1104; latter is CVE-2020-36403 affecting HTSlib versions 1.10 to 1.10.2)
 
 * Download index files atomically in idx_test_and_fetch().  This prevents
   corruption when running parallel jobs on S3 files.  Thanks to John Marshall.


### PR DESCRIPTION
After a recent decloaking in google/oss-fuzz-vulns@8020f97eb86f46f4ca213d2bfcffcaa6491bbd38, it seems [CVE-2020-36403](https://nvd.nist.gov/vuln/detail/CVE-2020-36403) was recently allocated to represent the issue fixed in 1.11 by PR #1104. (That's the only one from that batch of oss-fuzz items that has acquired a CVE number.)

This PR continues the practice of mentioning non-spurious HTSlib CVEs in the _NEWS_ file :smile: