### PR TITLE
Fix problems found attempting to build on i686

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,7 +110,8 @@ AX_CHECK_COMPILE_FLAG([-mavx2], [
   ]],[[
     __m256i a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
     __m256i b = _mm256_add_epi32(a, a);
-    return *((char *) &b);
+    long long c = _mm256_extract_epi64(b, 0);
+    return (int) c;
   ]])])
 
 dnl Options for rANS32x16 avx512 version

--- a/hts.c
+++ b/hts.c
@@ -1354,6 +1354,8 @@ static int hts_crypt4gh_redirect(const char *fn, const char *mode,
     int ret = -1;
 
     if (fn2_len > sizeof(fn_buf)) {
+        if (fn2_len >= INT_MAX) // Silence gcc format-truncation warning
+            return -1;
         fn2 = malloc(fn2_len);
         if (!fn2) return -1;
     }

--- a/hts_probe_cc.sh
+++ b/hts_probe_cc.sh
@@ -71,7 +71,8 @@ cat - <<'EOF' > conftest.c
 int main(int argc, char **argv) {
     __m256i a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
     __m256i b = _mm256_add_epi32(a, a);
-    return *((char *) &b);
+    long long c = _mm256_extract_epi64(b, 0);
+    return (int) c;
 }
 EOF
 FLAGS="-mavx2"

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -42,7 +42,7 @@ AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
 AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
   ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
   _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
-  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
     [AS_VAR_SET(CACHEVAR,[yes])],
     [AS_VAR_SET(CACHEVAR,[no])])
   _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])

--- a/test/test_time_funcs.c
+++ b/test/test_time_funcs.c
@@ -71,7 +71,8 @@ int main(int argc, char **argv) {
     if (test_normalised(0, INT_MAX - 1000, 1000) != 0)
         return EXIT_FAILURE;
     if (sizeof(time_t) >= 8) {
-        if (test_normalised(INT_MAX - 1000, (time_t) INT_MAX * 2, 1000) != 0)
+        if (test_normalised(INT_MAX - 1000,
+                            (time_t)((int64_t) INT_MAX * 2), 1000) != 0)
             return EXIT_FAILURE;
     }
 
@@ -116,7 +117,8 @@ int main(int argc, char **argv) {
         res |= test_specific(2038, 1, 19, 3, 14, 8, (time_t) -1);
     } else {
         // 2038-01-19 03:14:08
-        res |= test_specific(2038, 1, 19, 3, 14, 8, (time_t) INT_MAX + 1);
+        res |= test_specific(2038, 1, 19, 3, 14, 8,
+                             (time_t)((int64_t) INT_MAX + 1));
     }
 
     return res == 0 ? EXIT_SUCCESS : EXIT_FAILURE;


### PR DESCRIPTION
* Improve SIMD detection.

`_mm256_extract_epi64()`, used by the AVX2 rANS codec, is only available on X86_64.  Adding it to the configure tests prevents it from being used on i686.  Also change the `ax_check_compile_flag` test so it runs the linker, which catches missing symbols better than just running the compiler.

* Fix some overflow warnings in the test_time_funcs program, when `time_t` is only four bytes long.

* Silence an annoying gcc-10 format-truncation warning.