### PR TITLE
Fix n-squared complexity in sample line with many adjacent tabs

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -93,9 +93,6 @@ static char *find_chrom_header_line(char *s)
 
 static int bcf_hdr_add_sample_len(bcf_hdr_t *h, const char *s, size_t len)
 {
-    if ( !s ) return 0;
-    if (len == 0) len = strlen(s);
-
     const char *ss = s;
     while ( *ss && isspace_c(*ss) && ss - s < len) ss++;
     if ( !*ss || ss - s == len)
@@ -140,7 +137,12 @@ static int bcf_hdr_add_sample_len(bcf_hdr_t *h, const char *s, size_t len)
 
 int bcf_hdr_add_sample(bcf_hdr_t *h, const char *s)
 {
-    return bcf_hdr_add_sample_len(h, s, 0);
+    if (!s) {
+        // Allowed for backwards-compatibility, calling with s == NULL
+        // used to trigger bcf_hdr_sync(h);
+        return 0;
+    }
+    return bcf_hdr_add_sample_len(h, s, strlen(s));
 }
 
 int HTS_RESULT_USED bcf_hdr_parse_sample_line(bcf_hdr_t *hdr, const char *str)


### PR DESCRIPTION
This could be triggered by a #CHROM line ending in something like:
```
#CHROM\t...\tINFO\t\t\t\t\t\t ... many tabs ... \t\t\tfoo\n
```
Between each pair of tabs, `bcf_hdr_add_sample_len()` was called with `len = 0`, as if from `bcf_hdr_add_sample()`.  This made it use `strlen(s)` instead of 0 as the sample name length, resulting in the addition of a bogus sample name with lots of leading tabs.  The sample line parser then moved on to the next tab, and did the same thing again with one fewer leading tab.

Fix by making `bcf_hdr_add_sample_len()` always use the passed-in length, even if 0, allowing the empty sample name trap to do its work.  `bcf_hdr_add_sample()` is updated to call `strlen()` itself, and to also deal with the backwards-compatibility check where it was permissible to call it with a NULL string.