### PR TITLE
Add pathA##idx##pathB support for CRAM indices.

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -173,6 +173,11 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
 
     idx_stack[idx_stack_ptr] = idx;
 
+    // Support pathX.cram##idx##pathY.crai
+    const char *fn_delim = strstr(fn, HTS_IDX_DELIM);
+    if (fn_delim && !fn_idx)
+        fn_idx = fn_delim + strlen(HTS_IDX_DELIM);
+
     if (!fn_idx) {
         if (hts_idx_check_local(fn, HTS_FMT_CRAI, &tfn_idx) == 0 && hisremote(fn))
             tfn_idx = hts_idx_getfn(fn, ".crai");


### PR DESCRIPTION
Fixes samtools/samtools#1541

The original report was for s3: URIs, but it turns out this is simply lacking in local files too.   It seems surprising we never implemented this, but even in 1.10 (where `##idx##` was first added) CRAM support was missing. 7e583ccea8e8a1a31c16bf5224d8f7785182dd82 stated "it works transparently for all file types and all programs".  I guess we never actually checked it.