### PR TITLE
skip trailing tabs in vcf header and emit a warning

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -156,6 +156,13 @@ int HTS_RESULT_USED bcf_hdr_parse_sample_line(bcf_hdr_t *hdr, const char *str)
     if ( !*beg || *beg=='\n' ) return 0;
     if ( strncmp(beg,"\tFORMAT\t",8) )
     {
+        /* skip trailing tabs */
+        while ( *beg == '\t' ) beg++;
+        if ( !*beg || *beg=='\n' )
+        {
+            hts_log_warning("Ignoring trailing tab(s) in VCF header:\n\t%s",str);
+            return 0;
+        }
         hts_log_error("Could not parse the \"#CHROM..\" line, either FORMAT is missing or spaces are present instead of tabs:\n\t%s",str);
         return -1;
     }


### PR DESCRIPTION
We use an old vcf from the broad institute.

The current htslib doesn't like the old vcf header because there is a `\t` after `INFO`.

```
 wget -O - -q "https://data.broadinstitute.org/snowman/hg19/variant_calling/vqsr_resources/WGS/v1/dbsnp_135.b37.vcf.gz" | ./bcftools view --header-only > /dev/null 
[E::bcf_hdr_parse_sample_line] Could not parse the "#CHROM.." line, either FORMAT is missing or spaces are present instead of tabs:
	#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	

Failed to read from standard input: could not parse header

```

my PR tolerates those tabs and displays a warning.

```
$ wget -O - -q "https://data.broadinstitute.org/snowman/hg19/variant_calling/vqsr_resources/WGS/v1/dbsnp_135.b37.vcf.gz" | ./bcftools view --header-only > /dev/null 
[W::bcf_hdr_parse_sample_line] Ignoring trailing tab(s) in VCF header:
	#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	

```
