### PR TITLE
Resolve icc 2021 warning about HTS_DEPRECATED_ENUM.

### DIFF
--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -79,7 +79,7 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_DEPRECATED(message)
 #endif
 
-#if HTS_COMPILER_HAS(__deprecated__) || HTS_GCC_AT_LEAST(6,4)
+#if (HTS_COMPILER_HAS(__deprecated__) || HTS_GCC_AT_LEAST(6,4)) && !defined(__ICC)
 #define HTS_DEPRECATED_ENUM(message) __attribute__ ((__deprecated__ (message)))
 #else
 #define HTS_DEPRECATED_ENUM(message)


### PR DESCRIPTION
    In file included from htslib/synced_bcf_reader.h(59),
                     from bcf_sr_sort.h(37),
                     from bcf_sr_sort.c(31):
    htslib/hts.h(204): warning #2650: attributes ignored here
          json HTS_DEPRECATED_ENUM("Use htsExactFormat 'htsget' instead") = htsget,

Note that the normal HTS_DEPRECATED is fine, so it appears to only be
problematic when used with an enum.

(It's possible this is a new issue in icc 2021, but the licenses have
expired for all the old installs.)