### PR TITLE
Report HTS_CFLAGS_AVX2 et al in `make print-config`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,10 @@ libhts.a: $(LIBHTS_OBJS)
 	-$(RANLIB) $@
 
 print-config:
+	@echo HTS_CFLAGS_AVX2 = $(HTS_CFLAGS_AVX2)
+	@echo HTS_CFLAGS_AVX512 = $(HTS_CFLAGS_AVX512)
+	@echo HTS_CFLAGS_SSE4 = $(HTS_CFLAGS_SSE4)
+	@echo HTS_HAVE_NEON = $(HTS_HAVE_NEON)
 	@echo LDFLAGS = $(LDFLAGS)
 	@echo LIBHTS_OBJS = $(LIBHTS_OBJS)
 	@echo LIBS = $(LIBS)


### PR DESCRIPTION
Extend the `print-config` target added in 155e1aacac741febd6fd722cf7e3660da38d6a9b. This target-specific compiler flag information (probed for by _configure_) may also be of use to third parties.

In particular, pysam's current build infrastructure will need this information — cf pysam-developers/pysam#1112.

Pysam might in future switch to using HTSlib's build infrastructure to build _libhts.a_ (rather than using Python setuptools machinery to build the object files listed in `LIBHTS_OBJS` as reported by `print-config`), but this would still be of use to other third parties.