### PR TITLE
Fix crypt4gh redirection

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -1349,6 +1349,7 @@ static int hts_crypt4gh_redirect(const char *fn, const char *mode,
     hFILE *hfile1 = *hfile_ptr;
     hFILE *hfile2 = NULL;
     char fn_buf[512], *fn2 = fn_buf;
+    char mode2[102]; // Size set by sizeof(simple_mode) in hts_hopen()
     const char *prefix = "crypt4gh:";
     size_t fn2_len = strlen(prefix) + strlen(fn) + 1;
     int ret = -1;
@@ -1362,7 +1363,8 @@ static int hts_crypt4gh_redirect(const char *fn, const char *mode,
 
     // Reopen fn using the crypt4gh plug-in (if available)
     snprintf(fn2, fn2_len, "%s%s", prefix, fn);
-    hfile2 = hopen(fn2, mode, "parent", hfile1, NULL);
+    snprintf(mode2, sizeof(mode2), "%s%s", mode, strchr(mode, ':') ? "" : ":");
+    hfile2 = hopen(fn2, mode2, "parent", hfile1, NULL);
     if (hfile2) {
         // Replace original hfile with the new one.  The original is now
         // enclosed within hfile2


### PR DESCRIPTION
hopen() uses a ':' in `mode` to indicate that there are extra parameters.  hts_crypt4gh_redirect() needs to add this so that the "parent" parameter is picked up by the crypt4gh plug-in.

Failing to do this caused it to re-open the file instead of reusing the existing file handle - which worked for regular files but not for things like pipes or htsget.

Problem noticed when trying to reproduce some crypt4gh-over-htsget work.