### PR TITLE
Fix NEWS entry for function affected by realn_check_tag() fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,10 +4,11 @@ Noteworthy changes in release a.b
 Noteworthy changes in release 1.15.1 (7th April 2022)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Security fix: Fixed broken error reporting in the sam_cap_mapq()
+* Security fix: Fixed broken error reporting in the sam_prob_realn()
   function, due to a missing hts_log() parameter.  Prior to this fix
-  it was possible to abuse the log message format string by passing
-  a specially crafted alignment record to this function. (PR#1406)
+  (i.e., in HTSlib versions 1.8 to 1.15) it was possible to abuse
+  the log message format string by passing a specially crafted
+  alignment record to this function. (PR#1406)
 
 * HTSlib now uses libhtscodecs release 1.2.2.  This fixes a number
   of bugs where invalid compressed data could trigger usage of


### PR DESCRIPTION
PR #1406 fixed which arguments were used as `printf()` format strings in `realn_check_tag()`, which is a subroutine of `sam_prob_realn()` (only). Correct the name of the function affected, and add a note of which HTSlib releases were affected: the problem was introduced in 5c401f2b9ab16ae71b45d3b5cb4717e3978e7fa0 and fixed in 7981bc9356899ea5dbf076d432e9645ee55df1d6 (on develop) / 328c3f5771695d32fcd7a9fc45899140879174d0 (on master & 1.15.1).

(FYI see also pysam-developers/pysam#1107 re effects of designating things “security fixes”. Sadly the second `hts_log()` instance fixed was indeed a potential issue.)