### PR TITLE
Fastaq switch

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -4109,7 +4109,7 @@ static inline int sam_read1_sam(htsFile *fp, sam_hdr_t *h, bam1_t *b) {
         fp->line.l = 0;
         if (ret < 0) {
             hts_log_warning("Parse error at line %lld", (long long)fp->lineno);
-            if (h->ignore_sam_err) goto err_recover;
+            if (h && h->ignore_sam_err) goto err_recover;
         }
     }
 

--- a/sam.c
+++ b/sam.c
@@ -3850,6 +3850,14 @@ static int fastq_parse1(htsFile *fp, bam1_t *b) {
             return -1;  // EOF
         else if (ret < -1)
             return ret; // ERR
+
+        // Autodetect fastq.  This permits us to use unknown text formats,
+        // where hts_detect_format failed to identify the specifics, as
+        // "fasta_format" and retune to fastq after the first line.
+        if (fp->format.format == fasta_format && *x->name.s=='@') {
+            fp->format.format = fastq_format;
+            x->nprefix = '@';
+        }
     }
 
     // Name


### PR DESCRIPTION
This permits us to just select FASTA format and let the already shared fasta/fastq code auto-select to fastq after the first line has been read.

Needed for [samtools/samtools#](https://github.com/samtools/samtools/pull/1691)

Also added a commit to fix a minor error handling crash detected while testing the code.