### PR TITLE
Changes a data type in sam.h to avoid compiler warnings

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1524,7 +1524,7 @@ static inline const uint8_t *sam_format_aux1(const uint8_t *key,
         ++s;
     } else if (type == 'B') {
         uint8_t sub_type = *(s++);
-        int sub_type_size;
+        unsigned sub_type_size;
 
         // or externalise sam.c's aux_type2size function?
         switch (sub_type) {
@@ -1547,7 +1547,7 @@ static inline const uint8_t *sam_format_aux1(const uint8_t *key,
             goto bad_aux;
         n = le_to_u32(s);
         s += 4; // now points to the start of the array
-        if ((end - s) / sub_type_size < n)
+        if ((size_t)(end - s) / sub_type_size < n)
             goto bad_aux;
         r |= kputsn_("B:", 2, ks) < 0;
         r |= kputc(sub_type, ks) < 0; // write the type


### PR DESCRIPTION
While compiling on Windows 10, we are getting multiple warnings from a single method.
![image](https://user-images.githubusercontent.com/5293569/155736397-cae4ee72-cf4c-4e95-a540-ea9d5892f35d.png)

This PR solves this issue by changing a data type for sub_type_size variable. It looks like the problem has something to do with a specific version of a compiler. We could not reproduce it on a Linux machine.