### PR TITLE
Switch to rockylinux:9

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,7 +121,7 @@ ubuntu_task:
 rocky_task:
   name: rockylinux-gcc
   container:
-    image: rockylinux:latest
+    image: rockylinux:9
     cpu: 2
     memory: 1G
 
@@ -133,9 +133,9 @@ rocky_task:
   # NB: we could consider building a docker image with these
   # preinstalled and specifying that instead, to speed up testing.
   install_script: |
-    yum install -y autoconf automake make gcc perl-Data-Dumper zlib-devel \
-        bzip2 bzip2-devel xz-devel curl-devel openssl-devel ncurses-devel \
-        diffutils git
+    yum install -y autoconf automake make gcc perl-Data-Dumper perl-FindBin \
+        zlib-devel bzip2 bzip2-devel xz-devel curl-devel openssl-devel \
+        ncurses-devel diffutils git
 
   << : *COMPILE
   << : *TEST


### PR DESCRIPTION
Change rockylinux docker image to rockylinux:9 following deprecation of rockylinux:latest.

Adds perl-FindBin to installation list, as it's now in its own package.