### PR TITLE
Improve handling of CRAM "alignment span" for unmapped data.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -3228,7 +3228,8 @@ static cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
                     }
 
                     // position beyond end of range; bail out
-                    if (c_next->ref_seq_start > fd->range.end) {
+                    if (fd->range.refid != -1 &&
+                        c_next->ref_seq_start > fd->range.end) {
                         cram_free_container(c_next);
                         fd->ctr_mt = NULL;
                         fd->ooc = 1;
@@ -3236,7 +3237,8 @@ static cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
                     }
 
                     // before start of range; skip to next container
-                    if (c_next->ref_seq_start + c_next->ref_seq_span-1 <
+                    if (fd->range.refid != -1 &&
+                        c_next->ref_seq_start + c_next->ref_seq_span-1 <
                         fd->range.start) {
                         c_next->curr_slice_mt = c_next->max_slice;
                         cram_seek(fd, c_next->length, SEEK_CUR);
@@ -3301,7 +3303,8 @@ static cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
                 }
 
                 // position beyond end of range; bail out
-                if (s_next->hdr->ref_seq_start > fd->range.end) {
+                if (fd->range.refid != -1 &&
+                    s_next->hdr->ref_seq_start > fd->range.end) {
                     fd->ooc = 1;
                     cram_free_slice(s_next);
                     c_next->slice = s_next = NULL;
@@ -3309,7 +3312,8 @@ static cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
                 }
 
                 // before start of range; skip to next slice
-                if (s_next->hdr->ref_seq_start + s_next->hdr->ref_seq_span-1 <
+                if (fd->range.refid != -1 &&
+                    s_next->hdr->ref_seq_start + s_next->hdr->ref_seq_span-1 <
                     fd->range.start) {
                     cram_free_slice(s_next);
                     c_next->slice = s_next = NULL;

--- a/cram/cram_encode.h
+++ b/cram/cram_encode.h
@@ -106,7 +106,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c);
  *
  * See cram_next_container() and cram_close().
  */
-void cram_update_curr_slice(cram_container *c);
+void cram_update_curr_slice(cram_container *c, int version);
 
 #ifdef __cplusplus
 }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -5342,7 +5342,7 @@ int cram_flush(cram_fd *fd) {
 
     if (fd->mode == 'w' && fd->ctr) {
         if(fd->ctr->slice)
-            cram_update_curr_slice(fd->ctr);
+            cram_update_curr_slice(fd->ctr, fd->version);
 
         if (-1 == cram_flush_container_mt(fd, fd->ctr))
             return -1;
@@ -5449,7 +5449,7 @@ int cram_close(cram_fd *fd) {
 
     if (fd->mode == 'w' && fd->ctr) {
         if(fd->ctr->slice)
-            cram_update_curr_slice(fd->ctr);
+            cram_update_curr_slice(fd->ctr, fd->version);
 
         if (-1 == cram_flush_container_mt(fd, fd->ctr))
             return -1;


### PR DESCRIPTION
When writing, the specification states unmapped data must have alignment start and alignment span both zero.  Previously span was 1 (from end-start+1).

When reading, the code that filters data by the requested range now has an exception for ref_seq -1 (unmapped) so span is not checked.  This fixes the check for end-start-1 failing.  Note this previous triggered issues on files (correctly) output from htsjdk.

Fixes #1387