### PR TITLE
Make bam_tag2cigar's CG tag handling more lenient.

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -654,7 +654,8 @@ static int bam_tag2cigar(bam1_t *b, int recal_bin, int give_warning) // return 0
         errno = saved_errno; // restore errno on expected no-CG-tag case
         return 0;
     }
-    if (CG[0] != 'B' || CG[1] != 'I') return 0; // not of type B,I
+    if (CG[0] != 'B' || !(CG[1] == 'I' || CG[1] == 'i'))
+        return 0; // not of type B,I
     CG_len = le_to_u32(CG + 2);
     if (CG_len < c->n_cigar || CG_len >= 1U<<29) return 0; // don't move if the real CIGAR length is shorter than the fake cigar length
 


### PR DESCRIPTION
The SAM specification explicitly states the type for this tag is
CG:B:I.  However Htsjdk (sometimes or always?) writes these tags as
CG:B:i.  Htslib then silently ignores the tag, assuming it's some
unofficial (and incorrect) abuse of an uppercase tag for some local
purpose.

Given that there is data published in the wild using the incorrect
data type, it would be less problematic for us to simply handle the
incorrect value sign than the minimal risk of misinterpretting
someone's private tag data as CIGAR. (Plus they'd bring such woe onto
themselves by using the official name-space.)

Fixes samtools/samtools#1477

See also https://github.com/samtools/htsjdk/issues/1560