### PR TITLE
Fix a typo in sam.h documentation

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -189,7 +189,7 @@ extern const int8_t bam_cigar_table[256];
  * Mate position and insert size also need to be 64-bit, but
  * we won't accept more than 32-bit for tid.
  *
- * The bam_core_t structure is the *in memory* layout and not
+ * The bam1_core_t structure is the *in memory* layout and not
  * the same as the on-disk format.  64-bit changes here permit
  * SAM to work with very long chromosomes and permit BAM and CRAM
  * to seamlessly update in the future without further API/ABI


### PR DESCRIPTION
Hi!

I am in working on htslib bindings for the [Ruby](https://github.com/kojix2/ruby-htslib) and [Crystal](https://github.com/bio-cr/hts.cr) languages. This is just a small typo that no one notices, but I am very happy to send a pull request to htslib for the first time.

Best regards and thank You.