### PR TITLE
Add trivial le_to_u8() endianness routine

### DIFF
--- a/htslib/hts_endian.h
+++ b/htslib/hts_endian.h
@@ -113,6 +113,14 @@ typedef uint64_t uint64_u;
 #    endif
 #endif
 
+/// Get a uint8_t value from an unsigned byte array
+/** @param buf Pointer to source byte, may be unaligned
+ *  @return An 8-bit unsigned integer
+ */
+static inline uint8_t le_to_u8(const uint8_t *buf) {
+    return *buf;
+}
+
 /// Get a uint16_t value from an unsigned byte array
 /** @param buf Pointer to source byte, may be unaligned
  *  @return A 16 bit unsigned integer


### PR DESCRIPTION
In writing a switch like this one in `bcf_fmt_array()`:

https://github.com/samtools/htslib/blob/8d9193899ef3e34ea8ecc9f3fb72063e74697f69/vcf.c#L2386-L2392

&nbsp;
but in which the output types were unsigned rather than signed as in this one, I found that there was no `le_to_u8()` function. One could in fact just write `BRANCH(uint8_t,  *, …)` in many such cases, but that is pretty obscure for the reader.

This is even more trivial than `le_to_i8()` but can be useful for the regular treatment of unsigned types in these sorts of switches.