### PR TITLE
Slightly speed up various cram decoding functions

### DIFF
--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -229,7 +229,7 @@ static inline int block_resize(cram_block *b, size_t len) {
 
     size_t alloc = b->alloc;
     while (alloc <= len)
-        alloc = alloc ? alloc*1.5 : 1024;
+        alloc = alloc ? alloc + (alloc>>2) : 1024;
 
     return block_resize_exact(b, alloc);
 }

--- a/sam.c
+++ b/sam.c
@@ -598,9 +598,19 @@ int bam_set1(bam1_t *bam,
     }
     cp += n_cigar * 4;
 
-    for (i = 0; i + 1 < l_seq; i += 2) {
-        *cp++ = (seq_nt16_table[(unsigned char)seq[i]] << 4) | seq_nt16_table[(unsigned char)seq[i + 1]];
+#define NN 16
+    const uint8_t *useq = (uint8_t *)seq;
+    for (i = 0; i + NN < l_seq; i += NN) {
+        int j;
+        const uint8_t *u2 = useq+i;
+        for (j = 0; j < NN/2; j++)
+            cp[j] = (seq_nt16_table[u2[j*2]]<<4) | seq_nt16_table[u2[j*2+1]];
+        cp += NN/2;
     }
+    for (; i + 1 < l_seq; i += 2) {
+        *cp++ = (seq_nt16_table[useq[i]] << 4) | seq_nt16_table[useq[i + 1]];
+    }
+
     for (; i < l_seq; i++) {
         *cp++ = seq_nt16_table[(unsigned char)seq[i]] << 4;
     }


### PR DESCRIPTION
None of this is huge, but it all adds up.

- bam_set1 has been refactored so -O3 is more likely to do unrolling and vectorisation.

```
    // Old          time   inst        cyc
    // gcc -O2      12.36  78936832183 36853852204
    // gcc -O3      12.37  78713347525 36867027825
    // clang13 -O2  12.43  77451926728 37012866717
    // clang13 -O3  12.32  77627221907 36691623424
    // gcc12 -O2    12.43  78895089091 37081260172
    // gcc12 -O3    12.36  78505904437 36829216967

    // New
    // gcc -O2      12.47  78832021505 37200597109 +
    // gcc -O3      12.14  76499369401 36390334338 --
    // clang13 -O2  12.38  76678460761 36920111561 ~
    // clang13 -O3  12.26  76678023071 36548488492 ~
    // gcc12 -O2    12.38  78581694397 36880034181 -
    // gcc12 -O3    12.15  76356625541 36293921439 --
```

- Improve the MD/NM generation in CRAM decoding. With decode_md=1 (default) by decode changed from 12.91s to 12.57s With decode_md=0 it's 11.92, so that's 1/3rd of the overhead removed.

- Changed the block_resize to resize in slightly smaller chunks and to use integer maths.

- Reduce excessive pointer redirection in cram_decode_seq.

  Unsure if this speeds things up much (sometimes it seems to), but it provides tidier code too.

Combined before and after on 10 million NovaSeq CRAM (v3.1)

epyc 7543

                   before   after
    gcc(7)  -O2    7.67     7.63   -0.5%
    gcc12   -O2    7.59     7.60   +0.1%
    clang7  -O2    8.12     7.57   -6.8%
    clang13 -O2    8.06     7.54   -6.5%

    gcc(7)  -O3    7.73     7.46   -3.5%
    gcc12   -O3    7.46     7.35   -1.5%
    clang7  -O3    8.08     7.57   -6.3%
    clang13 -O3    7.95     7.66   -3.6%

Xeon Gold 6142

                   before   after
    gcc(7)  -O2    9.74     9.14   -6.2%
    gcc12   -O2    9.43     8.45  -10.4%
    clang7  -O2    9.61     8.64  -10.0%
    clang13 -O2    9.95     8.85  -11.1%

    gcc(7)  -O3    9.51     8.81   -7.4%
    gcc12   -O3    9.15     8.42   -8.0%
    clang7  -O3    9.92     8.72  -12.1%
    clang13 -O3    9.68     8.91   -8.0%
    
Biggest change is with clang, but also on Intel we see bigger changes than AMD too.