### PR TITLE
Fix a filter expression bug for flag.read2

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -1211,7 +1211,7 @@ static int bam_sym_lookup(void *data, char *str, char **end,
                     *end = str+5;
                     res->d = b->core.flag & BAM_FREAD1;
                     return 0;
-                } else if (!memcmp(str, "read2", 6)) {
+                } else if (!memcmp(str, "read2", 5)) {
                     *end = str+5;
                     res->d = b->core.flag & BAM_FREAD2;
                     return 0;


### PR DESCRIPTION
This was compared with string length 6 instead of 5, meaning it included the nul terminator byte.  This means "flag.read2" works at
the end of strings only.

Fixes samtools/samtools#1513