### PR TITLE
Expand CRAM API a bit to cope with new samtools cram_size command.

### DIFF
--- a/cram/cram_codecs.h
+++ b/cram/cram_codecs.h
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2012-2015, 2018, 2020 Genome Research Ltd.
+Copyright (c) 2012-2015, 2018, 2020, 2023 Genome Research Ltd.
 Author: James Bonfield <jkb@sanger.ac.uk>
 
 Redistribution and use in source and binary forms, with or without
@@ -160,7 +160,7 @@ typedef struct {
 /*
  * A generic codec structure.
  */
-typedef struct cram_codec {
+struct cram_codec {
     enum cram_encoding codec;
     cram_block *out;
     varint_vec *vv;
@@ -175,6 +175,7 @@ typedef struct cram_codec {
     int (*size)(cram_slice *slice, struct cram_codec *codec);
     int (*flush)(struct cram_codec *codec);
     cram_block *(*get_block)(cram_slice *slice, struct cram_codec *codec);
+    int (*describe)(struct cram_codec *codec, kstring_t *ks);
 
     union {
         cram_huffman_decoder         huffman;
@@ -201,7 +202,7 @@ typedef struct cram_codec {
         cram_const_codec             e_xconst;
         cram_varint_decoder          e_varint;
     } u;
-} cram_codec;
+};
 
 const char *cram_encoding2str(enum cram_encoding t);
 

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -101,6 +101,11 @@ enum cram_block_method {
 };
 #endif
 
+/* NOTE this structure may be expanded in future releases by appending
+ * additional fields.
+ *
+ * Do not assume the size is fixed and avoid using arrays of this struct.
+ */
 typedef struct {
     enum cram_block_method method;
 
@@ -224,9 +229,8 @@ HTSLIB_EXPORT
 enum cram_block_method cram_block_get_method(cram_block *b);
 
 HTSLIB_EXPORT
-enum cram_block_method cram_expand_method(uint8_t *data, int32_t size,
-                                          enum cram_block_method comp,
-                                          cram_method_details *cm);
+cram_method_details *cram_expand_method(uint8_t *data, int32_t size,
+                                        enum cram_block_method comp);
 
 HTSLIB_EXPORT
 void cram_block_set_content_id(cram_block *b, int32_t id);
@@ -270,7 +274,7 @@ void cram_codec_get_content_ids(cram_codec *c, int ids[2]);
 
 /*
  * Produces a human readable description of the codec parameters.
- * This ia appended to an existing kstring 'ks'.
+ * This is appended to an existing kstring 'ks'.
  *
  * Returns 0 on succes,
  *        <0 on failure


### PR DESCRIPTION
- cram_block_get_content_id is updated to return -1 for CORE block, removing the need to add a content_type API and share that enum.

- New cram_block_get_method method

- New cram_codec_get_content_ids, which externalises the existing cram_codec_to_id (with a hopefully better API and name).

- Make cram_decode_compression_header and cram_free_compression_header external.  The struct itself is opaque.

- Added cram_update_cid2ds_map, cram_cid2ds_query and cram_cid2ds_free to produce, query and free a block Content-ID to Data-Series mapping from the meta-data held within a CRAM Compression Header.

- Added a new cram_codec iterator to sequentially step through all cram_codec structures produced by decoding a compression header. This new code is entirely internal to htslib and is solely used by the new cram_update_cid2ds_map function.

- Add a codec->describe method. This produces a text description of codec parameters, such as

    EXTERNAL(id=1)
    HUFFMAN(codes={5,1,3},lengths={1,2,2})
    BYTE_ARRAY_LEN(len_codec={EXTERNAL(id=42)},val_codec={EXTERNAL(id=37)}

  Adds the external API: int cram_codec_describe(cram_codec *c, kstring_t *ks) TODO: Some of the proposed CRAM 4.0 codecs don't yet have descriptions, but these aren't official codecs anyway.

- Add a function to describe all encodings in a compression header block: int cram_describe_encodings(cram_block_compression_hdr *hdr, kstring_t *ks);

- Add cram_container_get_num_records and cram_container_get_num_bases functions. These are two new external APIs for querying sequence meta-data from containers, which in theory could be used for a (non-filtering) "view -c" cmd.