### PR TITLE
Add CRAM SQ/M5 header checking when specifying a fasta file.

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -4829,6 +4829,11 @@ int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr) {
                 return -1;
     }
 
+    if (-1 == refs_from_header(fd))
+        return -1;
+    if (-1 == refs2id(fd->refs, fd->header))
+        return -1;
+
     /* Fix M5 strings */
     if (fd->refs && !fd->no_ref && fd->embed_ref <= 1) {
         int i;
@@ -5003,11 +5008,6 @@ int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr) {
         cram_free_block(b);
         cram_free_container(c);
     }
-
-    if (-1 == refs_from_header(fd))
-        return -1;
-    if (-1 == refs2id(fd->refs, fd->header))
-        return -1;
 
     if (0 != hflush(fd->fp))
         return -1;

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -675,6 +675,7 @@ typedef struct ref_entry {
     char *seq;
     mFILE *mf;
     int is_md5;            // Reference comes from a raw seq found by MD5
+    int validated_md5;
 } ref_entry;
 
 KHASH_MAP_INIT_STR(refs, ref_entry*)


### PR DESCRIPTION
See https://github.com/samtools/samtools/issues/1748 for background, although this isn't fixing that issue and I'm not yet sure what that problem is.

I'm unsure on whether this is a desireable solution.  See the benchmarks below; the "fix" isn't free.

<hr/>

Given the possibility of creating a CRAM which cannot be decoded again due to specifying a fasta file that differs to the M5 tags specified in the header, we're now more militant in enforcing these match.

This does however add a performance hit when processing the header, which can unfairly penalise small files or creation of CRAMs for a small portion of the genome.

    # Old htslib 1.16 speed, enabled here by explicitly ignoring md5
    $ time samtools view -T $HREF -O cram,ignore_md5 -o /tmp/_.cram ~/scratch/data/9827_2#49.bam 10:10000000-11000000
    real    0m0.807s
    user    0m0.702s
    sys     0m0.101s

    # New performance, dominated by validating SQ M5s
    $ time samtools view -T $HREF -o /tmp/_.cram ~/scratch/data/9827_2#49.bam 10:10000000-11000000
    real    0m20.312s
    user    0m18.543s
    sys     0m1.760s

    # Using REF_PATH md5 cache instead is fast
    $ time samtools view -o /tmp/_.cram ~/scratch/data/9827_2#49.bam 10:10000000-11000000
    real    0m0.222s
    user    0m0.204s
    sys     0m0.016s

This significant start-up cost is why this check wasn't previously here.  We need to decide between validation of correctness and performance.  It's optional now, but perhaps ignore_md5 isn't the correct option (it affects other things) and perhaps it should be opt-in instead of opt-out.