### PR TITLE
Fix curl type warning on Windows with gcc 12.1

### DIFF
--- a/hfile_s3_write.c
+++ b/hfile_s3_write.c
@@ -321,7 +321,7 @@ static int complete_upload(hFILE_s3_write *fp, kstring_t *resp) {
     curl_easy_reset(fp->curl);
     curl_easy_setopt(fp->curl, CURLOPT_POST, 1L);
     curl_easy_setopt(fp->curl, CURLOPT_POSTFIELDS, fp->completion_message.s);
-    curl_easy_setopt(fp->curl, CURLOPT_POSTFIELDSIZE, fp->completion_message.l);
+    curl_easy_setopt(fp->curl, CURLOPT_POSTFIELDSIZE, (long) fp->completion_message.l);
     curl_easy_setopt(fp->curl, CURLOPT_WRITEFUNCTION, response_callback);
     curl_easy_setopt(fp->curl, CURLOPT_WRITEDATA, (void *)resp);
     curl_easy_setopt(fp->curl, CURLOPT_URL, url.s);


### PR DESCRIPTION
`curl_easy_setopt(handle, CURLOPT_POSTFIELDSIZE, val)` takes a long, but was being passed a size_t.  This works on Linux where they're the same size for both 64 and 32-bit platforms, but not on 64-bit Windows which has 32-bit longs and 64-bit size_t.  We used to get away with it, but gcc 12.1 complains.

Casting the value to long should be fine.  The POST data is for the completion message which should not get that big due to the limit of 10000 parts when uploading data.