### PR TITLE
Cut down the number of embed_ref=2 tests that get run

### DIFF
--- a/test/test.pl
+++ b/test/test.pl
@@ -661,14 +661,6 @@ sub test_view
             testv $opts, "./compare_sam.pl -Baux $md $sam $jsam";
         }
 
-        # embed_ref=2 mode
-        my $ersam = "ce#1000.sam";
-        my $ercram = "ce#1000_er.tmp.cram";
-        my $ersam2 = "${ercram}.sam";
-        testv $opts, "./test_view $tv_args -C -p $ercram $ersam";
-        testv $opts, "./test_view $tv_args -p $ersam2 $ercram";
-        testv $opts, "./compare_sam.pl $ersam $ersam2";
-
         if ($test_view_failures == 0)
         {
             passed($opts, "$sam conversions");
@@ -677,6 +669,21 @@ sub test_view
         {
             failed($opts, "$sam conversions", "$test_view_failures subtests failed");
         }
+    }
+
+    # embed_ref=2 mode
+    print "test_view testing embed_ref=2:\n";
+    $test_view_failures = 0;
+    my $ersam = "ce#1000.sam";
+    my $ercram = "ce#1000_er.tmp.cram";
+    my $ersam2 = "${ercram}.sam";
+    testv $opts, "./test_view $tv_args -C -p $ercram $ersam";
+    testv $opts, "./test_view $tv_args -p $ersam2 $ercram";
+    testv $opts, "./compare_sam.pl $ersam $ersam2";
+    if ($test_view_failures == 0) {
+        passed($opts, "embed_ref=2 tests");
+    } else {
+        failed($opts, "embed_ref=2 tests", "$test_view_failures subtests failed");
     }
 
     # BAM and CRAM range queries on prebuilt BAM and CRAM


### PR DESCRIPTION
Fixes a small testing inefficiency I noticed.

The test only runs on the ce#1000.sam file, so it shouldn't be inside the loop that runs on all sam files in the test directory.