### PR TITLE
S3 V4 signature to handle no credentials.

### DIFF
--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -1058,6 +1058,10 @@ static int v4_auth_header_callback(void *ctx, char ***hdrs) {
         return -1;
     }
 
+    if (!ad->id.l || !ad->secret.l) {
+        return copy_auth_headers(ad, hdrs);
+    }
+
     hash_string("", 0, content_hash); // empty hash
 
     ad->canonical_query_string.l = 0;


### PR DESCRIPTION
Signature v4 requests were trying to create authorisation strings when no credentials were present.  This change adds the v2 lines that handle this. Fixes samtools/samtools#1491.