### PR TITLE
Permit 2 letter extension in find_file_extension.

### DIFF
--- a/hts_internal.h
+++ b/hts_internal.h
@@ -139,7 +139,8 @@ static inline int find_file_extension(const char *fn, char ext_out[static HTS_MA
     {
         for (ext--; ext > fn && *ext != '.' && *ext != '/'; --ext) {}
     }
-    if (*ext != '.' || delim - ext > HTS_MAX_EXT_LEN || delim - ext < 4) return -1;
+    if (*ext != '.' || delim - ext > HTS_MAX_EXT_LEN || delim - ext < 3)
+        return -1;
     memcpy(ext_out, ext + 1, delim - ext - 1);
     ext_out[delim - ext - 1] = '\0';
     return 0;


### PR DESCRIPTION
sam_open_mode checks for ".fa" and ".fq" extension types, but these were never returned before as it had a hard rule of >= 3 characters.