### PR TITLE
Add stricter format string checking to a gcc CI build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,7 +72,7 @@ gcc_task:
        USE_CONFIG: no
     - environment:
        USE_CONFIG: yes
-       CFLAGS: -std=c99 -pedantic
+       CFLAGS: -std=c99 -pedantic -Wformat=2
        USE_LIBDEFLATE: yes
 
   << : *LIBDEFLATE


### PR DESCRIPTION
Following a tidy up in 7981bc93 and 0d83a7b2, all format strings in HTSlib are now literals.  Prevent non-literal strings from coming back by using `-Wformat=2` in one of the CI tests, which enables `-Wformat-nonliteral`.  This has to be a gcc test as it excludes functions that take a va_list from the format-nonliteral warning while clang doesn't, and we need to be able to pass non-literal format strings to these functions.

While this might be slightly inconvenient for developers, any annoyances are far outweighed by being able to automatically detect a class of nasty and otherwise difficult to spot bugs.
