### PR TITLE
Fix "make check" on MinGW.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -572,8 +572,12 @@ check test: $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS) $(BUILT_PLUGINS) $(HTSCODEC
 	test/test_time_funcs
 	test/fieldarith test/fieldarith.sam
 	test/hfile
-	HTS_PATH=. test/with-shlib.sh test/plugins-dlhts -g ./libhts.$(SHLIB_FLAVOUR)
-	HTS_PATH=. test/with-shlib.sh test/plugins-dlhts -l ./libhts.$(SHLIB_FLAVOUR)
+	if test "x$(BUILT_PLUGINS)" != "x"; then \
+	    HTS_PATH=. test/with-shlib.sh test/plugins-dlhts -g ./libhts.$(SHLIB_FLAVOUR); \
+	fi
+	if test "x$(BUILT_PLUGINS)" != "x"; then \
+	  HTS_PATH=. test/with-shlib.sh test/plugins-dlhts -l ./libhts.$(SHLIB_FLAVOUR); \
+	fi
 	test/test_bgzf test/bgziptest.txt
 	test/test-parse-reg -t test/colons.bam
 	cd test/sam_filter && ./filter.sh filter.tst

--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,9 @@ endif
 
 BUILT_PLUGINS = $(PLUGIN_OBJS:.o=$(PLUGIN_EXT))
 
+ifneq "$(BUILT_PLUGINS)" ""
+plugins: lib-shared
+endif
 plugins: $(BUILT_PLUGINS)
 
 
@@ -563,7 +566,7 @@ SRC = $(srcprefix)
 #
 # If using MSYS, avoid poor shell expansion via:
 #    MSYS2_ARG_CONV_EXCL="*" make check
-check test: $(BUILT_PROGRAMS) $(BUILT_TEST_PROGRAMS) $(BUILT_PLUGINS) $(HTSCODECS_TEST_TARGETS)
+check test: all $(HTSCODECS_TEST_TARGETS)
 	test/hts_endian
 	test/test_expr
 	test/test_kfunc


### PR DESCRIPTION
If we haven't previously done a "make" or "make all", the .dll file
won't have been created.  The test/with-shlib.sh script will then fail
as the "cp -p ../../hts-*.dll ." command fails.  We no longer even
attempt to execute this test when plugins don't exist (which they
won't on Windows unless we've installed the dlfcn package).

Note the analogous non-mingw commands are "ln -s ../../libhts.so.* ."
and similar, which don't fail in the $? sense, but do fail with
regards to produced a bogus target containing a wild-card pattern.

This implies the error checking in this script is broken for all
platforms bar MinGW, but given the very limited use for this one test
case it's an irrelevance.

(See also the abandoned https://github.com/jkbonfield/htslib/tree/mingw_make_check which adds code so `--enable-plugins` builds on MinGW.  Sadly it doesn't work for gs: and s3:, with cryptic errors, so delaying that to another time.)