### PR TITLE
Switch MacOS CI tests to an ARM-based image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -181,8 +181,8 @@ arm_ubuntu_task:
 
 macosx_task:
   name: macosx + clang
-  osx_instance:
-    image: monterey-base
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
   environment:
     CC: clang


### PR DESCRIPTION
Before x86-64 is phased out at the end of the year.

Uses cirrus-ci recommended container, see:
  https://cirrus-ci.org/guide/macOS/