### PR TITLE
Cap hts_getline() return value at INT_MAX

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -1899,7 +1899,7 @@ int hts_getline(htsFile *fp, int delimiter, kstring_t *str)
     case no_compression:
         str->l = 0;
         ret = kgetline2(str, (kgets_func2 *) hgetln, fp->fp.hfile);
-        if (ret >= 0) ret = str->l;
+        if (ret >= 0) ret = (str->l <= INT_MAX)? (int) str->l : INT_MAX;
         else if (herrno(fp->fp.hfile)) ret = -2, errno = herrno(fp->fp.hfile);
         else ret = -1;
         break;

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -676,7 +676,7 @@ int hts_set_opt(htsFile *fp, enum hts_fmt_option opt, ...);
   @param fp         The file handle
   @param delimiter  Unused, but must be '\n' (or KS_SEP_LINE)
   @param str        The line (not including the terminator) is written here
-  @return           Length of the string read;
+  @return           Length of the string read (capped at INT_MAX);
                     -1 on end-of-file; <= -2 on error
 */
 HTSLIB_EXPORT

--- a/test/sam.c
+++ b/test/sam.c
@@ -1525,7 +1525,11 @@ static void test_text_file(const char *filename, int nexp)
     if (in) {
         kstring_t str = KS_INITIALIZE;
         int ret, n = 0;
-        while ((ret = hts_getline(in, '\n', &str)) >= 0) n++;
+        while ((ret = hts_getline(in, '\n', &str)) >= 0) {
+            size_t len = strlen(str.s);
+            n++;
+            if (ret != len) fail("hts_getline read length %d (expected %zu)", ret, len);
+        }
         if (ret != -1) fail("hts_getline got an error from %s", filename);
         if (n != nexp) fail("hts_getline read %d lines from %s (expected %d)", n, filename, nexp);
 


### PR DESCRIPTION
Something I noticed while writing a script to generate an enormous VCF record for #1447: the initial version of this generated a 2.5 GiB VCF record line, but `vcf_read()` failed to read it.

It turns out that `kgetline2()` (as used by `hts_getline()` for uncompressed input) reads such a line without trouble, but `hts_getline()` truncates the read string's length to `int` and returns negative — thus indicating error rather than a successfully read line.

This PR clamps the successful return value at `INT_MAX`. An alternative would be to change the return type to e.g. `ssize_t`, but this would have potential ABI implications perhaps…

In practice, no `hts_getline()` invocations in htslib, samtools, or bcftools use the length returned at all; they only use the return value to distinguish between success/EOF/error. Other third-party code potentially may use the length.

Also add to the existing basic `hts_getline()` tests In _test/sam.c_: check that the successful return value is indeed the expected length.