### PR TITLE
Don't use `register` in public header file [trivial]

### DIFF
--- a/htslib/ksort.h
+++ b/htslib/ksort.h
@@ -88,7 +88,7 @@ typedef struct {
 	int depth;
 } ks_isort_stack_t;
 
-#define KSORT_SWAP(type_t, a, b) { register type_t t=(a); (a)=(b); (b)=t; }
+#define KSORT_SWAP(type_t, a, b) { type_t t=(a); (a)=(b); (b)=t; }
 
 #define KSORT_INIT(name, type_t, __sort_lt)	KSORT_INIT_(_ ## name, , type_t, __sort_lt)
 #define KSORT_INIT_STATIC(name, type_t, __sort_lt)	KSORT_INIT_(_ ## name, static klib_unused, type_t, __sort_lt)


### PR DESCRIPTION
The `register` storage class specifier was deprecated in C++11. and has been removed in C++17. The following C++ program:

```c++
#include "htslib/ksort.h"
KSORT_INIT_GENERIC(int)
```

produces numerous warnings with both GCC (by default) and Clang (with `-std=c++11`):

```
$ g++ -c use-ksort.cpp 
In file included from use-ksort.cpp:1:
use-ksort.cpp: In function 'int ks_ksmall_int(size_t, int*, size_t)':
htslib/ksort.h:91:52: warning: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
   91 | #define KSORT_SWAP(type_t, a, b) { register type_t t=(a); (a)=(b); (b)=t; }
      |                                                    ^
htslib/ksort.h:263:61: note: in expansion of macro 'KSORT_SWAP'
  263 |                                 if (__sort_lt(*high, *low)) KSORT_SWAP(type_t, *low, *high); \
      |                                                             ^~~~~~~~~~
[…etc…]
```

&nbsp;
and these become errors with `clang++ -std=c++17`.

HTSlib itself is a C project so is unaffected, but this header may be used from third-party C++ projects.

(This is the only remaining instance of `register` in HTSlib, in both headers and source files.)