### PR TITLE
Fix clang-13 unused variable messages.

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -1467,7 +1467,7 @@ static void *bgzf_mt_writer(void *vp) {
 int bgzf_mt_read_block(BGZF *fp, bgzf_job *j)
 {
     uint8_t header[BLOCK_HEADER_LENGTH], *compressed_block;
-    int count, size = 0, block_length, remaining;
+    int count, block_length, remaining;
 
     // NOTE: Guaranteed to be compressed as we block multi-threading in
     // uncompressed mode.  However it may be gzip compression instead
@@ -1496,7 +1496,6 @@ int bgzf_mt_read_block(BGZF *fp, bgzf_job *j)
     if (count != sizeof(header)) // no data read
         return -1;
 
-    size = count;
     block_length = unpackInt16((uint8_t*)&header[16]) + 1; // +1 because when writing this number, we used "-1"
     if (block_length < BLOCK_HEADER_LENGTH) {
         j->errcode |= BGZF_ERR_HEADER;
@@ -1510,7 +1509,6 @@ int bgzf_mt_read_block(BGZF *fp, bgzf_job *j)
         j->errcode |= BGZF_ERR_IO;
         return -1;
     }
-    size += count;
     j->comp_len = block_length;
     j->uncomp_len = BGZF_MAX_BLOCK_SIZE;
     j->block_address = block_address;

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -3069,7 +3069,7 @@ cram_codec *cram_huffman_encode_init(cram_stats *st,
                                      int version, varint_vec *vv) {
     int *vals = NULL, *freqs = NULL, *lens = NULL, code, len;
     int *new_vals, *new_freqs;
-    int i, ntot = 0, max_val = 0, min_val = INT_MAX, k;
+    int i, max_val = 0, min_val = INT_MAX, k;
     size_t nvals, vals_alloc = 0;
     cram_codec *c;
     cram_huffman_code *codes;
@@ -3095,7 +3095,6 @@ cram_codec *cram_huffman_encode_init(cram_stats *st,
         vals[nvals] = i;
         freqs[nvals] = st->freqs[i];
         assert(st->freqs[i] > 0);
-        ntot += freqs[nvals];
         if (max_val < i) max_val = i;
         if (min_val > i) min_val = i;
         nvals++;
@@ -3118,7 +3117,6 @@ cram_codec *cram_huffman_encode_init(cram_stats *st,
             vals[nvals]= kh_key(st->h, k);
             freqs[nvals] = kh_val(st->h, k);
             assert(freqs[nvals] > 0);
-            ntot += freqs[nvals];
             if (max_val < i) max_val = i;
             if (min_val > i) min_val = i;
             nvals++;

--- a/vcf.c
+++ b/vcf.c
@@ -3584,7 +3584,7 @@ bcf_hdr_t *bcf_hdr_merge(bcf_hdr_t *dst, const bcf_hdr_t *src)
         return dst;
     }
 
-    int i, ndst_ori = dst->nhrec, need_sync = 0, ret = 0, res;
+    int i, ndst_ori = dst->nhrec, need_sync = 0, res;
     for (i=0; i<src->nhrec; i++)
     {
         if ( src->hrec[i]->type==BCF_HL_GEN && src->hrec[i]->value )
@@ -3641,13 +3641,11 @@ bcf_hdr_t *bcf_hdr_merge(bcf_hdr_t *dst, const bcf_hdr_t *src)
                 {
                     hts_log_warning("Trying to combine \"%s\" tag definitions of different lengths",
                         src->hrec[i]->vals[0]);
-                    ret |= 1;
                 }
                 if ( (kh_val(d_src,k_src).info[rec->type]>>4 & 0xf) != (kh_val(d_dst,k_dst).info[rec->type]>>4 & 0xf) )
                 {
                     hts_log_warning("Trying to combine \"%s\" tag definitions of different types",
                         src->hrec[i]->vals[0]);
-                    ret |= 1;
                 }
             }
         }


### PR DESCRIPTION
The new version of clang is better at finding unused variables.  This PR removes those variables.