### PR TITLE
Improve coordinate parsing, particularly with tabix.

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -3713,13 +3713,16 @@ const char *hts_parse_region(const char *s, int *tid, hts_pos_t *beg,
     char *hyphen;
     *beg = hts_parse_decimal(colon+1, &hyphen, flags) - 1;
     if (*beg < 0) {
+        if ((*beg == -1 || *hyphen == '-') && colon[1] != '\0') {
+            // User specified zero, but we're 1-based.
+            hts_log_error("Coordinates must be > 0");
+            return NULL;
+        }
         if (isdigit_c(*hyphen) || *hyphen == '\0' || *hyphen == ',') {
             // interpret chr:-100 as chr:1-100
             *end = *beg==-1 ? HTS_POS_MAX : -(*beg+1);
             *beg = 0;
             return s_end;
-        } else if (*hyphen == '-') {
-            *beg = 0;
         } else {
             hts_log_error("Unexpected string \"%s\" after region", hyphen);
             return NULL;

--- a/hts.c
+++ b/hts.c
@@ -3713,7 +3713,7 @@ const char *hts_parse_region(const char *s, int *tid, hts_pos_t *beg,
     char *hyphen;
     *beg = hts_parse_decimal(colon+1, &hyphen, flags) - 1;
     if (*beg < 0) {
-        if ((*beg == -1 || *hyphen == '-') && colon[1] != '\0') {
+        if (*beg != -1 && *hyphen == '-' && colon[1] != '\0') {
             // User specified zero, but we're 1-based.
             hts_log_error("Coordinates must be > 0");
             return NULL;
@@ -3723,7 +3723,7 @@ const char *hts_parse_region(const char *s, int *tid, hts_pos_t *beg,
             *end = *beg==-1 ? HTS_POS_MAX : -(*beg+1);
             *beg = 0;
             return s_end;
-        } else {
+        } else if (*beg < -1) {
             hts_log_error("Unexpected string \"%s\" after region", hyphen);
             return NULL;
         }

--- a/tabix.1
+++ b/tabix.1
@@ -81,8 +81,8 @@ greater than that, you will need to use a CSI index.
 .SH INDEXING OPTIONS
 .TP 10
 .B -0, --zero-based
-Specify that the position in the data file is 0-based (e.g. UCSC files)
-rather than 1-based.
+Specify that the position in the data file is 0-based half-open
+(e.g. UCSC files) rather than 1-based.
 .TP
 .BI "-b, --begin " INT
 Column of start chromosomal position. [4]

--- a/tbx.c
+++ b/tbx.c
@@ -107,7 +107,11 @@ int tbx_parse1(const tbx_conf_t *conf, int len, char *line, tbx_intv_t *intv)
                 if ( s==line+b ) return -1; // expected int
                 if (!(conf->preset&TBX_UCSC)) --intv->beg;
                 else ++intv->end;
-                if (intv->beg < 0) intv->beg = 0;
+                if (intv->beg < 0) {
+                    hts_log_warning("Coordinate <= 0 detected. "
+                                    "Did you forget to use the -0 option?");
+                    intv->beg = 0;
+                }
                 if (intv->end < 1) intv->end = 1;
             } else {
                 if ((conf->preset&0xffff) == TBX_GENERIC) {


### PR DESCRIPTION
Double check the file coordinates are 1-based unless tabix -0 is
specified.  We treat a 0 coordinate as a warning now.  The
documentation is also more explicit that -0 also implied a half-open
coordinate system.

Also improve region parsing.  The code supports regions such as
"x"/"x:" (all of "x"), "x:10-20" "x:-20" (up to pos 20) and "x:20-"
(position 20 onwards).  However as genome coordinates are 1-based and
internally we have 0-based, we subtract one during parsing.  The
"x:-20" is done by negative value detection, but this was also
triggered with the illegal "x:0" region (treated as "up to 1").

Also, illegal regions such as "x:-10-20" were treated as "x:-20".
This is now a hard error.

Fixes #1409