### PR TITLE
Make hfile_s3 refresh AWS credentials on expiry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ shlib-exports-*.txt
 /test/test_realn
 /test/test-regidx
 /test/test_str2int
+/test/test_time_funcs
 /test/test-vcf-api
 /test/test-vcf-sweep
 /test/test_view

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ BUILT_TEST_PROGRAMS = \
 	test/test_realn \
 	test/test-regidx \
 	test/test_str2int \
+	test/test_time_funcs \
 	test/test_view \
 	test/test_index \
 	test/test-vcf-api \
@@ -234,6 +235,7 @@ bcf_sr_sort_h = bcf_sr_sort.h $(htslib_synced_bcf_reader_h) $(htslib_kbitset_h)
 header_h = header.h cram/string_alloc.h cram/pooled_alloc.h $(htslib_khash_h) $(htslib_kstring_h) $(htslib_sam_h)
 hfile_internal_h = hfile_internal.h $(htslib_hts_defs_h) $(htslib_hfile_h) $(textutils_internal_h)
 hts_internal_h = hts_internal.h $(htslib_hts_h) $(textutils_internal_h)
+hts_time_funcs_h = hts_time_funcs.h config.h
 sam_internal_h = sam_internal.h $(htslib_sam_h)
 textutils_internal_h = textutils_internal.h $(htslib_kstring_h)
 thread_pool_internal_h = thread_pool_internal.h $(htslib_thread_pool_h)
@@ -421,7 +423,7 @@ hfile.o hfile.pico: hfile.c config.h $(htslib_hfile_h) $(hfile_internal_h) $(hts
 hfile_gcs.o hfile_gcs.pico: hfile_gcs.c config.h $(htslib_hts_h) $(htslib_kstring_h) $(hfile_internal_h)
 hfile_libcurl.o hfile_libcurl.pico: hfile_libcurl.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_s3_write.o hfile_s3_write.pico: hfile_s3_write.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
-hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h)
+hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(hts_time_funcs_h)
 hts.o hts.pico: hts.c config.h os/lzma_stub.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_hts_endian_h) version.h config_vars.h $(hts_internal_h) $(hfile_internal_h) $(sam_internal_h) $(htslib_hts_expr_h) $(htslib_hts_os_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h) $(htslib_tbx_h) $(htscodecs_htscodecs_h)
 hts_expr.o hts_expr.pico: hts_expr.c config.h $(htslib_hts_expr_h) $(textutils_internal_h)
 hts_os.o hts_os.pico: hts_os.c config.h $(htslib_hts_defs_h) os/rand.c
@@ -563,6 +565,7 @@ check test: $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS) $(BUILT_PLUGINS) $(HTSCODEC
 	test/test_kfunc
 	test/test_kstring
 	test/test_str2int
+	test/test_time_funcs
 	test/fieldarith test/fieldarith.sam
 	test/hfile
 	HTS_PATH=. test/with-shlib.sh test/plugins-dlhts -g ./libhts.$(SHLIB_FLAVOUR)
@@ -628,6 +631,9 @@ test/test-parse-reg: test/test-parse-reg.o libhts.a
 
 test/test_str2int: test/test_str2int.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_str2int.o libhts.a $(LIBS) -lpthread
+
+test/test_time_funcs: test/test_time_funcs.o
+	$(CC) $(LDFLAGS) -o $@ test/test_time_funcs.o
 
 test/test_view: test/test_view.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_view.o libhts.a $(LIBS) -lpthread
@@ -720,6 +726,7 @@ test/test-parse-reg.o: test/test-parse-reg.c config.h $(htslib_hts_h) $(htslib_s
 test/test_realn.o: test/test_realn.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h)
 test/test-regidx.o: test/test-regidx.c config.h $(htslib_kstring_h) $(htslib_regidx_h) $(htslib_hts_defs_h) $(textutils_internal_h)
 test/test_str2int.o: test/test_str2int.c config.h $(textutils_internal_h)
+test/test_time_funcs.o: test/test_time_funcs.c $(htslib_time_funcs_h)
 test/test_view.o: test/test_view.c config.h $(cram_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_hts_log_h)
 test/test_index.o: test/test_index.c config.h $(htslib_sam_h) $(htslib_vcf_h)
 test/test-vcf-api.o: test/test-vcf-api.c config.h $(htslib_hts_h) $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_kseq_h)

