### PR TITLE
Improve support for very long input lines (> 2Gbyte)

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -2298,7 +2298,7 @@ int bgzf_getline(BGZF *fp, int delim, kstring_t *str)
     fp->uncompressed_address += str->l + 1;
     if ( delim=='\n' && str->l>0 && str->s[str->l-1]=='\r' ) str->l--;
     str->s[str->l] = 0;
-    return str->l;
+    return str->l <= INT_MAX ? (int) str->l : INT_MAX;
 }
 
 void bgzf_index_destroy(BGZF *fp)

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -303,7 +303,8 @@ typedef struct BGZF BGZF;
      * @param fp     BGZF file handler
      * @param delim  delimiter
      * @param str    string to write to; must be initialized
-     * @return       length of the string; -1 on end-of-file; <= -2 on error
+     * @return       length of the string (capped at INT_MAX);
+     *               -1 on end-of-file; <= -2 on error
      */
     HTSLIB_EXPORT
     int bgzf_getline(BGZF *fp, int delim, struct kstring_t *str);

--- a/tbx.c
+++ b/tbx.c
@@ -91,9 +91,10 @@ int tbx_name2id(tbx_t *tbx, const char *ss)
     return get_tid(tbx, ss, 0);
 }
 
-int tbx_parse1(const tbx_conf_t *conf, int len, char *line, tbx_intv_t *intv)
+int tbx_parse1(const tbx_conf_t *conf, size_t len, char *line, tbx_intv_t *intv)
 {
-    int i, b = 0, id = 1;
+    size_t i, b = 0;
+    int id = 1;
     char *s;
     intv->ss = intv->se = 0; intv->beg = intv->end = -1;
     for (i = 0; i <= len; ++i) {

--- a/vcf.c
+++ b/vcf.c
@@ -3437,7 +3437,7 @@ int vcf_write_line(htsFile *fp, kstring_t *line)
 
 int vcf_write(htsFile *fp, const bcf_hdr_t *h, bcf1_t *v)
 {
-    int ret;
+    ssize_t ret;
     fp->line.l = 0;
     if (vcf_format1(h, v, &fp->line) != 0)
         return -1;


### PR DESCRIPTION
Some changes to make reading and writing very long lines work better.  It is a partial fix for #1539 - the overflow mentioned in dealt with, but more work will be needed to make the very long VCF records readable.

* Cap the return value of `bgzf_getline()` to avoid integer overflow.
* Change data types in `tbx_parse1()` and `vcf_write()` so they can handle long lines (albeit only on 64-bit platforms).
* Put an extra loop around `read()` and `write()` in `fd_read()`, `fd_write()` to ensure they really have processed the expected amount of data.  This is especially important on Linux, which has a [limit on the amount of data that will be read or written](https://man7.org/linux/man-pages/man2/read.2.html#NOTES) in a single call.

This is mostly useful for `tabix`, which doesn't do much interpretation of its input.  With these changes it will happily index and return long lines if it has enough memory.

This does not change the maximum size of a SAM record, as that is limited by `bam1_t::l_data` which is an `int`.
The situation for VCF is a bit more complicated, and it may be possible to get very slightly over 2Gbytes as various limits apply to different parts of the record.  The size of the sample data, which is likely to be the biggest part, is currently restricted to 2Gbytes by [this check](https://github.com/samtools/htslib/blob/d7737aa694/vcf.c#L2612), and by the size of `bcf_fmt_t::p_off` which is 31 bits.  It might be possible to work around the `p_off` limit by abusing the ability of `bcf_fmt_t` to store edited data in a separate buffer - but doing so would be a bit hairy and would need a lot of thought and testing.