### PR TITLE
Fill in cr->rg when writing CRAM v1 [minor]

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -3057,7 +3057,8 @@ static int process_one_read(cram_fd *fd, cram_container *c,
         cr->rg = brg ? brg->id : -1;
     } else if (CRAM_MAJOR_VERS(fd->version) == 1) {
         sam_hrec_rg_t *brg = sam_hrecs_find_rg(fd->header->hrecs, "UNKNOWN");
-        assert(brg);
+        if (!brg) goto block_err;
+        cr->rg = brg->id;
     } else {
         cr->rg = -1;
     }


### PR DESCRIPTION
I'm sure no-one much cares about writing CRAM v1, but…

It seems like this branch of the `if`-`else` should also be filling in `cr->rg`. Noticed because with `brg` used only in the `assert()`, there is a “variable unused” warning when compiling with `-DNDEBUG`.

I suppose now that `brg` is used in the assignment, it could stay as an `assert()` and produce an assert failure (or a hard crash with `-DNDEBUG`) rather than `goto block_err` and returning an error code. Probably doesn't matter much either way — see paragraph 1 above!