### PR TITLE
Set tab delimiter in manpage for tabix GFF3 sort

### DIFF
--- a/tabix.1
+++ b/tabix.1
@@ -169,7 +169,7 @@ The default is 3, which turns on error and warning messages;
 Values higher than 3 produce additional informational and debugging messages.
 .PP
 .SH EXAMPLE
-(grep ^"#" in.gff; grep -v ^"#" in.gff | sort -k1,1 -k4,4n) | bgzip > sorted.gff.gz;
+(grep ^"#" in.gff; grep -v ^"#" in.gff | sort -t$'\t' -k1,1 -k4,4n) | bgzip > sorted.gff.gz;
 
 tabix -p gff sorted.gff.gz;
 

--- a/tabix.1
+++ b/tabix.1
@@ -169,7 +169,7 @@ The default is 3, which turns on error and warning messages;
 Values higher than 3 produce additional informational and debugging messages.
 .PP
 .SH EXAMPLE
-(grep ^"#" in.gff; grep -v ^"#" in.gff | sort -t$'\t' -k1,1 -k4,4n) | bgzip > sorted.gff.gz;
+(grep "^#" in.gff; grep -v "^#" in.gff | sort -t"`printf '\t'`" -k1,1 -k4,4n) | bgzip > sorted.gff.gz;
 
 tabix -p gff sorted.gff.gz;
 

--- a/tabix.1
+++ b/tabix.1
@@ -169,7 +169,7 @@ The default is 3, which turns on error and warning messages;
 Values higher than 3 produce additional informational and debugging messages.
 .PP
 .SH EXAMPLE
-(grep "^#" in.gff; grep -v "^#" in.gff | sort -t"`printf '\t'`" -k1,1 -k4,4n) | bgzip > sorted.gff.gz;
+(grep "^#" in.gff; grep -v "^#" in.gff | sort -t"`printf '\(rst'`" -k1,1 -k4,4n) | bgzip > sorted.gff.gz;
 
 tabix -p gff sorted.gff.gz;
 


### PR DESCRIPTION
This can help if there are spaces in the GFF3 file e.g. in column 2 or 3. Was found in the wild by my co-worker on a gff file here https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/002/285/GCF_000002285.3_CanFam3.1/GCF_000002285.3_CanFam3.1_genomic.gff.gz

Another alternative but similar command is

```
awk '$1 ~ /^#/ {print $0;next} {print $0 | "sort -t\"\t\" -k1,1 -k4,4n"}' file.gff > file.sorted.gff

```

But, the PR here keeps it as is