### PR TITLE
Further improve MM tag consistency checking.

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -6289,6 +6289,11 @@ int bam_parse_basemod(const bam1_t *b, hts_base_mod_state *state) {
                 state->MLstride [mod_num] = stride;
                 state->implicit [mod_num] = implicit;
 
+                if (delta < 0) {
+                    hts_log_error("MM tag refers to bases beyond sequence "
+                                  "length");
+                    return -1;
+                }
                 state->MMcount  [mod_num] = delta;
                 if (b->core.flag & BAM_FREVERSE) {
                     state->MM   [mod_num] = cp+1;


### PR DESCRIPTION
If we have an MM tag with base-type specific coordinates beyond the end of the sequence as there are too few bases of that type, then we now detect this within bam_parse_basemod.

This was already checked within bam_next_basemod for forward reads, but not spotted in reverse complemented ones.

Fixes #1466

Note this checks in a different place, as for reverse complemented reads we've already computed the total frequency as we're counting backwards, so spotting overflow can be done at the parse stage while setting up the "initial" (ie last) mod.  For forward reads our initial one is also the first, so a check isn't so useful here.