### PR TITLE
Replace CentOS test build with Rocky Linux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -117,11 +117,11 @@ ubuntu_task:
   << : *TEST
 
 
-# CentOS
-centos_task:
-  name: centos-gcc
+# Rocky Linux
+rocky_task:
+  name: rockylinux-gcc
   container:
-    image: centos:latest
+    image: rockylinux:latest
     cpu: 2
     memory: 1G
 


### PR DESCRIPTION
CentOS has moved to a rolling distribution, and the [CentOS Docker images](https://hub.docker.com/_/centos) that we use seem to have stopped working because they're [looking in the wrong place for packages](https://forums.centos.org/viewtopic.php?f=54&t=78708).  [Rocky Linux](https://wiki.rockylinux.org/) is more like the old CentOS, being a community build of the current RedHat, and had Docker images that still work.
