### PR TITLE
Capturing Error Messages 

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -4809,7 +4809,7 @@ void hts_log(enum htsLogLevel severity, const char *context, const char *format,
     errno = save_errno;
 }
 
-int get_last_err(const char *message, int len)
+int get_last_err(char *message, int len)
 {
     char *thread_log_buffer = NULL;
 

--- a/hts.c
+++ b/hts.c
@@ -4828,7 +4828,7 @@ int get_last_err(char *message, int len)
     return 0;
 }
 
-int clear_last_err() 
+int clear_last_err()
 {
     char *thread_log_buffer = NULL;
 

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -59,9 +59,6 @@ struct hFILE;
 struct hts_tpool;
 struct sam_hdr_t;
 
-
-typedef int (*file_progress_func)(int64_t current_pos, void *data);
-
 /**
  * @hideinitializer
  * Deprecated macro to expand a dynamic array of a given type

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -59,6 +59,9 @@ struct hFILE;
 struct hts_tpool;
 struct sam_hdr_t;
 
+
+typedef int (*file_progress_func)(int64_t current_pos, void *data);
+
 /**
  * @hideinitializer
  * Deprecated macro to expand a dynamic array of a given type

--- a/htslib/hts_log.h
+++ b/htslib/hts_log.h
@@ -94,7 +94,7 @@ HTS_FORMAT(HTS_PRINTF_FMT, 3, 4);
 
 
 HTSLIB_EXPORT
-int get_last_err(const char *message, int len);
+int get_last_err(char *message, int len);
 
 HTSLIB_EXPORT
 int clear_last_err();

--- a/htslib/hts_log.h
+++ b/htslib/hts_log.h
@@ -60,6 +60,9 @@ enum htsLogLevel hts_get_log_level(void);
  */
 extern int hts_verbose;
 
+
+extern const int hts_log_buffer_size;
+
 /*! Logs an event.
 * \param severity      Severity of the event:
 *                      - HTS_LOG_ERROR means that something went wrong so that a task could not be completed.
@@ -88,6 +91,13 @@ HTS_FORMAT(HTS_PRINTF_FMT, 3, 4);
 
 /*! Logs an event with severity HTS_LOG_TRACE and default context. Parameters: format, ... */
 #define hts_log_trace(...) hts_log(HTS_LOG_TRACE, __func__, __VA_ARGS__)
+
+
+HTSLIB_EXPORT
+int get_last_err(const char *message, int len);
+
+HTSLIB_EXPORT
+int clear_last_err();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Super excited to see the new logging functions, and consolidation of the error reporting! When embedding htslib it would be really nice to be able to capture the errors if a function has an error code. 

These changes would keep a thread local buffer of the last error message which could be checked in the event that a operation fails. Sort of like errno but more descriptive?

Not sure if you want these changes maybe they could be inspiration for another way of getting the error? Let me know if you have any feedback. 