### PR TITLE
Improve filter expression language consistency

### DIFF
--- a/hts_expr.c
+++ b/hts_expr.c
@@ -23,7 +23,6 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.  */
 
 // TODO:
-// - add maths functions.  pow, sqrt, log, ?
 // - ?: operator for conditionals?
 
 #define HTS_BUILDING_LIBRARY // Enables HTSLIB_EXPORT, see htslib/hts_defs.h
@@ -163,10 +162,52 @@ static int func_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
         }
         break;
 
+    case 'd':
+        if (strncmp(str, "default(", 8) == 0) {
+            if (expression(filt, data, fn, str+8, end, res)) return -1;
+            if (**end != ',')
+                return -1;
+            (*end)++;
+            hts_expr_val_t val = HTS_EXPR_VAL_INIT;
+            if (expression(filt, data, fn, ws(*end), end, &val)) return -1;
+            func_ok = 1;
+            if (!hts_expr_val_existsT(res)) {
+                kstring_t swap = res->s;
+                *res = val;
+                val.s = swap;
+                hts_expr_val_free(&val);
+            }
+        }
+        break;
+
+    case 'e':
+        if (strncmp(str, "exists(", 7) == 0) {
+            if (expression(filt, data, fn, str+7, end, res)) return -1;
+            func_ok = 1;
+            res->is_true = res->d = hts_expr_val_existsT(res);
+            res->is_str = 0;
+        } else if (strncmp(str, "exp(", 4) == 0) {
+            if (expression(filt, data, fn, str+4, end, res)) return -1;
+            func_ok = 1;
+            res->d = exp(res->d);
+            res->is_str = 0;
+            if (isnan(res->d))
+                hts_expr_val_undef(res);
+        }
+
+        break;
+
     case 'l':
         if (strncmp(str, "length(", 7) == 0) {
             if (expression(filt, data, fn, str+7, end, res)) return -1;
             func_ok = expr_func_length(res);
+        } else if (strncmp(str, "log(", 4) == 0) {
+            if (expression(filt, data, fn, str+4, end, res)) return -1;
+            func_ok = 1;
+            res->d = log(res->d);
+            res->is_str = 0;
+            if (isnan(res->d))
+                hts_expr_val_undef(res);
         }
         break;
 
@@ -177,6 +218,44 @@ static int func_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
         } else if (strncmp(str, "max(", 4) == 0) {
             if (expression(filt, data, fn, str+4, end, res)) return -1;
             func_ok = expr_func_max(res);
+        }
+        break;
+
+    case 'p':
+        if (strncmp(str, "pow(", 4) == 0) {
+            if (expression(filt, data, fn, str+4, end, res)) return -1;
+            func_ok = 1;
+
+            if (**end != ',')
+                return -1;
+            (*end)++;
+            hts_expr_val_t val = HTS_EXPR_VAL_INIT;
+            if (expression(filt, data, fn, ws(*end), end, &val)) return -1;
+            if (!hts_expr_val_exists(res) || !hts_expr_val_exists(&val)) {
+                hts_expr_val_undef(res);
+            } else if (res->is_str || val.is_str) {
+                hts_expr_val_free(&val); // arith on strings
+                return -1;
+            } else {
+                func_ok = 1;
+                res->d = pow(res->d, val.d);
+                hts_expr_val_free(&val);
+                res->is_str = 0;
+            }
+
+            if (isnan(res->d))
+                hts_expr_val_undef(res);
+        }
+        break;
+
+    case 's':
+        if (strncmp(str, "sqrt(", 5) == 0) {
+            if (expression(filt, data, fn, str+5, end, res)) return -1;
+            func_ok = 1;
+            res->d = sqrt(res->d);
+            res->is_str = 0;
+            if (isnan(res->d))
+                hts_expr_val_undef(res);
         }
         break;
     }
