### PR TITLE
Extend VCF API to distinguish between INS and DEL variant types

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,7 +121,7 @@ ubuntu_task:
 rocky_task:
   name: rockylinux-gcc
   container:
-    image: rockylinux:latest
+    image: rockylinux:9
     cpu: 2
     memory: 1G
 
@@ -133,9 +133,9 @@ rocky_task:
   # NB: we could consider building a docker image with these
   # preinstalled and specifying that instead, to speed up testing.
   install_script: |
-    yum install -y autoconf automake make gcc perl-Data-Dumper zlib-devel \
-        bzip2 bzip2-devel xz-devel curl-devel openssl-devel ncurses-devel \
-        diffutils git
+    yum install -y autoconf automake make gcc perl-Data-Dumper perl-FindBin \
+        zlib-devel bzip2 bzip2-devel xz-devel curl-devel openssl-devel \
+        ncurses-devel diffutils git
 
   << : *COMPILE
   << : *TEST

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -138,13 +138,16 @@ extern uint8_t bcf_type_shift[];
 #define BCF_BT_FLOAT    5
 #define BCF_BT_CHAR     7
 
-#define VCF_REF      0
-#define VCF_SNP      1
-#define VCF_MNP      2
-#define VCF_INDEL    4
-#define VCF_OTHER    8
-#define VCF_BND     16    // breakend
-#define VCF_OVERLAP 32    // overlapping deletion, ALT=*
+#define VCF_REF         0
+#define VCF_SNP     (1<<0)
+#define VCF_MNP     (1<<1)
+#define VCF_INDEL   (1<<2)
+#define VCF_OTHER   (1<<3)
+#define VCF_BND     (1<<4)      // breakend
+#define VCF_OVERLAP (1<<5)      // overlapping deletion, ALT=*
+#define VCF_INS     (1<<6)      // implies VCF_INDEL
+#define VCF_DEL     (1<<7)      // implies VCF_INDEL
+#define VCF_ANY     (VCF_SNP|VCF_MNP|VCF_INDEL|VCF_OTHER|VCF_BND|VCF_OVERLAP|VCF_INS|VCF_DEL)       // any variant type (but not VCF_REF)
 
 typedef struct bcf_variant_t {
     int type, n;    // variant type and the number of bases affected, negative for deletions
@@ -751,13 +754,26 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     int bcf_translate(const bcf_hdr_t *dst_hdr, bcf_hdr_t *src_hdr, bcf1_t *src_line);
 
     /**
-     *  bcf_get_variant_type[s]()  - returns one of VCF_REF, VCF_SNP, etc
+     *  bcf_get_variant_type[s]()  - returns one of VCF_REF, VCF_SNP, etc. (DEPRECATED)
+     *  bcf_has_variant_type[s]()  - the preferred way to query the presence of variant types
+     *  @bitmask:   combination of VCF_* variant type above, VCF_INDEL implies VCF_INS|VCF_DEL
+     *  @mode:      `exact` for an exact match, `overlap` for at least one matching variant,
+     *              `subset` for the listed variants only
      */
     HTSLIB_EXPORT
     int bcf_get_variant_types(bcf1_t *rec);
 
     HTSLIB_EXPORT
     int bcf_get_variant_type(bcf1_t *rec, int ith_allele);
+
+    enum bcf_variant_match { exact, overlap, subset };
+
+    HTSLIB_EXPORT
+    int bcf_has_variant_types(bcf1_t *rec, int bitmask, enum bcf_variant_match mode);
+
+    HTSLIB_EXPORT
+    int bcf_has_variant_type(bcf1_t *rec, int ith_allele, int bitmask, enum bcf_variant_match mode);
+
 
     HTSLIB_EXPORT
     int bcf_is_snp(bcf1_t *v);

--- a/test/test-bcf_set_variant_type.c
+++ b/test/test-bcf_set_variant_type.c
@@ -46,19 +46,19 @@ static void test_bcf_set_variant_type()
     bcf_set_variant_type("A", "T", &var1);
     if ( var1.type != VCF_SNP)
     {
-        error("A -> T was not detected as a breakend");
+        error("A -> T was not detected as a SNP");
     }
 
     // Test INDEL
     bcf_variant_t var2a;
     bcf_set_variant_type("A", "AA", &var2a);
-    if ( var2a.type != VCF_INDEL)
+    if ( var2a.type != (VCF_INDEL|VCF_INS) )
     {
         error("A -> AA was not detected as an INDEL");
     }
     bcf_variant_t var2b;
     bcf_set_variant_type("AA", "A", &var2b);
-    if ( var2b.type != VCF_INDEL)
+    if ( var2b.type != (VCF_INDEL|VCF_DEL) )
     {
         error("AA -> A was not detected as a INDEL");
     }

--- a/vcf.c
+++ b/vcf.c
@@ -4254,14 +4254,14 @@ static int bcf_set_variant_types(bcf1_t *b)
 int bcf_get_variant_types(bcf1_t *rec)
 {
     if ( rec->d.var_type==-1 ) bcf_set_variant_types(rec);
-    return rec->d.var_type;
+    return rec->d.var_type & ~(VCF_INS|VCF_DEL);
 }
 int bcf_get_variant_type(bcf1_t *rec, int ith_allele)
 {
     if ( rec->d.var_type==-1 ) bcf_set_variant_types(rec);
-    return rec->d.var[ith_allele].type;
+    return rec->d.var[ith_allele].type & ~(VCF_INS|VCF_DEL);
 }
-inline static int _has_variant_type(int type, int bitmask, enum bcf_variant_match mode)
+inline static int has_variant_type(int type, int bitmask, enum bcf_variant_match mode)
 {
     if ( mode==overlap ) return type & bitmask;
 
@@ -4279,11 +4279,13 @@ inline static int _has_variant_type(int type, int bitmask, enum bcf_variant_matc
 }
 int bcf_has_variant_type(bcf1_t *rec, int ith_allele, int bitmask, enum bcf_variant_match mode)
 {
-    return _has_variant_type(bcf_get_variant_type(rec, ith_allele), bitmask, mode);
+    if ( rec->d.var_type==-1 ) bcf_set_variant_types(rec);
+    return has_variant_type(rec->d.var[ith_allele].type, bitmask, mode);
 }
 int bcf_has_variant_types(bcf1_t *rec, int bitmask, enum bcf_variant_match mode)
 {
-    return _has_variant_type(bcf_get_variant_types(rec), bitmask, mode);
+    if ( rec->d.var_type==-1 ) bcf_set_variant_types(rec);
+    return has_variant_type(rec->d.var_type, bitmask, mode);
 }
 
 int bcf_update_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key, const void *values, int n, int type)

--- a/vcf.c
+++ b/vcf.c
@@ -4235,7 +4235,10 @@ static int bcf_set_variant_types(bcf1_t *b)
     bcf_dec_t *d = &b->d;
     if ( d->n_var < b->n_allele )
     {
-        d->var = (bcf_variant_t *) realloc(d->var, sizeof(bcf_variant_t)*b->n_allele);
+        bcf_variant_t *new_var = realloc(d->var, sizeof(bcf_variant_t)*b->n_allele);
+        if (!new_var)
+            return -1;
+        d->var = new_var;
         d->n_var = b->n_allele;
     }
     int i;
@@ -4251,41 +4254,80 @@ static int bcf_set_variant_types(bcf1_t *b)
     return 0;
 }
 
