### PR TITLE
Remove static from array type

### DIFF
--- a/hts_internal.h
+++ b/hts_internal.h
@@ -127,7 +127,7 @@ int bgzf_idx_push(BGZF *fp, hts_idx_t *hidx, int tid, hts_pos_t beg, hts_pos_t e
  */
 void bgzf_idx_amend_last(BGZF *fp, hts_idx_t *hidx, uint64_t offset);
 
-static inline int find_file_extension(const char *fn, char ext_out[static HTS_MAX_EXT_LEN])
+static inline int find_file_extension(const char *fn, char ext_out[HTS_MAX_EXT_LEN])
 {
     const char *delim = fn ? strstr(fn, HTS_IDX_DELIM) : NULL, *ext;
     if (!fn) return -1;


### PR DESCRIPTION
While this is valid in C99 I believe it was made optional in C11.  While this works in gcc and clang it does not work in MSVC. I know the officially supported build platform is MSYS on windows, but MSVC now supports compiling C11 and C17 and this would be one of the few changes needed to support it. 
