### PR TITLE
Embed ref2 unsorted

### DIFF
--- a/cram/README
+++ b/cram/README
@@ -1,0 +1,214 @@
+CRAM encoding internals
+=======================
+
+A quick summary of functions involved.
+
+The encoder works by accumulating a bunch of BAM records (via the
+cram_put_bam_seq function), and at a certain point (eg counter of
+records, or switching reference) the array of BAM records it turned
+into a container, which in turn creates slices, holding CRAM
+data-series in blocks.  The function that turns an array of BAM
+objects into the container is below.
+
+cram_encode_container func:
+    Validate references MD5 against header, unless no_ref mode
+    If embed_ref <= 1, fetch ref
+        Switch to embed_ref=2 if failed
+
+    Foreach slice:
+        If embed_ref == 2
+	    call cram_generate_reference
+	        if failed switch to no_ref mode
+	Foreach sequence
+	    call process_one_read to append BAM onto each data series (DS)
+	        call cram_stats_add for each DS to gather metrics
+		call cram_encode_aux
+
+    # We now have cram DS, per slice
+    call cram_encoder_init, per DS (based on cram_stats_add data)
+
+    Foreach slice:
+        call cram_encode_slice to turn DS to blocks
+	    call cram_compess_slice
+
+    call cram_encode_compression_header
+
+Threading
+---------
+
+CRAM can be multi-threaded, but this brings complications.
+
+The above function is the main CPU user, so it is this bit which can
+be executed in parallel from multiple threads.  To understand this we
+need to now look at how the primary loop works when writing a CRAM:
+
+Encoding main thread:
+    repeatedly calls cram_put_bam_seq
+        calls cram_new_container on first time through to initialise
+	calls cram_next_container when current is full or we need to flush
+	    calls cram_flush_container_mt to flush last container
+        pushes BAM object onto current container
+
+If non-threaded, cram_flush_container_mt does:
+    call cram_flush_container
+        call cram_encode_container to go from BAM to CRAM data-series
+ 	call cram_flush_container2 (writes it out)
+
+If threaded, cram_flush_container_mt does:
+    Main: Dispatch cram_flush_thread job
+        Thread: call cram_encode_container to go from BAM to CRAM data-series
+    Main: Call cram_flush_result to drain queue of encoded containers
+        Main: Call cram_flush_container2 (writes it out);
+
+
+
+Decisions on when to create new containers, detection of sorted vs unsorted,
+switching to multi-seq mode, etc occur at the main thread in
+cram_put_bam_seq.
+
+We can change our mind on container parameters at any point up until
+the cram_encode_container call.  At that point these parameters get
+baked into a container compression header and all data-series
+generated need to be in sync with the parameters.
+
+It is possible that some parameter changes can get detected while
+encoding the container, as it is there where we fetch references.  Eg
+the need to enable embedded reference or switch to non-ref mode.
+
+While encoding a container, we can change the parameters for *this*
+container, and we can also set the default parameter for subsequent
+new parameters via the global cram fd to avoid spamming attempts to
+load a reference which doesn't exist, but we cannot change other
+containers that are being processed in parallel.  They'll fend for
+themselves.
+
+References
+----------
+
+To avoid spamming the reference servers, there is a shared cache of
+references being currently used by all the worker threads (leading to
+confusing terminology of reference-counting of references).  So each
+container fetches its section of reference, but the memory for that is
+handled via its own layer.
+
+The shared references and ref meta-data is held in cram_fd -> refs (a
+refs_t pointer):
+
+    // References structure.
+    struct refs_t {
+        string_alloc_t *pool;  // String pool for holding filenames and SN vals
+    
+        khash_t(refs) *h_meta; // ref_entry*, index by name
+        ref_entry **ref_id;    // ref_entry*, index by ID
+        int nref;              // number of ref_entry
+    
+        char *fn;              // current file opened
+        BGZF *fp;              // and the hFILE* to go with it.
+    
+        int count;             // how many cram_fd sharing this refs struct
+    
+        pthread_mutex_t lock;  // Mutex for multi-threaded updating
+        ref_entry *last;       // Last queried sequence
+        int last_id;           // Used in cram_ref_decr_locked to delay free
+    };
+
+Within this, ref_entry is the per-reference information:
+
+    typedef struct ref_entry {
+        char *name;
+        char *fn;
+        int64_t length;
+        int64_t offset;
+        int bases_per_line;
+        int line_length;
+        int64_t count;     // for shared references so we know to dealloc seq
+        char *seq;
+        mFILE *mf;
+        int is_md5;        // Reference comes from a raw seq found by MD5
+        int validated_md5;
+    } ref_entry;
+
+Sharing of references to track use between threads is via
+cram_ref_incr* and cram_ref_decr* (which locked and unlocked
+variants).  We free a reference when the usage count hits zero.  To
+avoid spamming discard and reload in single-thread creation of a
+pos-sorted CRAM, we keep track of the last reference in cram_fd and
+delay discard by one loop iteration.
+
+There are complexities here around whether the references come from a
+single ref.fa file, are from a local MD5sum cache with one file per
+reference (mmapped), or whether they're fetched from some remote
+REF_PATH query such as the EBI.  (This later case typically downloads
+to a local md5 based ref-cache first and mmaps from there.)
+
+The refs struct start off by being populated from the SAM header.  We
+have M5 tag and name known, maybe a filename, but length is 0 and seq
+is NULL.  This is done by cram_load_reference:
+
+cram_load_reference (cram_fd, filename):
+    if filename non-NULL
+        call refs_load_fai
+	    Populates ref_entry with filename, name, length, line-len, etc
+    	sanitise_SQ_lines
+    If no refs loaded
+        call refs_from_header
+	    populates ref_entry with name.
+	    Sets length=0 as marker for not-yet-loaded
+
+The main interface used from the code is cram_get_ref().  It takes a
+reference ID, start and end coordinate and returns a pointer to the
+relevant sub-sequence.
+
+cram_get_ref:
+    r = fd->refs->ref_id[id];    // current ref
+    call cram_populate_ref if stored length is 0 (ie ref.fa set)
+        search REF_PATH / REF_CACHE
+	call bgzf_open if local_path
+	call open_path_mfile otherwise
+	copy to local REF_CACHE if required (eg remote fetch)
+
+    If start = 1 and end = ref-length
+       If ref seq unknown
+           call cram_ref_load to load entire ref and use that
+
+    If ref seq now known, return it
+
+    // Otherwise known via .fai or we've errored by now.
+    call load_ref_portion to return a sub-seq from index fasta
+
+The encoder asks for the entire reference rather than a small portion
+of it as we're usually encoding a large amount.  The decoder may be
+dealing with small range queries, so it only asks for the relevant
+sub-section of reference as specified in the cram slice headers.
+
+
+TODO
+====
+
+- Multi-ref mode is enabled when we have too many small containers in
+  a row.
+
+  Instead of firing off new containers when we switch reference, we
+  could always make a new container after N records, separating off
+  M <= N to make the container such that all M are the same reference,
+  and shuffling any remaining N-M down as the start of the next.
+
+  This means we can detect how many new containers we would create,
+  and enable multi-ref mode straight away rather than keeping a recent
+  history of how many small containers we've emitted.
+
+- The cache of references currently being used is a better place to
+  track the global embed-ref and non-ref logic.  Better than cram_fd.
+  Cram_fd is a one-way change, as once we enable non-ref we'll stick
+  with it.
+
+  However if it was per-ref in the ref-cache then we'd probe and try
+  each reference once, and then all new containers for that ref would
+  honour the per-ref parameters.  So a single missing reference in the
+  middle of a large file wouldn't change behaviour for all subsequence
+  references.
+
+  Optionally we could still do meta-analysis on how many references
+  are failing, and switch the global cram_fd params to avoid repeated
+  testing of reference availability if it's becoming obvious that none
+  of them are known.

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2438,8 +2438,9 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
             }
         }
 