@@ -286,32 +365,46 @@ static int unary_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
                       char *str, char **end, hts_expr_val_t *res) {
     int err;
     str = ws(str);
-    if (*str == '+') {
+    if (*str == '+' || *str == '-') {
         err = simple_expr(filt, data, fn, str+1, end, res);
-        err |= res->is_str;
-        res->is_true = res->d != 0;
-    } else if (*str == '-') {
-        err = simple_expr(filt, data, fn, str+1, end, res);
-        err |= res->is_str;
-        res->d = -res->d;
-        res->is_true = res->d != 0;
+        if (!hts_expr_val_exists(res)) {
+            hts_expr_val_undef(res);
+        } else {
+            err |= res->is_str;
+            if (*str == '-')
+                res->d = -res->d;
+            res->is_true = res->d != 0;
+        }
     } else if (*str == '!') {
         err = unary_expr(filt, data, fn, str+1, end, res);
         if (res->is_true) {
+            // Any explicitly true value becomes false
             res->d = res->is_true = 0;
-            res->is_str = 0;
+        } else if (!hts_expr_val_exists(res)) {
+            // We can also still negate undef values by toggling the
+            // is_true override value.
+            res->d = res->is_true = !res->is_true;
         } else if (res->is_str) {
-            res->is_str = 0;
+            // !null = true, !"foo" = false, NOTE: !"" = false also
             res->d = res->is_true = (res->s.s == NULL);
         } else {
             res->d = !(int64_t)res->d;
             res->is_true = res->d != 0;
         }
+        res->is_str = 0;
     } else if (*str == '~') {
         err = unary_expr(filt, data, fn, str+1, end, res);
-        err |= res->is_str;
-        res->d = ~(int64_t)res->d;
-        res->is_true = res->d != 0;
+        if (!hts_expr_val_exists(res)) {
+            hts_expr_val_undef(res);
+        } else {
+            err |= res->is_str;
+            if (!hts_expr_val_exists(res)) {
+                hts_expr_val_undef(res);
+            } else {
+                res->d = ~(int64_t)res->d;
+                res->is_true = res->d != 0;
+            }
+        }
     } else {
         err = simple_expr(filt, data, fn, str, end, res);
     }
@@ -338,7 +431,9 @@ static int mul_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
         str = ws(str);
         if (*str == '*' || *str == '/' || *str == '%') {
             if (unary_expr(filt, data, fn, str+1, end, &val)) return -1;
-            if (val.is_str || res->is_str) {
+            if (!hts_expr_val_exists(&val) || !hts_expr_val_exists(res)) {
+                hts_expr_val_undef(res);
+            } else if (val.is_str || res->is_str) {
                 hts_expr_val_free(&val);
                 return -1; // arith on strings
             }
@@ -348,12 +443,15 @@ static int mul_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
             res->d *= val.d;
         else if (*str == '/')
             res->d /= val.d;
-        else if (*str == '%')
-            res->d = (int64_t)res->d % (int64_t)val.d;
-        else
+        else if (*str == '%') {
+            if (val.d)
+                res->d = (int64_t)res->d % (int64_t)val.d;
+            else
+                hts_expr_val_undef(res);
+        } else
             break;
 
-        res->is_true = res->d != 0;
+        res->is_true = hts_expr_val_exists(res) && (res->d != 0);
         str = *end;
     }
 
@@ -378,9 +476,12 @@ static int add_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
     hts_expr_val_t val = HTS_EXPR_VAL_INIT;
     while (*str) {
         str = ws(str);
+        int undef = 0;
         if (*str == '+' || *str == '-') {
             if (mul_expr(filt, data, fn, str+1, end, &val)) return -1;
-            if (val.is_str || res->is_str) {
+            if (!hts_expr_val_exists(&val) || !hts_expr_val_exists(res)) {
+                undef = 1;
+            } else if (val.is_str || res->is_str) {
                 hts_expr_val_free(&val);
                 return -1; // arith on strings
             }
@@ -393,7 +494,11 @@ static int add_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
         else
             break;
 
-        res->is_true = res->d != 0;
+        if (undef)
+            hts_expr_val_undef(res);
+        else
+            res->is_true = res->d != 0;
+
         str = *end;
     }
 
@@ -412,11 +517,14 @@ static int bitand_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
     if (add_expr(filt, data, fn, str, end, res)) return -1;
 
     hts_expr_val_t val = HTS_EXPR_VAL_INIT;
+    int undef = 0;
     for (;;) {
         str = ws(*end);
         if (*str == '&' && str[1] != '&') {
             if (add_expr(filt, data, fn, str+1, end, &val)) return -1;
-            if (res->is_str || val.is_str) {
+            if (!hts_expr_val_exists(&val) || !hts_expr_val_exists(res)) {
+                undef = 1;
+            } else if (res->is_str || val.is_str) {
                 hts_expr_val_free(&val);
                 return -1;
             }
@@ -426,6 +534,8 @@ static int bitand_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
         }
     }
     hts_expr_val_free(&val);
+    if (undef)
+        hts_expr_val_undef(res);
 
     return 0;
 }
@@ -440,11 +550,14 @@ static int bitxor_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
     if (bitand_expr(filt, data, fn, str, end, res)) return -1;
 
     hts_expr_val_t val = HTS_EXPR_VAL_INIT;
+    int undef = 0;
     for (;;) {
         str = ws(*end);
         if (*str == '^') {
             if (bitand_expr(filt, data, fn, str+1, end, &val)) return -1;
-            if (res->is_str || val.is_str) {
+            if (!hts_expr_val_exists(&val) || !hts_expr_val_exists(res)) {
+                undef = 1;
+            } else if (res->is_str || val.is_str) {
                 hts_expr_val_free(&val);
                 return -1;
             }
@@ -454,6 +567,8 @@ static int bitxor_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
         }
     }
     hts_expr_val_free(&val);
+    if (undef)
+        hts_expr_val_undef(res);
 
     return 0;
 }
@@ -468,11 +583,14 @@ static int bitor_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
     if (bitxor_expr(filt, data, fn, str, end, res)) return -1;
 
     hts_expr_val_t val = HTS_EXPR_VAL_INIT;
+    int undef = 0;
     for (;;) {
         str = ws(*end);
         if (*str == '|' && str[1] != '|') {
             if (bitxor_expr(filt, data, fn, str+1, end, &val)) return -1;
-            if (res->is_str || val.is_str) {
+            if (!hts_expr_val_exists(&val) || !hts_expr_val_exists(res)) {
+                undef = 1;
+            } else if (res->is_str || val.is_str) {
                 hts_expr_val_free(&val);
                 return -1;
             }
@@ -482,6 +600,8 @@ static int bitor_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
         }
     }
     hts_expr_val_free(&val);
+    if (undef)
+        hts_expr_val_undef(res);
 
     return 0;
 }
@@ -500,33 +620,60 @@ static int cmp_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
 
     str = ws(*end);
     hts_expr_val_t val = HTS_EXPR_VAL_INIT;
-    int err = 0;
+    int err = 0, cmp_done = 0;
 
     if (*str == '>' && str[1] == '=') {
+        cmp_done = 1;
         err = cmp_expr(filt, data, fn, str+2, end, &val);
-        res->is_true=res->d = res->is_str && res->s.s && val.is_str && val.s.s
-            ? strcmp(res->s.s, val.s.s) >= 0
-            : !res->is_str && !val.is_str && res->d >= val.d;
-        res->is_str = 0;
+        if (!hts_expr_val_exists(res) || !hts_expr_val_exists(&val)) {
+            hts_expr_val_undef(res);
+        } else {
+            res->is_true=res->d
+                = res->is_str && res->s.s && val.is_str && val.s.s
+                ? strcmp(res->s.s, val.s.s) >= 0
+                : !res->is_str && !val.is_str && res->d >= val.d;
+            res->is_str = 0;
+        }
     } else if (*str == '>') {
+        cmp_done = 1;
         err = cmp_expr(filt, data, fn, str+1, end, &val);
-        res->is_true=res->d = res->is_str && res->s.s && val.is_str && val.s.s
-            ? strcmp(res->s.s, val.s.s) > 0
-            : !res->is_str && !val.is_str && res->d > val.d;
-        res->is_str = 0;
+        if (!hts_expr_val_exists(res) || !hts_expr_val_exists(&val)) {
+            hts_expr_val_undef(res);
+        } else {
+            res->is_true=res->d
+                = res->is_str && res->s.s && val.is_str && val.s.s
+                ? strcmp(res->s.s, val.s.s) > 0
+                : !res->is_str && !val.is_str && res->d > val.d;
+            res->is_str = 0;
+        }
     } else if (*str == '<' && str[1] == '=') {
+        cmp_done = 1;
         err = cmp_expr(filt, data, fn, str+2, end, &val);
-        res->is_true=res->d = res->is_str && res->s.s && val.is_str && val.s.s
-            ? strcmp(res->s.s, val.s.s) <= 0
-            : !res->is_str && !val.is_str && res->d <= val.d;
-        res->is_str = 0;
+        if (!hts_expr_val_exists(res) || !hts_expr_val_exists(&val)) {
+            hts_expr_val_undef(res);
+        } else {
+            res->is_true=res->d
+                = res->is_str && res->s.s && val.is_str && val.s.s
+                ? strcmp(res->s.s, val.s.s) <= 0
+                : !res->is_str && !val.is_str && res->d <= val.d;
+            res->is_str = 0;
+        }
     } else if (*str == '<') {
+        cmp_done = 1;
         err = cmp_expr(filt, data, fn, str+1, end, &val);
-        res->is_true=res->d = res->is_str && res->s.s && val.is_str && val.s.s
-            ? strcmp(res->s.s, val.s.s) < 0
-            : !res->is_str && !val.is_str && res->d < val.d;
-        res->is_str = 0;
+        if (!hts_expr_val_exists(res) || !hts_expr_val_exists(&val)) {
+            hts_expr_val_undef(res);
+        } else {
+            res->is_true=res->d
+                = res->is_str && res->s.s && val.is_str && val.s.s
+                ? strcmp(res->s.s, val.s.s) < 0
+                : !res->is_str && !val.is_str && res->d < val.d;
+            res->is_str = 0;
+        }
     }
+
+    if (cmp_done && (!hts_expr_val_exists(&val) || !hts_expr_val_exists(res)))
+        hts_expr_val_undef(res);
     hts_expr_val_free(&val);
 
     return err ? -1 : 0;
@@ -546,34 +693,45 @@ static int eq_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
 
     str = ws(*end);
 
-    int err = 0;
+    int err = 0, eq_done = 0;
     hts_expr_val_t val = HTS_EXPR_VAL_INIT;
 
     // numeric vs numeric comparison is as expected
     // string vs string comparison is as expected
     // numeric vs string is false
     if (str[0] == '=' && str[1] == '=') {
+        eq_done = 1;
         if ((err = eq_expr(filt, data, fn, str+2, end, &val))) {
             res->is_true = res->d = 0;
         } else {
-            res->is_true = res->d = res->is_str
-                ? (res->s.s && val.s.s ? strcmp(res->s.s, val.s.s)==0 : 0)
-                : !res->is_str && !val.is_str && res->d == val.d;
+            if (!hts_expr_val_exists(res) || !hts_expr_val_exists(&val)) {
+                hts_expr_val_undef(res);
+            } else {
+                res->is_true = res->d = res->is_str
+                    ? (res->s.s && val.s.s ?strcmp(res->s.s, val.s.s)==0 :0)
+                    : !res->is_str && !val.is_str && res->d == val.d;
+            }
         }
         res->is_str = 0;
 
     } else if (str[0] == '!' && str[1] == '=') {
+        eq_done = 1;
         if ((err = eq_expr(filt, data, fn, str+2, end, &val))) {
             res->is_true = res->d = 0;
         } else {
-            res->is_true = res->d = res->is_str
-                ? (res->s.s && val.s.s ? strcmp(res->s.s, val.s.s) != 0 : 1)
-                : res->is_str != val.is_str || res->d != val.d;
+            if (!hts_expr_val_exists(res) || !hts_expr_val_exists(&val)) {
+                hts_expr_val_undef(res);
+            } else {
+                res->is_true = res->d = res->is_str
+                    ? (res->s.s && val.s.s ?strcmp(res->s.s, val.s.s) != 0 :1)
+                    : res->is_str != val.is_str || res->d != val.d;
+            }
         }
         res->is_str = 0;
 
     } else if ((str[0] == '=' && str[1] == '~') ||
                (str[0] == '!' && str[1] == '~')) {
+        eq_done = 1;
         err = eq_expr(filt, data, fn, str+2, end, &val);
         if (!val.is_str || !res->is_str) {
             hts_expr_val_free(&val);
@@ -614,6 +772,9 @@ static int eq_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
         }
         res->is_str = 0;
     }
+
+    if (eq_done && ((!hts_expr_val_exists(&val)) || !hts_expr_val_exists(res)))
+        hts_expr_val_undef(res);
     hts_expr_val_free(&val);
 
     return err ? -1 : 0;
@@ -634,16 +795,37 @@ static int and_expr(hts_filter_t *filt, void *data, hts_expr_sym_func *fn,
         str = ws(*end);
         if (str[0] == '&' && str[1] == '&') {
             if (eq_expr(filt, data, fn, str+2, end, &val)) return -1;
-            res->is_true = res->d =
-                (res->is_true || (res->is_str && res->s.s) || res->d) &&
-                (val.is_true  || (val.is_str && val.s.s) || val.d);
-            res->is_str = 0;
+            if (!hts_expr_val_existsT(res) || !hts_expr_val_existsT(&val)) {
+                hts_expr_val_undef(res);
+                res->d = 0;
+            } else {
+                res->is_true = res->d =
+                    (res->is_true || (res->is_str && res->s.s) || res->d) &&
+                    (val.is_true  || (val.is_str && val.s.s) || val.d);
+                res->is_str = 0;
+            }
         } else if (str[0] == '|' && str[1] == '|') {
             if (eq_expr(filt, data, fn, str+2, end, &val)) return -1;
-            res->is_true = res->d =
-                res->is_true || (res->is_str && res->s.s) || res->d ||
-                val.is_true  || (val.is_str  && val.s.s ) || val.d;
-            res->is_str = 0;
+            if (!hts_expr_val_existsT(res) && !hts_expr_val_existsT(&val)) {
+                // neither defined
+                hts_expr_val_undef(res);
+                res->d = 0;
+            } else if (!hts_expr_val_existsT(res) &&
+                       !(val.is_true  || (val.is_str  && val.s.s ) || val.d)) {
+                // LHS undef and RHS false
+                hts_expr_val_undef(res);
+                res->d = 0;
+            } else if (!hts_expr_val_existsT(&val) &&
+                       !(res->is_true || (res->is_str && res->s.s) || res->d)){
+                // RHS undef and LHS false
+                hts_expr_val_undef(res);
+                res->d = 0;
+            } else {
+                res->is_true = res->d =
+                    res->is_true || (res->is_str && res->s.s) || res->d ||
+                    val.is_true  || (val.is_str  && val.s.s ) || val.d;
+                res->is_str = 0;
+            }
         } else {
             break;
         }
@@ -705,7 +887,7 @@ static int hts_filter_eval_(hts_filter_t *filt,
     if (res->is_str) {
         res->is_true |= res->s.s != NULL;
         res->d = res->is_true;
-    } else {
+    } else if (hts_expr_val_exists(res)) {
         res->is_true |= res->d != 0;
     }
 


### PR DESCRIPTION
This tries to follow the principles of 3-state logic used in other systems, such as SQL.  See https://en.wikipedia.org/wiki/Null_(SQL)#Comparisons_with_NULL_and_the_three-valued_logic_(3VL)

There is some controversy there and a suggestion that 4-state logic is better, which we sort of already have with the "null-but-true" concept, which may impact below.

The primary changes here are:

- New `hts_expr_val_exists` and `hts_expr_val_undef` inline functions to check if a value exists and to clear it.  These simply logic elsewhere.  This fixes SAM filter expressions like `[AB] / [BC] > 1` where tags AB or BC don't exist.  Similar updates have been applied to many logic and mathematical operators.  To avoid spammage these are silent, failing the expression without complaint due to undefined values.  Additionally `hts_exp_val_existsT` for conditionals (&&, ||) is true if the data exists or it is true (so null-but-true works).
- `hts_expr_val_undef` now uses NAN as a definition of undefined, rather than purely a false empty string.  I do this because we automatically gain some consistency with how NAN works on mathematical operators which we previously didn't have.  Eg `sqrt(-1) == sqrt(-1)` is false according to the strict comparison rules for NAN.
- In addition to this, <, >, <=, >=, == and != also fail for undefined values (due to the use of NAN).
- A new function `exists(var)` is used to test for the existance (whether it is defined) of a variable.  This returns a boolean, which removes the need for the null-but-true and zero-but-true nature used in current tag querying.  We still have this null-but-true concept as we've previously documented the difference between filter expression `[X0]` (has tag X0) and `[X0] && [X0]!=0` (has tag X0 with a non-zero value).  This still works, but is now much easier to write using `[X0] != 0` rather than it automatically including `!exists[X0] || [X0] != 0`.  This is therefore an incompatibility, but probably a sensible one.

  What we previously struggled to do was to check a tag does not exist.  It was possible via `!([X0] || [X1]==0)`, but that was highly cryptic and I doubt many figured it out!  Now `!exists([X0])` is a far simpler solution.  NOTE however the old cryptic method no longer works, as null || false is still null (not false) and !null is also null due to the afforementioned logic.  (I'm prepared to change this though; maybe we need null-and-false vs null-and-true so we can explicitly distinguish from null-is-unknown.)
  
  **INCOMPATIBILITY**:  Note previously "[X1] != 0" meant X1 is non-zero or X1 doesn't exist.  This now gets interpreted only as X1 is non-zero.  I believe this change is a considerable improvement and worth breaking compatibility over.
  
- A new function `default(var1,var2)` which returns the first value that is defined of the pair.  So `exists(var1)?var1:var2` (if we had a ?: operator that is).
- New mathematic operators pow, exp, sqrt, log. These perhaps should have been their own commit, but I added them during this work purely because they're a convenient mechanism for getting +/- inf and nan into things for validation testing.

If I use the old test_expr.c test harness on the new hts_expr.c code now also passes all tests.

Fixes https://github.com/samtools/samtools/issues/1677

