### PR TITLE
Move the "start<1" error check in cram_get_ref to before thread locking.

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3363,7 +3363,7 @@ char *cram_get_ref(cram_fd *fd, int id, int start, int end) {
     char *seq;
     int ostart = start;
 
-    if (id == -1)
+    if (id == -1 || start < 1)
         return NULL;
 
     /* FIXME: axiomatic query of r->seq being true?
@@ -3439,8 +3439,6 @@ char *cram_get_ref(cram_fd *fd, int id, int start, int end) {
         end = r->length;
     if (end >= r->length)
         end  = r->length;
-    if (start < 1)
-        return NULL;
 
     if (end - start >= 0.5*r->length || fd->shared_ref) {
         start = 1;


### PR DESCRIPTION
This fixes #1329, which was discovered by code scanning and reported by Github @ryancaicse.

I do not believe it is likely to be triggered, but the value of this file can sometimes come from a CRAM file so it is possible malformed data could lead to a threading deadlock. (Untested)