### PR TITLE
Fix hts_parse_decimal and make synced BCF targets parsing more robust

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -3482,7 +3482,7 @@ static inline long long push_digit(long long i, char c)
 long long hts_parse_decimal(const char *str, char **strend, int flags)
 {
     long long n = 0;
-    int decimals = 0, e = 0, lost = 0;
+    int decimals = 0, e = 0, lost = 0, has_digit = 0;
     char sign = '+', esign = '+';
     const char *s;
 
@@ -3491,13 +3491,20 @@ long long hts_parse_decimal(const char *str, char **strend, int flags)
 
     if (*s == '+' || *s == '-') sign = *s++;
     while (*s)
-        if (isdigit_c(*s)) n = push_digit(n, *s++);
+        if (isdigit_c(*s)) n = push_digit(n, *s++), has_digit = 1;
         else if (*s == ',' && (flags & HTS_PARSE_THOUSANDS_SEP)) s++;
         else break;
 
     if (*s == '.') {
         s++;
-        while (isdigit_c(*s)) decimals++, n = push_digit(n, *s++);
+        while (isdigit_c(*s)) decimals++, n = push_digit(n, *s++), has_digit = 1;
+    }
+
+    // there must have been a digit or else cannot be a valid number
+    if ( !has_digit )
+    {
+        if ( strend ) *strend = (char*)str;
+        return 0;
     }
 
     if (*s == 'E' || *s == 'e') {

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -1107,7 +1107,7 @@ static int _regions_parse_line(char *line, int ichr, int ifrom, int ito, char **
     if ( k==l )
     {
         *from = *to = hts_parse_decimal(ss, &tmp, 0);
-        if ( tmp==ss ) return -1;
+        if ( tmp==ss || (*tmp && *tmp!='\t') ) return -1;
     }
     else
     {
@@ -1115,7 +1115,7 @@ static int _regions_parse_line(char *line, int ichr, int ifrom, int ito, char **
             *from = hts_parse_decimal(ss, &tmp, 0);
         else
             *to = hts_parse_decimal(ss, &tmp, 0);
-        if ( ss==tmp ) return -1;
+        if ( ss==tmp || (*tmp && *tmp!='\t') ) return -1;
 
         for (i=k; i<l && *se; i++)
         {
@@ -1127,7 +1127,7 @@ static int _regions_parse_line(char *line, int ichr, int ifrom, int ito, char **
             *to = hts_parse_decimal(ss, &tmp, 0);
         else
             *from = hts_parse_decimal(ss, &tmp, 0);
-        if ( ss==tmp ) return -1;
+        if ( ss==tmp || (*tmp && *tmp!='\t') ) return -1;
     }
 
     ss = se = line;
@@ -1193,7 +1193,10 @@ bcf_sr_regions_t *bcf_sr_regions_init(const char *regions, int is_file, int ichr
                     hts_close(reg->file); reg->file = NULL; free(reg);
                     return NULL;
                 }
+                ito = ifrom;
             }
+            else if ( ito<0 )
+                ito = abs(ito);
             if ( !ret ) continue;
             if ( is_bed ) from++;
             *chr_end = 0;


### PR DESCRIPTION
The function bcf_sr_regions_init() autodetects the format of input regions,
trying to decide between CHR,POS vs CHR,BEG,END formats. However, the function
hts_parse_decimal() was recognising standalone `G` as `0` which resulted in
`chr1 1234 G` being interpretted as `chr1 1234 0`.

This commit makes the digit parsing more strict, requiring at least one digit
to appear before the exponent or unit part.

See also samtools/bcftools#1598