### PR TITLE
Fix ref fix from c91804c

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3422,7 +3422,7 @@ char *cram_get_ref(cram_fd *fd, int id, int start, int end) {
      */
     pthread_mutex_lock(&fd->refs->lock);
     if (r->length == 0) {
-        if (fd->refs->fn)
+        if (fd->ref_fn)
             hts_log_warning("Reference file given, but ref '%s' not present",
                             r->name);
         if (cram_populate_ref(fd, id, r) == -1) {


### PR DESCRIPTION
We have too many similarly sounding reference filenames. While the previous fixed worked when MMAP was in use, when it's not we end up setting fd->refs->fn in cram_populate_ref, which causes samtools test failures on Windows.

With hindsight, the fix was wrong as fd->ref_fn is the actual filename we specified with view -T, while fd->refs->fn is the current filename loaded (which is the same thing *unless* we're using a local cache and no mmap in which case it's also updated to point to the filename associated with the open file descriptor).

Definitely an "I wouldn't start from here" problem. (Sorry!)