### PR TITLE
SAM flag filter specification strings and parsing & filtering API functions

### DIFF
--- a/sam.5
+++ b/sam.5
@@ -56,7 +56,7 @@ lcbl.
 0x0040	1	the read is the first read in a pair
 0x0080	2	the read is the second read in a pair
 0x0100	s	the alignment is not primary
-0x0200	f	the read fails platform/vendor quality checks
+0x0200	x	filtered out, e.g., by platform/vendor quality checks
 0x0400	d	the read is either a PCR or an optical duplicate
 0x0800	S	the alignment is supplementary
 .TE


### PR DESCRIPTION
In https://github.com/samtools/samtools/pull/1442#issuecomment-871244137 I wrote:

> (I can never remember which option I want to use and have to look it up each time. What I would really like to have for this is to come up with some `[+-=].*` syntax something like `chmod(1)` symbolic permissions so that all these options could be unified into a single `-f`/`--flags` option — at which point these legacy options would become somewhat moot.)

It turns out I was thinking of `find … -perm [+-]mode` syntax probably more than symbolic Unix permissions per se, but the point stands: that perhaps some other notation would solve the `‑f`/ `‑‑ff`/ `‑‑rf`/etc plethora of confusing flag filtering options problem better than trying to come up with multiple more memorable overlapping option names.

Motivated by the renewed attempt to come up with a new set of option names in samtools/bcftools#1611, here is a specific proposal for that:

Flag specification strings are of the form `#flag,…,flag,#flag,…,flag,…`, i.e., a comma-separated list of flag items (each of which is either a numeric flag bitset, a symbolic flag bitset (`/[pPuUrR12sxdS_]+/`, as in _sam.5_ and samtools/htsjdk#232), or a single flag name (eg `PAIRED`)), each of which may be prefixed by a punctuation character (represented by `#` in the previous template) that controls which filter the subsequent items contribute to (until the next punctuation character):

Chr | To pass filtering and be kept, the read must…
---|---
`- &` |    …have ALL of the flags prefixed by either `-` or `&`
`! ^`  |   …have NONE of the flags prefixed by either `!` or `^`
`+ \|`  |  …have ANY (at least one) of the flags prefixed by either `+` or `\|`
`~`    |  …NOT have at least one of the flags prefixed by `~`
`=`   |  …have EXACTLY the flags prefixed by `=` (and no others)

(`-` and `+` are the same characters as used by `find … -perm` for similar tests, and `&` and `|` represent AND (all of these flags) and OR (any of these flags). `!` and `^` are as per regexp and glob character classes. `~` suggests negative, but is a more tentative suggestion than the others.)

The various samtools/bcftools commands would then use `sam_parse_flag_filter()` with different initial `mode` arguments to parse their various flag filtering command line options. Hence for example the following would be equivalent:

```
samtools view -f '3|12^48~192' …

samtools view -f '&1,2' -f '|4,8' -f '^16,32' -f '~64,128' …

samtools view -f '&1,2,|4,8,^16,32,~64,128' …

samtools view -f 1 -f 2 --rf 4 --rf 8 -F 16 -F 32 -G 64 -G 128 …

samtools view --require-flags 3 --include-flags 12 --exclude-flags 48 -G 192 …
```

Is something like this better or worse than trying to come up with mnemonic long option names and mnemonic short option letters for all these possibilities?

IMHO such punctuation characters certainly have more mnemonic value than a plethora of even more cryptic `‑f`/`‑F`/`‑‑ff`/`‑‑rf`/`-G` short options. Whether they are more mnemonic than `‑‑require‑flags`/ `‑‑excl[ude]‑flags`/ `‑‑incl[ude]‑flags`/ `‑‑something‑flags` long options is more of an open question: the long option names are quite distinctive from each other but as we've seen whether e.g. `require` means `&` or `|` is not quite as obvious as would be ideal.