### PR TITLE
Expose a bit more of the CRAM API.

### DIFF
--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -188,6 +188,19 @@ int32_t cram_slice_hdr_get_num_blocks(cram_block_slice_hdr *hdr) {
     return hdr->num_blocks;
 }
 
+int cram_slice_hdr_get_embed_ref_id(cram_block_slice_hdr *h) {
+    return h->ref_base_id;
+}
+
+void cram_slice_hdr_get_coords(cram_block_slice_hdr *h,
+                               int *refid, hts_pos_t *start, hts_pos_t *span) {
+    if (refid)
+        *refid = h->ref_seq_id;
+    if (start)
+        *start = h->ref_seq_start;
+    if (span)
+        *span  = h->ref_seq_span;
+}
 
 /*
  *-----------------------------------------------------------------------------

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -249,6 +249,46 @@ int cram_copy_slice(cram_fd *in, cram_fd *out, int32_t num_slice);
 
 /*
  *-----------------------------------------------------------------------------
+ * cram slice interrogation
+ */
+
+/*
+ * Returns the number of cram blocks within this slice.
+ */
+HTSLIB_EXPORT
+int32_t cram_slice_hdr_get_num_blocks(cram_block_slice_hdr *hdr);
+
+/*
+ * Returns the block content_id for the block containing an embedded reference
+ * sequence.  If none is present, -1 is returned.
+ */
+HTSLIB_EXPORT
+int cram_slice_hdr_get_embed_ref_id(cram_block_slice_hdr *h);
+
+/*
+ * Returns slice reference ID, start and span (length) coordinates.
+ * Return parameters may be NULL in which case they are ignored.
+ */
+HTSLIB_EXPORT
+void cram_slice_hdr_get_coords(cram_block_slice_hdr *h,
+                               int *refid, hts_pos_t *start, hts_pos_t *span);
+
+/*
+ * Decodes a slice header from a cram block.
+ * Returns the opaque cram_block_slice_hdr pointer on success,
+ *         NULL on failure.
+ */
+HTSLIB_EXPORT
+cram_block_slice_hdr *cram_decode_slice_header(cram_fd *fd, cram_block *b);
+
+/*
+ * Frees a cram_block_slice_hdr structure.
+ */
+HTSLIB_EXPORT
+void cram_free_slice_header(cram_block_slice_hdr *hdr);
+
+/*
+ *-----------------------------------------------------------------------------
  * cram_io basics
  */
 


### PR DESCRIPTION
This is to enable samtools cram2ref PR.

Draft as although this works as-is, I'm thinking of adding io_lib's cram_size and cram_dump utilities too which will need further API additions.

If you wish each tool as its own PR to keep the size of this one day, then say so and I can take this out of draft, but if so then it needs merging promptly as I don't want to be making PR branches off another PR branch as that way lies merge hell.