### PR TITLE
Catch untracked files (and make version.sh work on shallow checkouts)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,7 +48,7 @@ test_template: &TEST
   test_script: |
     make test-shlib-exports
     make test
-
+    if test "x$DO_UNTRACKED_FILE_CHECK" = "xyes"; then make check-untracked ; fi
 
 #--------------------------------------------------
 # Task: linux builds.
@@ -68,6 +68,7 @@ gcc_task:
   matrix:
     - environment:
        DO_MAINTAINER_CHECKS: yes
+       DO_UNTRACKED_FILE_CHECK: yes
        USE_CONFIG: no
     - environment:
        USE_CONFIG: yes
@@ -96,6 +97,7 @@ ubuntu_task:
   matrix:
     - environment:
        USE_CONFIG: yes
+       DO_UNTRACKED_FILE_CHECK: yes
     - environment:
        USE_CONFIG: yes
        CFLAGS: -g -Wall -O3 -fsanitize=address

--- a/Makefile
+++ b/Makefile
@@ -473,6 +473,13 @@ maintainer-check:
 	test/maintainer/check_copyright.pl .
 	test/maintainer/check_spaces.pl .
 
+# Look for untracked files in the git repository.
+check-untracked:
+	@if test -e .git && git status --porcelain | grep '^\?'; then \
+	    echo 'Untracked files detected (see above). Please either clean up, add to .gitignore, or for test output files consider naming them to match *.tmp or *.tmp.*' ; \
+	    false ; \
+	fi
+
 # Create a shorthand. We use $(SRC) or $(srcprefix) rather than $(srcdir)/
 # for brevity in test and install rules, and so that build logs do not have
 # ./ sprinkled throughout.
@@ -801,7 +808,7 @@ distdir:
 force:
 
 
-.PHONY: all check clean distclean distdir force
+.PHONY: all check check-untracked clean distclean distdir force
 .PHONY: install install-pkgconfig installdirs lib-shared lib-static
 .PHONY: maintainer-check maintainer-clean mostlyclean plugins
 .PHONY: print-config print-version show-version tags

--- a/version.sh
+++ b/version.sh
@@ -31,7 +31,11 @@ srcdir=${0%/version.sh}
 if [ -e $srcdir/.git ]
 then
     # If we ever get to 10.x this will need to be more liberal
-    VERSION=`cd $srcdir && git describe --match '[0-9].[0-9]*' --dirty`
+    v=`cd $srcdir && git describe --always --match '[0-9].[0-9]*' --dirty`
+    case $v in
+        [0-9]*.[0-9]*) VERSION="$v" ;;
+        [0-9a-f][0-9a-f]*) VERSION="$VERSION-1-g$v" ;;
+    esac
 fi
 
 # Numeric version is for use in .dylib or .so libraries


### PR DESCRIPTION
This PR contains two commits.  The first fixes `version.sh` so that it works on `--depth=1` clones of the repository.  This both gets rid of the annoying "No names found, cannot describe anything." messages that were printed because `git describe` couldn't find a tag; and it also makes the `version.sh` report a correct-ish version string on such clones.

The second commit adds CI test support to catch any untracked files that make be present after build and test.  Finding such files usually means they need to be added to `.gitignore`.
