### PR TITLE
Fix incorrect offset into fastq header in name2 mode

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -3735,7 +3735,7 @@ static int fastq_parse1(htsFile *fp, bam1_t *b) {
     }
 
     l = x->name.l;
-    char *s = x->name.s + i;
+    char *s = x->name.s;
     while (i < l && !isspace_c(s[i]))
         i++;
     if (i < l) {


### PR DESCRIPTION
The offset to skip over the first name in the fastq header was being applied twice, potentially causing the search for the comment part to fall off the end of the allocated string.

Thanks to @jmarshall for reporting this.