### PR TITLE
bgzip text compression mode

### DIFF
--- a/bgzip.1
+++ b/bgzip.1
@@ -74,6 +74,13 @@ after decompression completes the input file will be removed.
 
 .SH OPTIONS
 .TP 10
+.B "-a, --text"
+Attempt to ensure BGZF blocks end on a newline.  The exception to this
+is where a single line is larger than a BGZF block (64Kb).  This can
+aid tools that use the index to perform random access on the
+compressed stream, as the start of a block is likely to also be the
+start of a text record.
+.TP
 .BI "-b, --offset " INT
 Decompress to standard output from virtual file position (0-based uncompressed
 offset).

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -119,7 +119,10 @@ extern "C" {
     /* kgetline() uses the supplied fgets()-like function to read a "\n"-
      * or "\r\n"-terminated line from fp.  The line read is appended to the
      * kstring without its terminator and 0 is returned; EOF is returned at
-     * EOF or on error (determined by querying fp, as per fgets()). */
+     * EOF or on error (determined by querying fp, as per fgets()).
+     *
+     * If a line contains a nul byte, then any subsequent content on the line
+     * is silently discarded. kgetline2() avoids this caveat. */
     typedef char *kgets_func(char *, int, void *);
     HTSLIB_EXPORT
     int kgetline(kstring_t *s, kgets_func *fgets_fn, void *fp);
@@ -131,6 +134,12 @@ extern "C" {
     typedef ssize_t kgets_func2(char *, size_t, void *);
     HTSLIB_EXPORT
     int kgetline2(kstring_t *s, kgets_func2 *fgets_fn, void *fp);
+
+    /* kgetline3() is similar to kgetline2() but includes the line's
+     * terminator. Upon success, the appended line lacks a newline terminator
+     * only for the last line of a file that doesn't end in one. */
+    HTSLIB_EXPORT
+    int kgetline3(kstring_t *s, kgets_func2 *fgets_fn, void *fp);
 
 #ifdef __cplusplus
 }

--- a/kstring.c
+++ b/kstring.c
@@ -282,7 +282,7 @@ int kgetline(kstring_t *s, kgets_func *fgets_fn, void *fp)
 	return 0;
 }
 
-int kgetline2(kstring_t *s, kgets_func2 *fgets_fn, void *fp)
+int kgetline3(kstring_t *s, kgets_func2 *fgets_fn, void *fp)
 {
 	size_t l0 = s->l;
 
@@ -307,7 +307,16 @@ int kgetline2(kstring_t *s, kgets_func2 *fgets_fn, void *fp)
 		s->l += len;
 	}
 
-	if (s->l == l0) return EOF;
+	return s->l > l0 ? 0 : EOF;
+}
+
+int kgetline2(kstring_t *s, kgets_func2 *fgets_fn, void *fp)
+{
+	size_t l0 = s->l;
+	int ret = kgetline3(s, fgets_fn, fp);
+	if (ret < 0) {
+		return ret;
+	}
 
 	if (s->l > l0 && s->s[s->l-1] == '\n') {
 		s->l--;

--- a/test/test.pl
+++ b/test/test.pl
@@ -398,6 +398,30 @@ sub test_bgzip {
     }
     passed($opts,$test);
 
+    # Round-trip test in text mode
+    my $test = sprintf('%s %2s threads', 'bgzip text mode round-trip',
+                       $threads ? $threads : 'no');
+    print "$test: ";
+    my $c = "$$opts{bin}/bgzip $at -a -i -I '$index' < '$data' > '$compressed'";
+    my ($ret, $out) = _cmd($c);
+    if ($ret) {
+        failed($opts, $test, "non-zero exit from $c");
+        return;
+    }
+    $c = "$$opts{bin}/bgzip $at -d < '$compressed' > '$uncompressed'";
+    ($ret, $out) = _cmd($c);
+    if ($ret) {
+        failed($opts, $test, "non-zero exit from $c");
+        return;
+    }
+    $c = "cmp '$data' '$uncompressed'";
+    ($ret, $out) = _cmd($c);
+    if ($ret) {
+        failed($opts, $test, $out ? $out : "'$data' '$uncompressed' differ");
+        return;
+    }
+    passed($opts,$test);
+
     # Extract from an offset
     $test = sprintf('%s %2s threads', 'bgzip -b',
                     $threads ? $threads : 'no');


### PR DESCRIPTION
Compressing with `-n`/`--text` promotes alignment of BGZF blocks with the uncompressed text lines. BGZF blocks start at the beginning of an input line and end after some subsequent newline (except when the block's first line overflows the BGZF block size).

This ensures it's possible to specify byte ranges of a BGZF file that decompress into complete text records -- useful for parallel processing and "slicing" from remote servers.

Inspiration: `bam_write1()` [uses the same trick](https://github.com/samtools/htslib/blob/e769401d18c19ce6150a1d40bdccd2af814e6b1c/sam.c#L818) to align BGZF blocks with BAM records.