### PR TITLE
Proposal to add hts_log callback function and hts_log_set_logger()

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -4754,19 +4754,32 @@ static char get_severity_tag(enum htsLogLevel severity)
     return '*';
 }
 
+static hts_log_func *hts_logger = NULL;
+static void *hts_logger_data = NULL;
+
+void hts_log_set_logger(hts_log_func *logger, void *data)
+{
+    hts_logger = logger;
+    hts_logger_data = data;
+}
+
 void hts_log(enum htsLogLevel severity, const char *context, const char *format, ...)
 {
     int save_errno = errno;
     if (severity <= hts_verbose) {
         va_list argptr;
 
-        fprintf(stderr, "[%c::%s] ", get_severity_tag(severity), context);
-
         va_start(argptr, format);
-        vfprintf(stderr, format, argptr);
+        if (hts_logger) {
+            hts_logger(hts_logger_data, severity, get_severity_tag(severity), context, format, argptr);
+        }
+        else {
+            fprintf(stderr, "[%c::%s] ", get_severity_tag(severity), context);
+            vfprintf(stderr, format, argptr);
+            fprintf(stderr, "\n");
+        }
         va_end(argptr);
 
-        fprintf(stderr, "\n");
     }
     errno = save_errno;
 }

--- a/htslib/hts_log.h
+++ b/htslib/hts_log.h
@@ -29,6 +29,7 @@ SOFTWARE.
 #ifndef HTS_LOG_H
 #define HTS_LOG_H
 
+#include <stdarg.h>
 #include "hts_defs.h"
 
 #ifdef __cplusplus
@@ -88,6 +89,11 @@ HTS_FORMAT(HTS_PRINTF_FMT, 3, 4);
 
 /*! Logs an event with severity HTS_LOG_TRACE and default context. Parameters: format, ... */
 #define hts_log_trace(...) hts_log(HTS_LOG_TRACE, __func__, __VA_ARGS__)
+
+typedef void hts_log_func(void *data, enum htsLogLevel severity, char severity_tag, const char *context, const char *format, va_list args);
+
+HTSLIB_EXPORT
+void hts_log_set_logger(hts_log_func *logger, void *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
A somewhat tidied-up version of @lczech's concrete proposal in #1397 for overriding the default printing of hts_log messages to stderr. Draft, as the new function (and associated typedef) would require documenting in _hts_log.h_.

I don't know whether the `hts_log_*` functions are called from threads that HTSlib has started. If so, this callback function would be called from those threads — which might be “interesting”. This PR doesn't consider what to do in this case.