### PR TITLE
Fix clang builds under mingw.

### DIFF
--- a/hfile_internal.h
+++ b/hfile_internal.h
@@ -90,11 +90,13 @@ struct hFILE_backend {
 
 /* May be called by hopen_*() functions to decode a fopen()-style mode into
    open(2)-style flags.  */
+HTSLIB_EXPORT
 int hfile_oflags(const char *mode);
 
 /* Must be called by hopen_*() functions to allocate the hFILE struct and set
    up its base.  Capacity is a suggested buffer size (e.g., via fstat(2))
    or 0 for a default-sized buffer.  */
+HTSLIB_EXPORT
 hFILE *hfile_init(size_t struct_size, const char *mode, size_t capacity);
 
 /* Alternative to hfile_init() for in-memory backends for which the base
@@ -107,6 +109,7 @@ hFILE *hfile_init_fixed(size_t struct_size, const char *mode,
 /* May be called by hopen_*() functions to undo the effects of hfile_init()
    in the event opening the stream subsequently fails.  (This is safe to use
    even if fp is NULL.  This takes care to preserve errno.)  */
+HTSLIB_EXPORT
 void hfile_destroy(hFILE *fp);
 
 
@@ -138,10 +141,13 @@ struct hFILE_scheme_handler {
 };
 
 /* May be used as an isremote() function in simple cases.  */
+HTSLIB_EXPORT
 extern int hfile_always_local (const char *fname);
+HTSLIB_EXPORT
 extern int hfile_always_remote(const char *fname);
 
 /* Should be called by plugins for each URL scheme they wish to handle.  */
+HTSLIB_EXPORT
 void hfile_add_scheme_handler(const char *scheme,
                               const struct hFILE_scheme_handler *handler);
 

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -158,6 +158,7 @@ static inline off_t htell(hFILE *fp)
 */
 static inline int hgetc(hFILE *fp)
 {
+    HTSLIB_EXPORT
     extern int hgetc2(hFILE *);
     return (fp->end > fp->begin)? (unsigned char) *(fp->begin++) : hgetc2(fp);
 }
@@ -229,6 +230,7 @@ or I/O errors.
 static inline ssize_t HTS_RESULT_USED
 hread(hFILE *fp, void *buffer, size_t nbytes)
 {
+    HTSLIB_EXPORT
     extern ssize_t hread2(hFILE *, void *, size_t, size_t);
 
     size_t n = fp->end - fp->begin;
@@ -243,6 +245,7 @@ hread(hFILE *fp, void *buffer, size_t nbytes)
 */
 static inline int hputc(int c, hFILE *fp)
 {
+    HTSLIB_EXPORT
     extern int hputc2(int, hFILE *);
     if (fp->begin < fp->limit) *(fp->begin++) = c;
     else c = hputc2(c, fp);
@@ -254,6 +257,7 @@ static inline int hputc(int c, hFILE *fp)
 */
 static inline int hputs(const char *text, hFILE *fp)
 {
+    HTSLIB_EXPORT
     extern int hputs2(const char *, size_t, size_t, hFILE *);
 
     size_t nbytes = strlen(text), n = fp->limit - fp->begin;
@@ -271,7 +275,9 @@ In the absence of I/O errors, the full _nbytes_ will be written.
 static inline ssize_t HTS_RESULT_USED
 hwrite(hFILE *fp, const void *buffer, size_t nbytes)
 {
+    HTSLIB_EXPORT
     extern ssize_t hwrite2(hFILE *, const void *, size_t, size_t);
+    HTSLIB_EXPORT
     extern int hfile_set_blksize(hFILE *fp, size_t bufsiz);
 
     if (!fp->mobile) {

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -456,16 +456,19 @@ The input character may be either an IUPAC ambiguity code, '=' for 0, or
 '0'/'1'/'2'/'3' for a result of 1/2/4/8.  The result is encoded as 1/2/4/8
 for A/C/G/T or combinations of these bits for ambiguous bases.
 */
+HTSLIB_EXPORT
 extern const unsigned char seq_nt16_table[256];
 
 /*! @abstract Table for converting a 4-bit encoded nucleotide to an IUPAC
 ambiguity code letter (or '=' when given 0).
 */
+HTSLIB_EXPORT
 extern const char seq_nt16_str[];
 
 /*! @abstract Table for converting a 4-bit encoded nucleotide to about 2 bits.
 Returns 0/1/2/3 for 1/2/4/8 (i.e., A/C/G/T), or 4 otherwise (0 or ambiguous).
 */
+HTSLIB_EXPORT
 extern const int seq_nt16_int[];
 
 /*!

--- a/htslib/hts_log.h
+++ b/htslib/hts_log.h
@@ -58,6 +58,7 @@ enum htsLogLevel hts_get_log_level(void);
  * One of the HTS_LOG_* values. The default is HTS_LOG_WARNING.
  * \note Avoid direct use of this variable. Use hts_set_log_level and hts_get_log_level instead.
  */
+HTSLIB_EXPORT
 extern int hts_verbose;
 
 /*! Logs an event.

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -118,6 +118,7 @@ typedef sam_hdr_t bam_hdr_t;
 Result is operator code or -1. Be sure to cast the index if it is a plain char:
     int op = bam_cigar_table[(unsigned char) ch];
 */
+HTSLIB_EXPORT
 extern const int8_t bam_cigar_table[256];
 
 #define bam_cigar_op(c) ((c)&BAM_CIGAR_MASK)

--- a/htslib/tbx.h
+++ b/htslib/tbx.h
@@ -52,6 +52,7 @@ typedef struct tbx_t {
     void *dict;
 } tbx_t;
 
+HTSLIB_EXPORT
 extern const tbx_conf_t tbx_conf_gff, tbx_conf_bed, tbx_conf_psltbl, tbx_conf_sam, tbx_conf_vcf;
 
     #define tbx_itr_destroy(iter) hts_itr_destroy(iter)

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -123,6 +123,7 @@ typedef struct bcf_hdr_t {
     int32_t m[3];          // m: allocated size of the dictionary block in use (see n above)
 } bcf_hdr_t;
 
+HTSLIB_EXPORT
 extern uint8_t bcf_type_shift[];
 
 /**************
@@ -1341,7 +1342,9 @@ which works for both BCF and VCF.
 #define BCF_MIN_BT_INT16 (-32760)      /* INT16_MIN + 8 */
 #define BCF_MIN_BT_INT32 (-2147483640) /* INT32_MIN + 8 */
 
+HTSLIB_EXPORT
 extern uint32_t bcf_float_vector_end;
+HTSLIB_EXPORT
 extern uint32_t bcf_float_missing;
 static inline void bcf_float_set(float *ptr, uint32_t value)
 {

--- a/textutils_internal.h
+++ b/textutils_internal.h
@@ -65,9 +65,11 @@ typedef struct hts_json_token hts_json_token;
 /// Allocate an empty JSON token structure, for use with hts_json_* functions
 /** @return An empty token on success; NULL on failure
  */
+HTSLIB_EXPORT
 hts_json_token *hts_json_alloc_token(void);
 
 /// Free a JSON token
+HTSLIB_EXPORT
 void hts_json_free_token(hts_json_token *token);
 
 /// Accessor function to get JSON token type
@@ -85,6 +87,7 @@ as follows:
   - `!` other errors (e.g. out of memory)
   - `\0` terminator at end of input
 */
+HTSLIB_EXPORT
 char hts_json_token_type(hts_json_token *token);
 
 /// Accessor function to get JSON token in string form
@@ -98,6 +101,7 @@ will point at the kstring_t buffer passed as the third parameter to
 hts_json_fnext().  In that case, the value will only be valid until the
 next call to hts_json_fnext().
  */
+HTSLIB_EXPORT
 char *hts_json_token_str(hts_json_token *token);
 
 /// Read one JSON token from a string
@@ -111,6 +115,7 @@ is modified by having token-terminating characters overwritten as NULs.
 The `state` argument records the current position within `str` after each
 `hts_json_snext()` call, and should be set to 0 before the first call.
 */
+HTSLIB_EXPORT
 char hts_json_snext(char *str, size_t *state, hts_json_token *token);
 
 /// Read and discard a complete JSON value from a string
@@ -123,6 +128,7 @@ char hts_json_snext(char *str, size_t *state, hts_json_token *token);
 Skips a complete JSON value, which may be a single token or an entire object
 or array.
 */
+HTSLIB_EXPORT
 char hts_json_sskip_value(char *str, size_t *state, char type);
 
 struct hFILE;
@@ -137,6 +143,7 @@ The `kstr` buffer is used to store the string value of the token read,
 so `token->str` is only valid until the next time `hts_json_fnext()` is
 called with the same `kstr` argument.
 */
+HTSLIB_EXPORT
 char hts_json_fnext(struct hFILE *fp, hts_json_token *token, kstring_t *kstr);
 
 /// Read and discard a complete JSON value from a file
@@ -148,6 +155,7 @@ char hts_json_fnext(struct hFILE *fp, hts_json_token *token, kstring_t *kstr);
 Skips a complete JSON value, which may be a single token or an entire object
 or array.
 */
+HTSLIB_EXPORT
 char hts_json_fskip_value(struct hFILE *fp, char type);
 
 // The <ctype.h> functions operate on ints such as are returned by fgetc(),


### PR DESCRIPTION
Under mingw clang requires dllexport to be applied to both function
declarations and function definitions.  (Gcc is happy for the
definition only to have the dllexport attribute.)

Note this exports several "internal" functions, including some
apparently unused anywhere (hts_json_*).   Perhaps they were once used
in htslib-plugins, but no more.

I haven't taken the decision to remove these though, but it's worth
considering for whenever we next do an ABI breaking change.  Either
that or stop pretending that their internal only when clearly they are
not, and move their API to the external htslib/*.h files instead.
These appear to be somewhat in Limbo right now.

Fixes #1433