### PR TITLE
Provide a definition of ssize_t when compiling with MSVC [more robust alternative to #1375]

### DIFF
--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -35,6 +35,13 @@
 
 #include "hts_defs.h"
 
+// Ensure ssize_t exists within this header. All #includes must precede this,
+// and ssize_t must be undefined again at the end of this header.
+#if defined _MSC_VER && defined _INTPTR_T_DEFINED && !defined _SSIZE_T_DEFINED && !defined ssize_t
+#define HTSLIB_SSIZE_T
+#define ssize_t intptr_t
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -448,6 +455,11 @@ typedef struct BGZF BGZF;
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef HTSLIB_SSIZE_T
+#undef HTSLIB_SSIZE_T
+#undef ssize_t
 #endif
 
 #endif

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -32,6 +32,13 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include "hts_defs.h"
 
+// Ensure ssize_t exists within this header. All #includes must precede this,
+// and ssize_t must be undefined again at the end of this header.
+#if defined _MSC_VER && defined _INTPTR_T_DEFINED && !defined _SSIZE_T_DEFINED && !defined ssize_t
+#define HTSLIB_SSIZE_T
+#define ssize_t intptr_t
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -366,6 +373,11 @@ int hfile_has_plugin(const char *name);
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef HTSLIB_SSIZE_T
+#undef HTSLIB_SSIZE_T
+#undef ssize_t
 #endif
 
 #endif

--- a/htslib/hts_os.h
+++ b/htslib/hts_os.h
@@ -77,4 +77,10 @@ extern int is_cygpty(int fd);
 #define random rand
 #endif
 
+/* MSVC does not provide ssize_t in its <sys/types.h>. This ensures the type
+   is available (unless suppressed by defining HTS_NO_SSIZE_T first). */
+#if defined _MSC_VER && defined _INTPTR_T_DEFINED && !defined _SSIZE_T_DEFINED && !defined HTS_NO_SSIZE_T && !defined ssize_t
+#define ssize_t intptr_t
+#endif
+
 #endif // HTSLIB_HTS_OS_H

--- a/htslib/knetfile.h
+++ b/htslib/knetfile.h
@@ -44,6 +44,13 @@
 #define netclose(fd) closesocket(fd)
 #endif
 
+// Ensure ssize_t exists within this header. All #includes must precede this,
+// and ssize_t must be undefined again at the end of this header.
+#if defined _MSC_VER && defined _INTPTR_T_DEFINED && !defined _SSIZE_T_DEFINED && !defined ssize_t
+#define HTSLIB_SSIZE_T
+#define ssize_t intptr_t
+#endif
+
 // FIXME: currently I/O is unbuffered
 
 #define KNF_TYPE_LOCAL 1
@@ -100,6 +107,11 @@ extern "C" {
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef HTSLIB_SSIZE_T
+#undef HTSLIB_SSIZE_T
+#undef ssize_t
 #endif
 
 #endif

--- a/htslib/kstring.h
+++ b/htslib/kstring.h
@@ -55,6 +55,13 @@
 #endif
 #endif
 
+// Ensure ssize_t exists within this header. All #includes must precede this,
+// and ssize_t must be undefined again at the end of this header.
+#if defined _MSC_VER && defined _INTPTR_T_DEFINED && !defined _SSIZE_T_DEFINED && !defined ssize_t
+#define HTSLIB_SSIZE_T
+#define ssize_t intptr_t
+#endif
+
 /* kstring_t is a simple non-opaque type whose fields are likely to be
  * used directly by user code (but see also ks_str() and ks_len() below).
  * A kstring_t object is initialised by either of
@@ -395,5 +402,10 @@ static inline int *ksplit(kstring_t *s, int delimiter, int *n)
 	*n = ksplit_core(s->s, delimiter, &max, &offsets);
 	return offsets;
 }
+
+#ifdef HTSLIB_SSIZE_T
+#undef HTSLIB_SSIZE_T
+#undef ssize_t
+#endif
 
 #endif

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -33,6 +33,13 @@ DEALINGS IN THE SOFTWARE.  */
 #include "hts.h"
 #include "hts_endian.h"
 
+// Ensure ssize_t exists within this header. All #includes must precede this,
+// and ssize_t must be undefined again at the end of this header.
+#if defined _MSC_VER && defined _INTPTR_T_DEFINED && !defined _SSIZE_T_DEFINED && !defined ssize_t
+#define HTSLIB_SSIZE_T
+#define ssize_t intptr_t
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -2264,6 +2271,11 @@ int bam_mods_at_qpos(const bam1_t *b, int qpos, hts_base_mod_state *state,
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef HTSLIB_SSIZE_T
+#undef HTSLIB_SSIZE_T
+#undef ssize_t
 #endif
 
 #endif


### PR DESCRIPTION
PR #1375 proposes unconditionally typedeffing `ssize_t` on MSVC in _htslib/hts_defs.h_, but as discussed in https://github.com/samtools/htslib/issues/1025#issuecomment-587032812 this is fragile if user code or other header files `#included` also include their own workarounds for this `ssize_t` issue. (It would be reminiscent of the olden days when every C library had its own bool type!)

A robust alternative is to `#define ssize_t` **within each affected HTSlib header only**, undoing it at the end of the header:

Define `ssize_t` within the public headers that use it, enabling them to be compiled with MSVC, which does not provide this type definition in its <sys/types.h> or any other headers.

Having `ssize_t` as a macro may confuse other headers, so be sure to do this only after all other #includes and to undefine it again at the end of each header. User code or other libraries may also have workarounds for this issue, so checking its not already #defined and removing our `ssize_t` macro afterwards also avoids conflicting with other workarounds.

Under MSVC, including <stdint.h>/<string.h>/etc also causes <vcruntime.h> to be included, which defines `size_t` and `intptr_t` as unsigned/signed versions of the same type. So we define `ssize_t` as the latter, if it is not already defined (by some other workaround) and if `_INTPTR_T_DEFINED` has indeed been defined by <vcruntime.h> (to avoid confusing error messages).

(I assume that Cygwin and MinGW compilations always use GCC. If users might use Cygwin or MinGW headers with the MSVC compiler, the `#if` will need some Cygwin and MinGW guards too.)

Also define it (permanently) in <htslib/hts_os.h>, unless suppressed by defining `HTS_NO_SSIZE_T` before including the header.

At the time of #1025, this `ssize_t` problem was the only thing preventing public HTSlib headers from being easily included from user code compiled by MSVC. I have not checked to see if this is still the case in 2022.

----

This workaround is admittedly somewhat voluminous!

An alternative would be to define a `hts_ssize_t` typedef as `ssize_t`/`SSIZE_T` in <htslib/hts_defs.h> and use that instead of `ssize_t` in function signatures in other public HTSlib headers. IMHO this would be a very unfortunate approach, as it would mislead API users into thinking they had to use that type name in their own code instead of the familiar POSIX standard `ssize_t` type name.