### PR TITLE
Improve API docs for bgzf_mt

### DIFF
--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -316,23 +316,22 @@ typedef struct BGZF BGZF;
     int bgzf_read_block(BGZF *fp) HTS_RESULT_USED;
 
     /**
-     * Enable multi-threading (when compiled with -DBGZF_MT) via a shared
-     * thread pool.  This means both encoder and decoder can balance
-     * usage across a single pool of worker jobs.
+     * Enable multi-threading via a shared thread pool.  This means
+     * both encoder and decoder can balance usage across a single pool
+     * of worker jobs.
      *
-     * @param fp          BGZF file handler; must be opened for writing
+     * @param fp          BGZF file handler
      * @param pool        The thread pool (see hts_create_threads)
      */
     HTSLIB_EXPORT
     int bgzf_thread_pool(BGZF *fp, struct hts_tpool *pool, int qsize);
 
     /**
-     * Enable multi-threading (only effective when the library was compiled
-     * with -DBGZF_MT)
+     * Enable multi-threading
      *
-     * @param fp          BGZF file handler; must be opened for writing
-     * @param n_threads   #threads used for writing
-     * @param n_sub_blks  #blocks processed by each thread; a value 64-256 is recommended
+     * @param fp          BGZF file handler
+     * @param n_threads   #threads used for reading / writing
+     * @param n_sub_blks  Unused (was #blocks processed by each thread)
      */
     HTSLIB_EXPORT
     int bgzf_mt(BGZF *fp, int n_threads, int n_sub_blks);


### PR DESCRIPTION
Note that this now works on reading as well as writing.

Removed the comment about only when compiled with `-DBGZF_MT` as this was misleading implying the user has to adjust CFLAGS.  It's on by default and there's nothing the user can do to turn it off without manually editing bgzf.c, in which case they're on their own.

Also document that n_sub_blks now does nothing.

Fixes #1553