### PR TITLE
Support 0 coordinate in BCF

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -1413,6 +1413,7 @@ static inline int bcf_read1_core(BGZF *fp, bcf1_t *v)
     if (ks_resize(&v->indiv, indiv_len ? indiv_len : 1) != 0) return -2;
     v->rid  = le_to_i32(x + 8);
     v->pos  = le_to_u32(x + 12);
+    if ( v->pos==UINT32_MAX ) v->pos = -1;  // this is for telomere coordinate, e.g. MT:0
     v->rlen = le_to_i32(x + 16);
     v->qual = le_to_float(x + 20);
     v->n_info = le_to_u16(x + 24);


### PR DESCRIPTION
The 0 coordinate is valid in VCF specification, but the round-trip
VCF -> BCF -> VCF turns MT:0 into MT:4294967296. Add a check to
detect this overflow.

See https://github.com/samtools/htslib/issues/1475 and https://github.com/samtools/bcftools/issues/1753