+// bcf_get_variant_type/bcf_get_variant_types should only return the following,
+// to be compatible with callers that are not expecting newer values
+// like VCF_INS, VCF_DEL.  The full set is available from the newer
+// vcf_has_variant_type* interfaces.
+#define ORIG_VAR_TYPES (VCF_SNP|VCF_MNP|VCF_INDEL|VCF_OTHER|VCF_BND|VCF_OVERLAP)
 int bcf_get_variant_types(bcf1_t *rec)
 {
-    if ( rec->d.var_type==-1 ) bcf_set_variant_types(rec);
-    return rec->d.var_type & ~(VCF_INS|VCF_DEL);
+    if ( rec->d.var_type==-1 ) {
+        if (bcf_set_variant_types(rec) != 0) {
+            hts_log_error("Couldn't get variant types: %s", strerror(errno));
+            exit(1); // Due to legacy API having no way to report failures
+        }
+    }
+    return rec->d.var_type & ORIG_VAR_TYPES;
 }
+
 int bcf_get_variant_type(bcf1_t *rec, int ith_allele)
 {
-    if ( rec->d.var_type==-1 ) bcf_set_variant_types(rec);
-    return rec->d.var[ith_allele].type & ~(VCF_INS|VCF_DEL);
+    if ( rec->d.var_type==-1 ) {
+        if (bcf_set_variant_types(rec) != 0) {
+            hts_log_error("Couldn't get variant types: %s", strerror(errno));
+            exit(1); // Due to legacy API having no way to report failures
+        }
+    }
+    if (ith_allele < 0 || ith_allele >= rec->n_allele) {
+        hts_log_error("Requested allele outside valid range");
+        exit(1);
+    }
+    return rec->d.var[ith_allele].type & ORIG_VAR_TYPES;
 }
