### PR TITLE
Fix error code 0 returned by bcftools after error

### DIFF
--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -641,7 +641,9 @@ static int _reader_fill_buffer(bcf_srs_t *files, bcf_sr_t *reader)
         }
         else if ( reader->tbx_idx )
         {
-            if ( (ret=tbx_itr_next(reader->file, reader->tbx_idx, reader->itr, &files->tmps)) < 0 ) break;  // no more lines
+            ret = tbx_itr_next(reader->file, reader->tbx_idx, reader->itr, &files->tmps);
+            if ( ret < -1 ) files->errnum = bcf_read_error;
+            if ( ret < 0 ) break; // no more lines or an error
             ret = vcf_parse1(&files->tmps, reader->header, reader->buffer[reader->nbuffer+1]);
             if ( ret<0 ) { files->errnum = vcf_parse_error; break; }
         }

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -623,7 +623,9 @@ static int _reader_fill_buffer(bcf_srs_t *files, bcf_sr_t *reader)
         {
             if ( reader->file->format.format==vcf )
             {
-                if ( (ret=hts_getline(reader->file, KS_SEP_LINE, &files->tmps)) < 0 ) break;   // no more lines
+                ret = hts_getline(reader->file, KS_SEP_LINE, &files->tmps);
+                if ( ret < -1 ) files->errnum = bcf_read_error;
+                if ( ret < 0 ) break; // no more lines or an error
                 ret = vcf_parse1(&files->tmps, reader->header, reader->buffer[reader->nbuffer+1]);
                 if ( ret<0 ) { files->errnum = vcf_parse_error; break; }
             }


### PR DESCRIPTION
Without this, bcftools returns error code 0 even when interrupted by these errors visible in stderr:
     - [E::hts_itr_next] Failed to seek to offset 70116896333: Illegal seek
     - [E::bgzf_read_block] Failed to read BGZF block data at offset 29255442 expected 12238 bytes; hread returned -1

This code change is in line with what is written in the next `else` block