### PR TITLE
Fix cram_dependent_data_series when FN is used.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -668,6 +668,13 @@ int cram_dependent_data_series(cram_fd *fd,
             s->data_series |= CRAM_CF | CRAM_NF;
         if (s->data_series & (CRAM_BA | CRAM_QS | CRAM_BB | CRAM_QQ))
             s->data_series |= CRAM_BF | CRAM_CF | CRAM_RL;
+        if (s->data_series & CRAM_FN) {
+            // The CRAM_FN loop checks for reference length boundaries,
+            // which needs a working seq_pos.  Some fields are fixed size
+            // irrespective of if we decode (BS), but others need to know
+            // the size of the string fetched back (SC, IN, BB).
+            s->data_series |= CRAM_SC | CRAM_IN | CRAM_BB;
+        }
 
         orig_ds = s->data_series;
 


### PR DESCRIPTION
If we get into the primary loop of cram_decode_seq, iterating over feature (count FN) then we have unguarded code that always checks for sequence overlapping the reference.  To do this, seq_pos must be set. Some data series we know how seq_pos is adjusted irrespective of whether we decode, eg BS is always +1, but others are strings and the only way we know how to update seq_pos is to decode them.

Hence added FN as having a dependency on SC, IN and BB.

Fixes samtools/samtools#1475

It's more questionable though in that bug report as to why FLAGS (BF data series) ever propogated to needing FN (cigar feature number).  It's due to the `CRAM_CIGAR` check, but I'm unsure why it's there at present.  It's obviously a bit overly cautious in this case.  That said, it's simply a missing optimisation rather than an error.

Edit: it's also harmless in all modern CRAMs.  The cigar check means whenever we ask for BF we get RL added in for free, which is maybe wasted effort, but normally nothing for Illumina and one minor int data series for long read data.  The only reason it expands so much on this data file is RL is stored in the CORE block, along with half a dozen other data series.  This causes a dependency explosion, but really it's the file that is the most questionable here (it's likely old).