-        if ((!s->ref && s->hdr->ref_base_id < 0)
-            || memcmp(digest, s->hdr->md5, 16) != 0) {
+        if (!c->comp_hdr->no_ref &&
+            ((!s->ref && s->hdr->ref_base_id < 0)
+             || memcmp(digest, s->hdr->md5, 16) != 0)) {
             char M[33];
             const char *rname = sam_hdr_tid2name(sh, ref_id);
             if (!rname) rname="?"; // cannot happen normally

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -3829,7 +3829,7 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
             if (NULL == (c = cram_next_container(fd, b))) {
                 if (fd->ctr) {
                     // prevent cram_close attempting to flush
-                    cram_free_container(fd->ctr);
+                    fd->ctr_mt = fd->ctr; // delay free when threading
                     fd->ctr = NULL;
                 }
                 return -1;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3203,7 +3203,7 @@ void cram_ref_decr(refs_t *r, int id) {
 }
 
 /*
- * Used by cram_ref_load and cram_ref_get. The file handle will have
+ * Used by cram_ref_load and cram_get_ref. The file handle will have
  * already been opened, so we can catch it. The ref_entry *e informs us
  * of whether this is a multi-line fasta file or a raw MD5 style file.
  * Either way we create a single contiguous sequence.
@@ -3455,7 +3455,7 @@ char *cram_get_ref(cram_fd *fd, int id, int start, int end) {
             hts_log_warning("Reference file given, but ref '%s' not present",
                             r->name);
         if (cram_populate_ref(fd, id, r) == -1) {
-            hts_log_error("Failed to populate reference for id %d", id);
+            hts_log_warning("Failed to populate reference for id %d", id);
             pthread_mutex_unlock(&fd->refs->lock);
             pthread_mutex_unlock(&fd->ref_lock);
             return NULL;
@@ -3652,6 +3652,8 @@ cram_container *cram_new_container(int nrec, int nslice) {
     c->max_apos   = 0;
     c->multi_seq  = 0;
     c->qs_seq_orient = 1;
+    c->no_ref = 0;
+    c->embed_ref = -1; // automatic selection
 
     c->bams = NULL;
 

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -457,6 +457,8 @@ struct cram_container {
     /* Copied from fd before encoding, to allow multi-threading */
     int ref_start, first_base, last_base, ref_id, ref_end;
     char *ref;
+    int embed_ref;               // 1 if embedding ref, 2 if embedding cons
+    int no_ref;                  // true if referenceless
     //struct ref_entry *ref;
 
     /* For multi-threading */
@@ -793,14 +795,14 @@ struct cram_fd {
     cram_container *ctr_mt;
 
     // positions for encoding or decoding
-    int first_base, last_base;
+    int first_base, last_base; // copied to container
 
     // cached reference portion
     refs_t *refs;              // ref meta-data structure
     char *ref, *ref_free;      // current portion held in memory
-    int   ref_id;
-    int   ref_start;
-    int   ref_end;
+    int   ref_id;              // copied to container
+    int   ref_start;           // copied to container
+    int   ref_end;             // copied to container
     char *ref_fn;   // reference fasta filename
 
     // compression level and metrics
@@ -813,8 +815,8 @@ struct cram_fd {
     int seqs_per_slice;
     int bases_per_slice;
     int slices_per_container;
-    int embed_ref;
-    int no_ref;
+    int embed_ref; // copied to container
+    int no_ref;    // copied to container
     int ignore_md5;
     int use_bz2;
     int use_rans;


### PR DESCRIPTION
- Fix crash when `cram_encode_container` during multi-threaded CRAM encoding.

- Prevent embed_ref=2 on name sorted data from being a hard failure for cram encoding.  It now switches to non-ref mode instead, so we always encode something, even if it's suboptimal.