### PR TITLE
Warn if ref file is given but it doesn't contain the refs we need.

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3422,6 +3422,9 @@ char *cram_get_ref(cram_fd *fd, int id, int start, int end) {
      */
     pthread_mutex_lock(&fd->refs->lock);
     if (r->length == 0) {
+        if (fd->refs->fn)
+            hts_log_warning("Reference file given, but ref '%s' not present",
+                            r->name);
         if (cram_populate_ref(fd, id, r) == -1) {
             hts_log_error("Failed to populate reference for id %d", id);
             pthread_mutex_unlock(&fd->refs->lock);


### PR DESCRIPTION
Eg "samtools view -T human.fa human.cram" but we have a "1" vs "chr1" mix up.

It's not a hard error, as we may have a partial reference we wish to use and there are further fallback measures to continue.   Similarly we cannot check this at header loading time, as possibly we have a reference file for a single chromosome, a CRAM aligned against that single chromosome, but all SQ lines present in the header.

Improves the diagnostics for #1515