### PR TITLE
FIx a bug in the codec learning algorithm for TOKA

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2183,6 +2183,8 @@ int cram_compress_block2(cram_fd *fd, cram_slice *s,
                 case FQZ_b:    strat = CRAM_MAJOR_VERS(fd->version)+256; break;
                 case FQZ_c:    strat = CRAM_MAJOR_VERS(fd->version)+2*256; break;
                 case FQZ_d:    strat = CRAM_MAJOR_VERS(fd->version)+3*256; break;
+                case TOK3:     strat = 0; break;
+                case TOKA:     strat = 1; break;
                 default:       strat = 0;
                 }
                 metrics->strat  = strat;


### PR DESCRIPTION
The name tokeniser has a rANS vs Arithmetic coder choice as a parameter (in the "strat" variable).  We lacked this distinction when learning which method works best, so in the choice of toka (tok3+arith) vs bzip2 vs gzip etc we selected tok3 and switched back to strat 0, disabling the arithmetic coder.

This only affects archive mode, or where a user explicitly used eg "samtools view -O cram,version=3.1,use_arith".