### PR TITLE
Remove `RANLIB`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@
 
 CC     = gcc
 AR     = ar
-RANLIB = ranlib
 
 # Default libraries to link if configure is not used
 htslib_default_libs = -lz -lm -lbz2 -llzma -lcurl
@@ -319,8 +318,7 @@ plugins: $(BUILT_PLUGINS)
 
 libhts.a: $(LIBHTS_OBJS)
 	@-rm -f $@
-	$(AR) -rc $@ $(LIBHTS_OBJS)
-	-$(RANLIB) $@
+	$(AR) -rcs $@ $(LIBHTS_OBJS)
 
 print-config:
 	@echo LDFLAGS = $(LDFLAGS)

--- a/config.mk.in
+++ b/config.mk.in
@@ -38,7 +38,6 @@ datarootdir  = @datarootdir@
 mandir       = @mandir@
 
 CC     = @CC@
-RANLIB = @RANLIB@
 
 CPPFLAGS = @CPPFLAGS@
 CFLAGS   = @CFLAGS@

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,6 @@ EOF
    AC_MSG_ERROR([$1], [$2])])
 
 AC_PROG_CC
-AC_PROG_RANLIB
 
 dnl Turn on compiler warnings, if possible
 HTS_PROG_CC_WARNINGS


### PR DESCRIPTION
* `ar` is guaranteed to generate the symbol table on POSIX:
  - https://stackoverflow.com/a/38244200
  - https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ar.html
  - We invoke `ar` with `-s` to force generation of the symbol table on OSes where this isn't the default behaviour (old BSD).