### PR TITLE
README.md: Update for tabix. [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ HTSlib implements a generalized BAM index, with file extension `.csi`
 (coordinate-sorted index). The HTSlib file reader first looks for the new index
 and then for the old if the new index is absent.
 
-This project also includes the popular tabix indexer, which indexes both `.tbi`
+This project also includes the popular tabix indexer, which creates both `.tbi`
 and `.csi` formats, and the bgzip compression utility.
 
 [1]: http://samtools.github.io/hts-specs/


### PR DESCRIPTION
There was a suggestion to update the document about the tabix on the htslib RPM package on Fedora project.
https://src.fedoraproject.org/rpms/htslib/pull-request/4

The tabix creates .tbi/.csi by indexing other file formats.

Note `[skip ci]` is a mark to skip Cirrus CI used in this repo. You can see <https://cirrus-ci.org/guide/writing-tasks/>.