### PR TITLE
Consider filename extensions (where necessary) in format detection

### DIFF
--- a/htsfile.c
+++ b/htsfile.c
@@ -283,7 +283,7 @@ int main(int argc, char **argv)
 
         if (mode == identify) {
             htsFormat fmt;
-            if (hts_detect_format(fp, &fmt) < 0) {
+            if (hts_detect_format2(fp, argv[i], &fmt) < 0) {
                 error("detecting \"%s\" format failed", argv[i]);
                 hclose_abruptly(fp);
                 continue;

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -534,9 +534,28 @@ const char *hts_feature_string(void);
   @param fp    File opened for reading, positioned at the beginning
   @param fmt   Format structure that will be filled out on return
   @return      0 for success, or negative if an error occurred.
+
+  Equivalent to hts_detect_format2(fp, NULL, fmt).
 */
 HTSLIB_EXPORT
 int hts_detect_format(struct hFILE *fp, htsFormat *fmt);
+
+/*!
+  @abstract    Determine format primarily by peeking at the start of a file
+  @param fp    File opened for reading, positioned at the beginning
+  @param fname Name of the file, or NULL if not available
+  @param fmt   Format structure that will be filled out on return
+  @return      0 for success, or negative if an error occurred.
+  @since       1.15
+
+Some formats are only recognised if the filename is available and has the
+expected extension, as otherwise more generic files may be misrecognised.
+In particular:
+ - FASTA/Q indexes must have .fai/.fqi extensions; without this requirement,
+   some similar BED files would be misrecognised as indexes.
+*/
+HTSLIB_EXPORT
+int hts_detect_format2(struct hFILE *fp, const char *fname, htsFormat *fmt);
 
 /*!
   @abstract    Get a human-readable description of the file format


### PR DESCRIPTION
Fix the issue of some BED files being misrecognised as FASTA/Q indexes, by — as suggested in https://github.com/samtools/htslib/issues/1085#issuecomment-645360420 and https://github.com/samtools/htslib/issues/1085#issuecomment-645402870 — adding another API function that also considers the filename extension.

I have not implemented “`hts_detect_format()` should only recognise files as `fqi_format` or `fai_format` if they are uncompressed” — as suggested in https://github.com/samtools/htslib/issues/1347#issuecomment-952896121 — as it would mean that an affected BED file would be recognised as BED if compressed but as a FASTA/Q index if not compressed, and that seems like an unfortunate inconsistency. (The inconsistency of misrecognising an actual FASTA-IDX as BED when it's read from standard input (uncommon for index files!) is comparatively minor.) 

* FASTA/Q indexes (uncommon for `hts_open()`) are a particular case of 5/6-column BED files (comparatively common). We don't want to misrecognise any actual BED files as FASTA/Q indexes, so require a `.fai`/`.fqi` extension for the latter — which are unlikely to appear on standard input anyway, so filenames will usually be available.

We now have the machinery to recognise GZI indexes as well:

* GZI indexes have not previously been recognised, as they have no magic numbers. They can now be recognised by their `.gzi` extension.

Fixes #1085, fixes #1165, and fixes #1347.