-inline static int has_variant_type(int type, int bitmask, enum bcf_variant_match mode)
+#undef ORIG_VAR_TYPES
+
+int bcf_has_variant_type(bcf1_t *rec, int ith_allele, uint32_t bitmask)
 {
-    if ( mode==overlap ) return type & bitmask;
+    if ( rec->d.var_type==-1 ) {
+        if (bcf_set_variant_types(rec) != 0) return -1;
+    }
+    if (ith_allele < 0 || ith_allele >= rec->n_allele) return -1;
+    if (bitmask == VCF_REF) {  // VCF_REF is 0, so handled as a special case
+        return rec->d.var[ith_allele].type == VCF_REF;
+    }
+    return bitmask & rec->d.var[ith_allele].type;
+}
+
+int bcf_variant_length(bcf1_t *rec, int ith_allele)
+{
+    if ( rec->d.var_type==-1 ) {
+        if (bcf_set_variant_types(rec) != 0) return bcf_int32_missing;
+    }
+    if (ith_allele < 0 || ith_allele >= rec->n_allele) return bcf_int32_missing;
+    return rec->d.var[ith_allele].n;
+}
+
+int bcf_has_variant_types(bcf1_t *rec, uint32_t bitmask,
+                          enum bcf_variant_match mode)
+{
+    if ( rec->d.var_type==-1 ) {
+        if (bcf_set_variant_types(rec) != 0) return -1;
+    }
+    uint32_t type = rec->d.var_type;
+    if ( mode==bcf_match_overlap ) return bitmask & type;
 
     // VCF_INDEL is always set with VCF_INS and VCF_DEL by bcf_set_variant_type[s], but the bitmask may
     // ask for say `VCF_INS` or `VCF_INDEL` only
     if ( bitmask&(VCF_INS|VCF_DEL) && !(bitmask&VCF_INDEL) ) type &= ~VCF_INDEL;
     else if ( bitmask&VCF_INDEL && !(bitmask&(VCF_INS|VCF_DEL)) ) type &= ~(VCF_INS|VCF_DEL);
 
-    if ( mode==subset )
+    if ( mode==bcf_match_subset )
     {
         if ( ~bitmask & type ) return 0;
         else return bitmask & type;
     }
+    // mode == bcf_match_exact
     return type==bitmask ? type : 0;
-}
-int bcf_has_variant_type(bcf1_t *rec, int ith_allele, int bitmask, enum bcf_variant_match mode)
-{
-    if ( rec->d.var_type==-1 ) bcf_set_variant_types(rec);
-    return has_variant_type(rec->d.var[ith_allele].type, bitmask, mode);
-}
-int bcf_has_variant_types(bcf1_t *rec, int bitmask, enum bcf_variant_match mode)
-{
-    if ( rec->d.var_type==-1 ) bcf_set_variant_types(rec);
-    return has_variant_type(rec->d.var_type, bitmask, mode);
 }
 
 int bcf_update_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key, const void *values, int n, int type)


### PR DESCRIPTION
The change is largely backward API and ABI compatible unless the var_type flag is queried for *equality* in the user program, rather than used as a bitmask.

API alternatives for querying these flags in a robust way are provided.

This is linked to https://github.com/samtools/htslib/issues/1454 and https://github.com/samtools/bcftools/issues/1704