### PR TITLE
Fix CRAM region queries when CIGAR isn't being decoded.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -1777,7 +1777,7 @@ static int cram_decode_seq(cram_fd *fd, cram_container *c, cram_slice *s,
     }
 
     cr->ncigar = ncigar - cr->cigar;
-    cr->aend = ref_pos;
+    cr->aend = ref_pos > cr->apos ? ref_pos : cr->apos;
 
     //printf("2: %.*s %d .. %d\n", cr->name_len, DSTRING_STR(name_ds) + cr->name, cr->apos, ref_pos);
 


### PR DESCRIPTION
If using the required_fields option to select columns for decoding,
excluding CIGAR, then the sequence end position (cr->apos to cr->aend)
is not set correctly.

With CIGAR computed, ref_pos is increased by each CIGAR option.
Without it it'll end up being equivalent to cr->apos-1.  Now it is
always minimum cr->apos itself (ie covers apos to apos inclusive).

The impact of this is filtering for the entirety of a single
chromosome could leave a sequence as pos 1 with apos=1 aend=0, which
then rejected the sequence as aend < 1 (for region chr:1-LEN).

I think this also fixes samtools/samtools#1574, but cannot be sure without
confirmation.