### PR TITLE
Detect ARM Neon support and only build appropriate SIMD object files

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -117,3 +117,4 @@ endif
 HTS_CFLAGS_AVX2 = @hts_cflags_avx2@
 HTS_CFLAGS_AVX512 = @hts_cflags_avx512@
 HTS_CFLAGS_SSE4 = @hts_cflags_sse4@
+HTS_HAVE_NEON = @hts_have_neon@

--- a/configure.ac
+++ b/configure.ac
@@ -127,6 +127,21 @@ AX_CHECK_COMPILE_FLAG([-mavx512f], [
     return *((char *) &b);
   ]])])
 
+dnl Detect ARM Neon availability
+AC_CACHE_CHECK([whether C compiler supports ARM Neon], [hts_cv_have_neon], [
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
+      #include "arm_neon.h"
+    ]], [[
+      int32x4_t a = vdupq_n_s32(1);
+      int32x4_t b = vaddq_s32(a, a);
+      return *((char *) &b);
+    ]])], [hts_cv_have_neon=yes], [hts_cv_have_neon=no])])
+if test "$hts_cv_have_neon" = yes; then
+  hts_have_neon=yes
+  AC_SUBST([hts_have_neon])
+fi
+
 
 dnl Avoid chicken-and-egg problem where pkg-config supplies the
 dnl PKG_PROG_PKG_CONFIG macro, but we want to use it to check

--- a/hts_probe_cc.sh
+++ b/hts_probe_cc.sh
@@ -95,4 +95,19 @@ if run_compiler "$FLAGS" ; then
     echo "HTS_CFLAGS_AVX512 = $FLAGS"
 fi
 
+# Check for neon
+
+rm -f conftest.c
+cat - <<'EOF' > conftest.c
+#include "arm_neon.h"
+int main(int argc, char **argv) {
+    int32x4_t a = vdupq_n_s32(1);
+    int32x4_t b = vaddq_s32(a, a);
+    return *((char *) &b);
+}
+EOF
+if run_compiler "" ; then
+    echo "HTS_HAVE_NEON = yes"
+fi
+
 rm -f conftest.c

--- a/htscodecs_bundled.mk
+++ b/htscodecs_bundled.mk
@@ -28,9 +28,10 @@ HTSCODECS_SOURCES = $(HTSPREFIX)htscodecs/htscodecs/arith_dynamic.c \
         $(HTSPREFIX)htscodecs/htscodecs/htscodecs.c \
         $(HTSPREFIX)htscodecs/htscodecs/pack.c \
         $(HTSPREFIX)htscodecs/htscodecs/rANS_static4x16pr.c \
-	$(HTSPREFIX)htscodecs/htscodecs/rANS_static32x16pr_avx2.c \
-	$(HTSPREFIX)htscodecs/htscodecs/rANS_static32x16pr_avx512.c \
-	$(HTSPREFIX)htscodecs/htscodecs/rANS_static32x16pr_sse4.c \
+	$(if $(HTS_CFLAGS_AVX2),$(HTSPREFIX)htscodecs/htscodecs/rANS_static32x16pr_avx2.c) \
+	$(if $(HTS_CFLAGS_AVX512),$(HTSPREFIX)htscodecs/htscodecs/rANS_static32x16pr_avx512.c) \
+	$(if $(HTS_CFLAGS_SSE4),$(HTSPREFIX)htscodecs/htscodecs/rANS_static32x16pr_sse4.c) \
+	$(if $(HTS_HAVE_NEON),$(HTSPREFIX)htscodecs/htscodecs/rANS_static32x16pr_neon.c) \
 	$(HTSPREFIX)htscodecs/htscodecs/rANS_static32x16pr.c \
         $(HTSPREFIX)htscodecs/htscodecs/rANS_static.c \
         $(HTSPREFIX)htscodecs/htscodecs/rle.c \


### PR DESCRIPTION
Add test compilations to detect ARM Neon support to _configure.ac_ and _hts_probe_cc.sh_. If compiler support is present, add _rANS_static32x16pr_neon.c_ to `$(HTSCODECS_SOURCES)` in _htscodecs_bundled.mk_. Fixes #1450.

Similarly only add _rANS_static32x16pr_avx2.c_ et al to `$(HTSCODECS_SOURCES)` if the respective AVX2, AVX512, SSE4 support is present. As building these files already uses GNU Make-specific constructs (namely target-specific variables in _Makefile_) and the `$(HTS_CFLAGS_AVX2)` Make variables already exist and are either empty or a non-empty option string, this is easily achieved via `$(if $(HTS_CFLAGS_AVX2),...)`.

There is no compiler flag required for Neon, so invent `HTS_HAVE_NEON` and use it to control building _rANS_static32x16pr_neon.c_ without adding any bespoke compilation options for it.