--- a/hts_time_funcs.h
+++ b/hts_time_funcs.h
@@ -1,0 +1,167 @@
+/*  hts_time_funcs.h -- Implementations of non-standard time functions
+
+    Copyright (C) 2022 Genome Research Ltd.
+
+    Author: Rob Davies <rmd@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+/*
+  This mainly exists because timegm() is not a standard function, and so
+  Cannot be used in portable code.  Unfortunately the standard one (mktime)
+  always takes the local timezone into accout so doing a UTC conversion
+  with it involves changing the TZ environment variable, which is rather
+  messy and not likely to go well with threaded code.
+
+  The code here is a much simplified version of the BSD timegm() implementation.
+  It currently rejects dates before 1970, avoiding problems with -ve time_t.
+  It also works strictly in UTC, so doesn't have to worry about tm_isdst
+  which makes the calculation much easier.
+
+  Some of this is derived from BSD sources, for example
+  https://github.com/NetBSD/src/blob/trunk/lib/libc/time/localtime.c
+  which state:
+
+  ** This file is in the public domain, so clarified as of
+  ** 1996-06-05 by Arthur David Olson.
+
+  Non-derived code is copyright as above.
+*/
+
+#include <config.h>
+
+static inline int hts_time_normalise(int *tens, int *units, int base) {
+    if (*units < 0 || *units >= base) {
+        int delta = *units >= 0 ? *units / base : (-1 - (-1 - *units) / base);
+        int64_t tmp = (int64_t) (*tens) + delta;
+        if (tmp < INT_MIN || tmp > INT_MAX) return 1;
+        *tens = tmp;
+        *units -= delta * base;
+    }
+    return 0;
+}
+
+static inline int hts_year_is_leap(int64_t year) {
+    return ((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0);
+}
+
+// Number of leap years to start of year
+// Only works for year >= 1.
+static inline int64_t hts_leaps_to_year_start(int64_t year) {
+    --year;
+    return year / 4 - year / 100 + year / 400;
+}
+
+static inline int hts_time_normalise_tm(struct tm *t)
+{
+    const int days_per_mon[2][12] = {
+        { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 },
+        { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
+    };
+    const int year_days[2] = { 365, 366 };
+    int overflow = 0;
+    int64_t year;
+
+    if (t->tm_sec > 62) {
+        overflow |= hts_time_normalise(&t->tm_min, &t->tm_sec, 60);
+    }
+    overflow |= hts_time_normalise(&t->tm_hour, &t->tm_min,  60);
+    overflow |= hts_time_normalise(&t->tm_mday, &t->tm_hour, 24);
+    overflow |= hts_time_normalise(&t->tm_year, &t->tm_mon,  12);
+    if (overflow)
+        return 1;
+
+    year = (int64_t) t->tm_year + 1900LL;
+    while (t->tm_mday <= 0) {
+        --year;
+        t->tm_mday += year_days[hts_year_is_leap(year + (1 < t->tm_mon))];
+    }
+    while (t->tm_mday > 366) {
+        t->tm_mday -= year_days[hts_year_is_leap(year + (1 < t->tm_mon))];
+        ++year;
+    }
+    for (;;) {
+        int mdays = days_per_mon[hts_year_is_leap(year)][t->tm_mon];
+        if (t->tm_mday <= mdays)
+            break;
+        t->tm_mday -= mdays;
+        t->tm_mon++;
+        if (t->tm_mon >= 12) {
+            year++;
+            t->tm_mon = 0;
+        }
+    }
+    year -= 1900;
+    if (year != t->tm_year) {
+        if (year < INT_MIN || year > INT_MAX)
+            return 1;
+        t->tm_year = year;
+    }
+    return 0;
+}
+
+/**
+ *  Convert broken-down time to an equivalent time_t value
+ *  @param target  Target broken-down time structure
+ *  @return Equivalent time_t value on success; -1 on failure
+ *
+ *  This function first normalises the time in @p target so that the
+ *  structure members are in the valid range.  It then calculates the
+ *  number of seconds (ignoring leap seconds) between midnight Jan 1st 1970
+ *  and the target date.
+ *
+ *  If @p target is outside the range that can be represented in a time_t,
+ *  or tm_year is less than 70 (which would return a negative value) then
+ *  it returns -1 and sets errno to EOVERFLOW.
+ */
+
+static inline time_t hts_time_gm(struct tm *target)
+{
+    int month_start[2][12] = {
+        { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 },
+        { 0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335 }
+    };
+    int years_from_epoch, leaps, days;
+    int64_t secs;
+
+    if (hts_time_normalise_tm(target) != 0)
+        goto overflow;
+
+    if (target->tm_year < 70)
+        goto overflow;
+
+    years_from_epoch = target->tm_year - 70;
+    leaps = (hts_leaps_to_year_start(target->tm_year + 1900)
+        - hts_leaps_to_year_start(1970));
+    days = ((365 * (years_from_epoch - leaps) + 366 * leaps)
+        + month_start[hts_year_is_leap(target->tm_year + 1900)][target->tm_mon]
+        + target->tm_mday - 1);
+    secs = ((int64_t) days * 86400LL
+        + target->tm_hour * 3600
+        + target->tm_min * 60
+        + target->tm_sec);
+    if (sizeof(time_t) < 8 && secs > INT_MAX)
+        goto overflow;
+
+    return (time_t) secs;
+
+ overflow:
+    errno = EOVERFLOW;
+    return (time_t) -1;
+}

--- a/htslib-s3-plugin.7
+++ b/htslib-s3-plugin.7
@@ -24,6 +24,21 @@ s3 plugin \- htslib AWS S3 plugin
 .\" FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 .\" DEALINGS IN THE SOFTWARE.
 .\"
+.
+.\" For code blocks and examples (cf groff's Ultrix-specific man macros)
+.de EX
+
+.  in +\\$1
+.  nf
+.  ft CR
+..
+.de EE
+.  ft
+.  fi
+.  in
+
+..
+
 .SH DESCRIPTION
 The S3 plugin allows htslib file functions to communicate with servers that use
 the AWS S3 protocol.  Files are identified by their bucket and object key in a
@@ -114,13 +129,72 @@ files will be used.  The default file locations are either
 \fI~/.aws/credentials\fR or \fI~/.s3cfg\fR (in that order).
 
 Entries used in aws style credentials file are aws_access_key_id, 
-aws_secret_access_key, aws_session_token, region and addressing_style.  Only the
-first two are usually needed.
+aws_secret_access_key, aws_session_token, region, addressing_style and
+expiry_time (unofficial, see SHORT-LIVED CREDENTIALS below).
+Only the first two are usually needed.
 
 Entries used in s3cmd style config files are access_key, secret_key,
 access_token, host_base, bucket_location and host_bucket. Again only the first
 two are usually needed. The host_bucket option is only used to set a path-style
 URL, see below.
+
+.SH SHORT-LIVED CREDENTIALS
+
+Some cloud identity and access management (IAM) systems can make short-lived
+credentials that allow access to resources.
+These credentials will expire after a time and need to be renewed to
+give continued access.
+To enable this, the S3 plugin allows an \fIexpiry_time\fR entry to be set in the
+\fI.aws/credentials\fR file.
+The value for this entry should be the time when the token expires,
+following the format in RFC3339 section 5.6, which takes the form:
+
+   2012-04-29T05:20:48Z
+
+That is, year - month - day, the letter "T", hour : minute : second.
+The time can be followed by the letter "Z", indicating the UTC timezone,
+or an offset from UTC which is a "+" or "-" sign followed by two digits for
+the hours offset, ":", and two digits for the minutes.
+
+The S3 plugin will attempt to re-read the credentials file up to 1 minute
+before the given expiry time, which means the file needs to be updated with
+new credentials before then.
+As the exact way of doing this can vary between services and IAM providers,
+the S3 plugin expects this to be done by an external user-supplied process.
+This may be achieved by running a program that replaces the file as new
+credentials become available.
+The following script shows how it might be done for AWS instance credentials:
+.EX 2
+#!/bin/sh
+instance='http://169.254.169.254'
+tok_url="$instance/latest/api/token"
+ttl_hdr='X-aws-ec2-metadata-token-ttl-seconds: 10'
+creds_url="$instance/latest/meta-data/iam/security-credentials"
+key1='aws_access_key_id = \(rs(.AccessKeyId)\(rsn'
+key2='aws_secret_access_key = \(rs(.SecretAccessKey)\(rsn'
+key3='aws_session_token = \(rs(.Token)\(rsn'
+key4='expiry_time = \(rs(.Expiration)\(rsn'
+while true; do
+    token=`curl -X PUT -H "$ttl_hdr" "$tok_url"`
+    tok_hdr="X-aws-ec2-metadata-token: $token"
+    role=`curl -H "$tok_hdr" "$creds_url/"`
+    expires='now'
+    ( curl -H "$tok_hdr" "$creds_url/$role" \(rs
+      | jq -r "\(rs"${key1}${key2}${key3}${key4}\(rs"" > credentials.new ) \(rs
+      && mv -f credentials.new credentials \(rs
+      && expires=`grep expiry_time credentials | cut -d ' ' -f 3-`
+    if test $? -ne 0 ; then break ; fi
+    expiry=`date -d "$expires - 3 minutes" '+%s'`
+    now=`date '+%s'`
+    test "$expiry" -gt "$now" && sleep $((($expiry - $now) / 2))
+    sleep 30
+done
+.EE
+
+Note that the \fIexpiry_time\fR key is currently only supported for the
+\fI.aws/credentials\fR file (or the file referred to in the
+.B AWS_SHARED_CREDENTIALS_FILE
+environment variable).
 
 .SH NOTES
 In most cases this plugin transforms the given URL into a virtual host-style
@@ -135,5 +209,7 @@ host_bucket must \fBnot\fR include the \fB%(bucket).s\fR string.
 .SH "SEE ALSO"
 .BR htsfile (1)
 .BR samtools (1)
+.PP
+RFC 3339: <https://www.rfc-editor.org/rfc/rfc3339#section-5.6>
 .PP
 htslib website: <http://www.htslib.org/>

--- a/test/test_time_funcs.c
+++ b/test/test_time_funcs.c
@@ -1,0 +1,122 @@
+/*  test_time_compat.c -- Test time functions
+
+    Copyright (C) 2022 Genome Research Ltd.
+
+    Author: Rob Davies <rmd@sanger.ac.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <errno.h>
+#include <time.h>
+
+#include "../hts_time_funcs.h"
+
+int test_normalised(time_t start, time_t end, time_t incr) {
+    time_t i, j;
+    struct tm *utc;
+
+    for (i = start; i < end; i += incr) {
+        utc = gmtime(&i);
+        j = hts_time_gm(utc);
+        if (i != j) {
+            fprintf(stderr,
+                    "hts_time_gm() failed, got %"PRId64" expected %"PRId64"\n",
+                    (int64_t) j, (int64_t) i);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int test_specific(int year, int mon, int mday, int hour, int min, int sec,
+                  time_t expected) {
+    struct tm utc = { sec, min, hour, mday, mon - 1, year - 1900, 0, 0, 0 };
+    time_t res = hts_time_gm(&utc);
+    if (res != expected) {
+        fprintf(stderr,
+                "hts_time_gm() failed for %4d/%02d/%02d %02d:%02d:%02d :"
+                " got %"PRId64" expected %"PRId64"\n",
+                year, mon, mday, hour, min, sec,
+                (int64_t) res, (int64_t) expected);
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    int res = 0;
+
+    if (test_normalised(0, INT_MAX - 1000, 1000) != 0)
+        return EXIT_FAILURE;
+    if (sizeof(time_t) >= 8) {
+        if (test_normalised(INT_MAX - 1000, (time_t) INT_MAX * 2, 1000) != 0)
+            return EXIT_FAILURE;
+    }
+
+    // 2022-06-14 12:32:10
+    res |= test_specific(2022, 6, 14, 12, 32, 10, 1655209930);
+    // 2022-06-14 12:32:10
+    res |= test_specific(1993, 9, 10514, 12, 32, 10, 1655209930);
+    // 2022-02-28 12:00:00
+    res |= test_specific(2020, 2, 28, 12, 0, 0, 1582891200);
+    // 2022-02-29 12:00:00
+    res |= test_specific(2020, 2, 29, 12, 0, 0, 1582977600);
+    // 2022-03-01 12:00:00
+    res |= test_specific(2020, 2, 30, 12, 0, 0, 1583064000);
+    // 2022-02-29 12:00:00
+    res |= test_specific(2020, 3, 0, 12, 0, 0, 1582977600);
+    // 2020-02-01 12:00:00
+    res |= test_specific(2019, 14, 1, 12, 0, 0, 1580558400);
+    // 2020-03-01 12:00:00
+    res |= test_specific(2019, 15, 1, 12, 0, 0, 1583064000);
+    // 2021-03-01 12:00:00
+    res |= test_specific(2019, 27, 1, 12, 0, 0, 1614600000);
+    // 2024-02-01 12:00:00
+    res |= test_specific(2019, 62, 1, 12, 0, 0, 1706788800);
+    // 2024-03-01 12:00:00
+    res |= test_specific(2019, 63, 1, 12, 0, 0, 1709294400);
+    // 2020-12-31 23:59:59
+    res |= test_specific(2021, 0, 31, 23, 59, 59, 1609459199);
+    // 2020-03-01 12:00:00
+    res |= test_specific(2021, -9, 1, 12, 0, 0, 1583064000);
+    // 2020-02-01 12:00:00
+    res |= test_specific(2021, -10, 1, 12, 0, 0, 1580558400);
+    // 2019-02-01 12:00:00
+    res |= test_specific(2021, -22, 1, 12, 0, 0, 1549022400);
+    // 1970-01-01 00:00:00
+    res |= test_specific(1970, 1, 1, 0, 0, 0, 0);
+    // 2038-01-19 03:14:07
+    res |= test_specific(1970, 1, 1, 0, 0, INT_MAX, INT_MAX);
+    // 2038-01-19 03:14:07
+    res |= test_specific(2038, 1, 19, 3, 14, 7, INT_MAX);
+    if (sizeof(time_t) < 8) {
+        // 2038-01-19 03:14:08
+        res |= test_specific(2038, 1, 19, 3, 14, 8, (time_t) -1);
+    } else {
+        // 2038-01-19 03:14:08
+        res |= test_specific(2038, 1, 19, 3, 14, 8, (time_t) INT_MAX + 1);
+    }
+
+    return res == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
This is to make HTSlib work better with AWS IAM credentials, which have a limited lifespan, and so may need to be refreshed. To allow this, hfile_s3 is made to look for an unofficial `expiry_time` entry in the `AWS_SHARED_CREDENTIALS_FILE`.  If present, the file will be re-read if the current time is within one minute of the given expiry (new credentails are available five minutes before expiry, according to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html, and in practice much earlier).

Currently no effort is made to understand the JSON format emitted by the AWS security-credentials endpoint - mainly because there are several ways to get credentials, which all have subtle differences.  Rather than try to support them all, it's left up to the end user to reformat the credentials into the style of the normal '.aws/credentials' file.  An example of how this can be done for one source of credentials on AWS is added to the manual page.

Fixes a bug where parse_ini would append to rather than replace existing values.

Moves x-amz-security-token to the set of headers updated via callback, as it can now change when the credentials are updated.

Includes an implementation of the timegm() function, which is not portable (e.g. mingw doesn't have it) but needed to convert the expiry time to a time_t.  This is put in a separate header so that it can be more easily reused elsewhere if we want. Includes tests to check that details like leap years and normalisation work properly.