### PR TITLE
Add basic recognition for XZ- & Zstd-compressed data, and D4 format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ hfile_gcs.o hfile_gcs.pico: hfile_gcs.c config.h $(htslib_hts_h) $(htslib_kstrin
 hfile_libcurl.o hfile_libcurl.pico: hfile_libcurl.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_s3_write.o hfile_s3_write.pico: hfile_s3_write.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
-hts.o hts.pico: hts.c config.h $(htslib_hts_expr_h) $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_hts_endian_h) version.h config_vars.h $(hts_internal_h) $(hfile_internal_h) $(sam_internal_h) $(htslib_hts_os_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h) $(htslib_tbx_h) $(htscodecs_htscodecs_h)
+hts.o hts.pico: hts.c config.h os/lzma_stub.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_hts_endian_h) version.h config_vars.h $(hts_internal_h) $(hfile_internal_h) $(sam_internal_h) $(htslib_hts_expr_h) $(htslib_hts_os_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h) $(htslib_tbx_h) $(htscodecs_htscodecs_h)
 hts_expr.o hts_expr.pico: hts_expr.c config.h $(htslib_hts_expr_h) $(textutils_internal_h)
 hts_os.o hts_os.pico: hts_os.c config.h $(htslib_hts_defs_h) os/rand.c
 vcf.o vcf.pico: vcf.c config.h $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_hfile_h) $(hts_internal_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_sam_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_hts_endian_h)

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1344,7 +1344,7 @@ static char *lzma_mem_inflate(char *cdata, size_t csize, size_t *size) {
     r = lzma_code(&strm, LZMA_FINISH);
     if (r != LZMA_OK && r != LZMA_STREAM_END) {
         hts_log_error("Call to lzma_code failed with error %d", r);
-        return NULL;
+        goto fail;
     }
 
     new_out = realloc(out, strm.total_out > 0 ? strm.total_out : 1);

--- a/hts.c
+++ b/hts.c
@@ -285,6 +285,7 @@ static enum htsFormatCategory format_category(enum htsExactFormat fmt)
         return index_file;
 
     case bed:
+    case d4_format:
         return region_list;
 
     case htsget:
@@ -634,6 +635,13 @@ int hts_detect_format(hFILE *hfile, htsFormat *fmt)
             fmt->version.major = 1, fmt->version.minor = -1;
         return 0;
     }
+    else if (len >= 8 && memcmp(s, "d4\xdd\xdd", 4) == 0) {
+        fmt->category = region_list;
+        fmt->format = d4_format;
+        // How to decode the D4 Format Version bytes is not yet specified
+        // so we don't try to set fmt->version.{major,minor}.
+        return 0;
+    }
     else if (cmp_nonblank("{\"htsget\":", s, &s[len]) == 0) {
         fmt->category = unknown_category;
         fmt->format = htsget;
@@ -718,6 +726,7 @@ char *hts_format_description(const htsFormat *format)
     case gzi:   kputs("GZI", &str); break;
     case tbi:   kputs("Tabix", &str); break;
     case bed:   kputs("BED", &str); break;
+    case d4_format:     kputs("D4", &str); break;
     case htsget: kputs("htsget", &str); break;
     case hts_crypt4gh_format: kputs("crypt4gh", &str); break;
     case empty_format:  kputs("empty", &str); break;
@@ -1597,6 +1606,7 @@ const char *hts_format_file_extension(const htsFormat *format) {
     case gzi:  return "gzi";
     case tbi:  return "tbi";
     case bed:  return "bed";
+    case d4_format:    return "d4";
     case fasta_format: return "fa";
     case fastq_format: return "fq";
     default:   return "?";

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -210,6 +210,7 @@ enum htsExactFormat {
 
 enum htsCompression {
     no_compression, gzip, bgzf, custom, bzip2_compression, razf_compression,
+    xz_compression, zstd_compression,
     compression_maximum = 32767
 };
 

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -205,6 +205,7 @@ enum htsExactFormat {
     empty_format,  // File is empty (or empty after decompression)
     fasta_format, fastq_format, fai_format, fqi_format,
     hts_crypt4gh_format,
+    d4_format,
     format_maximum = 32767
 };
 


### PR DESCRIPTION
There has been some recent discussion of using Zstandard compression (cf #530).

As a very small first step towards this, this adds `xz_compression` and `zstd_compression` to `enum htsCompression` and recognises their magic numbers, as we do for `bzip2_compression`. As htslib already uses liblzma, this also adds `decompress_peek_xz()` (if liblzma is configured in) to peek at the contents. Unlike libbz2's decompression routines, an `lzma_stream_decoder` can decompress a few hundred bytes of a stream without needing to read in an entire multi-hundred-KB block — hence is suitable for use with peeking.

There is also some talk of an intersection between D4 and htsget (though IMHO I'm not yet sure this intersection is non-empty), and of upcoming work in that area. So this also adds basic recognition of D4 format. Note that the D4 spec is fairly incomplete and (as far as I am aware) the format currently has only one implementation. So you may wish to leave the D4 commit off for now. This PR does not set `version.major`/`.minor` for D4; see 38/d4-format#34.