### PR TITLE
Remove use of sprintf() from HTSlib source

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -656,9 +656,10 @@ static int cram_index_build_multiref(cram_fd *fd,
         }
 
         if (ref != -2) {
-            sprintf(buf, "%d\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%d\t%d\n",
-                    ref, ref_start, ref_end - ref_start + 1,
-                    (int64_t)cpos, landmark, sz);
+            snprintf(buf, sizeof(buf),
+                     "%d\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%d\t%d\n",
+                     ref, ref_start, ref_end - ref_start + 1,
+                     (int64_t)cpos, landmark, sz);
             if (bgzf_write(fp, buf, strlen(buf)) < 0)
                 return -4;
         }
@@ -669,9 +670,10 @@ static int cram_index_build_multiref(cram_fd *fd,
     }
 
     if (ref != -2) {
-        sprintf(buf, "%d\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%d\t%d\n",
-                ref, ref_start, ref_end - ref_start + 1,
-                (int64_t)cpos, landmark, sz);
+        snprintf(buf, sizeof(buf),
+                 "%d\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%d\t%d\n",
+                 ref, ref_start, ref_end - ref_start + 1,
+                 (int64_t)cpos, landmark, sz);
         if (bgzf_write(fp, buf, strlen(buf)) < 0)
             return -4;
     }
@@ -701,9 +703,10 @@ int cram_index_slice(cram_fd *fd,
     if (s->hdr->ref_seq_id == -2) {
         ret = cram_index_build_multiref(fd, c, s, fp, cpos, spos, sz);
     } else {
-        sprintf(buf, "%d\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%d\t%d\n",
-                s->hdr->ref_seq_id, s->hdr->ref_seq_start,
-                s->hdr->ref_seq_span, (int64_t)cpos, (int)spos, (int)sz);
+        snprintf(buf, sizeof(buf),
+                 "%d\t%"PRId64"\t%"PRId64"\t%"PRId64"\t%d\t%d\n",
+                 s->hdr->ref_seq_id, s->hdr->ref_seq_start,
+                 s->hdr->ref_seq_span, (int64_t)cpos, (int)spos, (int)sz);
         ret = (bgzf_write(fp, buf, strlen(buf)) >= 0)? 0 : -4;
     }
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2531,7 +2531,7 @@ static refs_t *refs_load_fai(refs_t *r_orig, const char *fn, int is_err) {
         /* Only the reference file provided. Get the index file name from it */
             if (!(r->fn = string_dup(r->pool, fn)))
                 goto err;
-            sprintf(fai_fn, "%.*s.fai", PATH_MAX-5, fn);
+            snprintf(fai_fn, PATH_MAX, "%.*s.fai", PATH_MAX-5, fn);
         }
     }
 
@@ -4816,7 +4816,7 @@ static void full_path(char *out, char *in) {
         strncpy(out, in, PATH_MAX-1);
         out[PATH_MAX-1] = 0;
     } else {
-        int len;
+        size_t len;
 
         // unable to get dir or out+in is too long
         if (!getcwd(out, PATH_MAX) ||
@@ -4826,7 +4826,7 @@ static void full_path(char *out, char *in) {
             return;
         }
 
-        sprintf(out+len, "/%.*s", PATH_MAX - 2 - len, in);
+        snprintf(out+len, PATH_MAX - len, "/%s", in);
 
         // FIXME: cope with `pwd`/../../../foo.fa ?
     }

--- a/cram/open_trace_file.c
+++ b/cram/open_trace_file.c
@@ -242,7 +242,7 @@ static char *expand_path(const char *file, char *dirname, int max_s_digits) {
 
     /* Special case for "./" or absolute filenames */
     if (*file == '/' || (len==1 && *dirname == '.')) {
-        sprintf(path, "%s", file);
+        memcpy(path, file, lenf + 1);
     } else {
         /* Handle %[0-9]*s expansions, if required */
         char *path_end = path;

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -451,12 +451,12 @@ static int auth_header_callback(void *ctx, char ***hdrs) {
 
 /* like a escape path but for query strings '=' and '&' are untouched */
 static char *escape_query(const char *qs) {
-    size_t i, j = 0, length;
+    size_t i, j = 0, length, alloced;
     char *escaped;
 
     length = strlen(qs);
-
-    if ((escaped = malloc(length * 3 + 1)) == NULL) {
+    alloced = length * 3 + 1;
+    if ((escaped = malloc(alloced)) == NULL) {
         return NULL;
     }
 
@@ -467,29 +467,25 @@ static char *escape_query(const char *qs) {
              c == '_' || c == '-' || c == '~' || c == '.' || c == '/' || c == '=' || c == '&') {
             escaped[j++] = c;
         } else {
-            sprintf(escaped + j, "%%%02X", c);
+            snprintf(escaped + j, alloced - j, "%%%02X", c);
             j += 3;
         }
     }
 
-    if (i != length) {
-        // in the case of a '?' copy the rest of the qs across unchanged
-        strcpy(escaped + j, qs + i);
-    } else {
-        escaped[j] = '\0';
-    }
+    escaped[j] = '\0';
 
     return escaped;
 }
 
 
 static char *escape_path(const char *path) {
-    size_t i, j = 0, length;
+    size_t i, j = 0, length, alloced;
     char *escaped;
 
     length = strlen(path);
+    alloced = length * 3 + 1;
 
-    if ((escaped = malloc(length * 3 + 1)) == NULL) {
+    if ((escaped = malloc(alloced)) == NULL) {
         return NULL;
     }
 
@@ -502,7 +498,7 @@ static char *escape_path(const char *path) {
              c == '_' || c == '-' || c == '~' || c == '.' || c == '/') {
             escaped[j++] = c;
         } else {
-            sprintf(escaped + j, "%%%02X", c);
+            snprintf(escaped + j, alloced - j, "%%%02X", c);
             j += 3;
         }
     }
@@ -842,14 +838,14 @@ AWS S3 sig version 4 writing code
 
 ****************************************************************/
 
-static void hash_string(char *in, size_t length, char *out) {
+static void hash_string(char *in, size_t length, char *out, size_t out_len) {
     unsigned char hashed[SHA256_DIGEST_BUFSIZE];
     int i, j;
 
     s3_sha256((const unsigned char *)in, length, hashed);
 
     for (i = 0, j = 0; i < SHA256_DIGEST_BUFSIZE; i++, j+= 2) {
-        sprintf(out + j, "%02x", hashed[i]);
+        snprintf(out + j, out_len - j, "%02x", hashed[i]);
     }
 }
 
@@ -866,7 +862,7 @@ static void ksfree(kstring_t *s) {
 }
 
 
-static int make_signature(s3_auth_data *ad, kstring_t *string_to_sign, char *signature_string) {
+static int make_signature(s3_auth_data *ad, kstring_t *string_to_sign, char *signature_string, size_t sig_string_len) {
     unsigned char date_key[SHA256_DIGEST_BUFSIZE];
     unsigned char date_region_key[SHA256_DIGEST_BUFSIZE];
     unsigned char date_region_service_key[SHA256_DIGEST_BUFSIZE];
@@ -893,7 +889,7 @@ static int make_signature(s3_auth_data *ad, kstring_t *string_to_sign, char *sig
     s3_sign_sha256(signing_key, len, (const unsigned char *)string_to_sign->s, string_to_sign->l, signature, &len);
 
     for (i = 0, j = 0; i < len; i++, j+= 2) {
-        sprintf(signature_string + j, "%02x", signature[i]);
+        snprintf(signature_string + j, sig_string_len - j, "%02x", signature[i]);
     }
 
     ksfree(&secret_access_key);
@@ -945,7 +941,7 @@ static int make_authorisation(s3_auth_data *ad, char *http_request, char *conten
         goto cleanup;
     }
 
-    hash_string(canonical_request.s, canonical_request.l, cr_hash);
+    hash_string(canonical_request.s, canonical_request.l, cr_hash, sizeof(cr_hash));
 
     ksprintf(&scope, "%s/%s/s3/aws4_request", ad->date_short, ad->region.s);
 
@@ -959,7 +955,7 @@ static int make_authorisation(s3_auth_data *ad, char *http_request, char *conten
         goto cleanup;
     }
 
-    if (make_signature(ad, &string_to_sign, signature_string)) {
+    if (make_signature(ad, &string_to_sign, signature_string, sizeof(signature_string))) {
         goto cleanup;
     }
 
@@ -1094,10 +1090,10 @@ static int write_authorisation_callback(void *auth, char *request, kstring_t *co
     }
 
     if (content) {
-        hash_string(content->s, content->l, content_hash);
+        hash_string(content->s, content->l, content_hash, sizeof(content_hash));
     } else {
         // empty hash
-        hash_string("", 0, content_hash);
+        hash_string("", 0, content_hash, sizeof(content_hash));
     }
 
     ad->canonical_query_string.l = 0;
@@ -1166,7 +1162,7 @@ static int v4_auth_header_callback(void *ctx, char ***hdrs) {
         return copy_auth_headers(ad, hdrs);
     }
 
-    hash_string("", 0, content_hash); // empty hash
+    hash_string("", 0, content_hash, sizeof(content_hash)); // empty hash
 
     ad->canonical_query_string.l = 0;
 

--- a/kstring.c
+++ b/kstring.c
@@ -57,7 +57,7 @@ int kputd(double d, kstring_t *s) {
 		if (ks_resize(s, s->l + 50) < 0)
 			return EOF;
 		// We let stdio handle the exponent cases
-		int s2 = sprintf(s->s + s->l, "%g", d);
+		int s2 = snprintf(s->s + s->l, s->m - s->l, "%g", d);
 		len += s2;
 		s->l += s2;
 		return len;

--- a/plugin.c
+++ b/plugin.c
@@ -210,7 +210,7 @@ const char *hts_plugin_path(void) {
     }
 
     static char s_path[1024];
-    sprintf(s_path, "%.1023s", ks.s ? ks.s : "");
+    snprintf(s_path, sizeof(s_path), "%s", ks.s ? ks.s : "");
     free(ks.s);
 
     return s_path;

--- a/sam.c
+++ b/sam.c
@@ -5392,20 +5392,22 @@ int bam_plp_insertion_mod(const bam_pileup1_t *p,
                     for (j = 0; j < nm; j++) {
                         char qual[20];
                         if (mod[j].qual >= 0)
-                            sprintf(qual, "%d", mod[j].qual);
+                            snprintf(qual, sizeof(qual), "%d", mod[j].qual);
                         else
                             *qual=0;
                         if (mod[j].modified_base < 0)
                             // ChEBI
-                            indel += sprintf(&ins->s[indel], "%c(%d)%s",
-                                             "+-"[mod[j].strand],
-                                             -mod[j].modified_base,
-                                             qual);
+                            indel += snprintf(&ins->s[indel], ins->m - indel,
+                                              "%c(%d)%s",
+                                              "+-"[mod[j].strand],
+                                              -mod[j].modified_base,
+                                              qual);
                         else
-                            indel += sprintf(&ins->s[indel], "%c%c%s",
-                                             "+-"[mod[j].strand],
-                                             mod[j].modified_base,
-                                             qual);
+                            indel += snprintf(&ins->s[indel], ins->m - indel,
+                                              "%c%c%s",
+                                              "+-"[mod[j].strand],
+                                              mod[j].modified_base,
+                                              qual);
                     }
                     ins->s[indel++] = ']';
                     ins->l += indel - o_indel; // grow by amount we used

--- a/test/hfile.c
+++ b/test/hfile.c
@@ -176,7 +176,7 @@ int main(void)
     original = slurp("vcf.c");
     for (i = 1; i <= 6; i++) {
         char *text;
-        sprintf(buffer, "test/hfile%d.tmp", i);
+        snprintf(buffer, sizeof(buffer), "test/hfile%d.tmp", i);
         text = slurp(buffer);
         if (strcmp(original, text) != 0) {
             fprintf(stderr, "%s differs from vcf.c\n", buffer);

--- a/test/sam.c
+++ b/test/sam.c
@@ -1504,7 +1504,7 @@ static void faidx1(const char *filename)
 
     fin = fopen(filename, "rb");
     if (fin == NULL) fail("can't open %s", filename);
-    sprintf(tmpfilename, "%s.tmp", filename);
+    snprintf(tmpfilename, sizeof(tmpfilename), "%s.tmp", filename);
     fout = fopen(tmpfilename, "wb");
     if (fout == NULL) fail("can't create temporary %s", tmpfilename);
     while (fgets(line, sizeof line, fin)) {

--- a/test/test-regidx.c
+++ b/test/test-regidx.c
@@ -304,20 +304,20 @@ void test_explicit(char *tgt, char *qry, char *exp)
     regidx_destroy(idx);
 }
 
-void create_line_bed(char *line, char *chr, int start, int end)
+void create_line_bed(char *line, size_t size, char *chr, int start, int end)
 {
-    sprintf(line,"%s\t%d\t%d\n",chr,start-1,end);
+    snprintf(line,size,"%s\t%d\t%d\n",chr,start-1,end);
 }
-void create_line_tab(char *line, char *chr, int start, int end)
+void create_line_tab(char *line, size_t size, char *chr, int start, int end)
 {
-    sprintf(line,"%s\t%d\t%d\n",chr,start,end);
+    snprintf(line,size,"%s\t%d\t%d\n",chr,start,end);
 }
-void create_line_reg(char *line, char *chr, int start, int end)
+void create_line_reg(char *line, size_t size, char *chr, int start, int end)
 {
-    sprintf(line,"%s:%d-%d\n",chr,start,end);
+    snprintf(line,size,"%s:%d-%d\n",chr,start,end);
 }
 
-typedef void (*set_line_f)(char *line, char *chr, int start, int end);
+typedef void (*set_line_f)(char *line, size_t size, char *chr, int start, int end);
 
 void test(set_line_f set_line, regidx_parse_f parse)
 {
@@ -329,17 +329,17 @@ void test(set_line_f set_line, regidx_parse_f parse)
     for (i=1; i<n; i++)
     {
         start = end = 10*i;
-        set_line(line,chr,start,end);
+        set_line(line,sizeof(line),chr,start,end);
         debug("insert: %s", line);
         if ( regidx_insert(idx,line)!=0 ) error("insert failed: %s\n", line);
 
         start = end = 10*i + 1;
-        set_line(line,chr,start,end);
+        set_line(line,sizeof(line),chr,start,end);
         debug("insert: %s", line);
         if ( regidx_insert(idx,line)!=0 ) error("insert failed: %s\n", line);
 
         start = 20000*i; end = start + 2000;
-        set_line(line,chr,start,end);
+        set_line(line,sizeof(line),chr,start,end);
         debug("insert: %s", line);
         if ( regidx_insert(idx,line)!=0 ) error("insert failed: %s\n", line);
     }
@@ -396,7 +396,7 @@ void test(set_line_f set_line, regidx_parse_f parse)
 
         // fully contained interval, one hit
         start = 20000*i - 5000; end = 20000*i + 3000;
-        set_line(line,chr,start,end);
+        set_line(line,sizeof(line),chr,start,end);
         if ( !regidx_overlap(idx,chr,start-1,end-1,itr) ) error("query failed, there should be a hit: %s:%d-%d\n",chr,start,end);
         debug("ok: overlap(s) found for %s:%d-%d\n",chr,start,end);
         nhit = 0;

--- a/test/test_mod.c
+++ b/test/test_mod.c
@@ -79,7 +79,7 @@ static char *code(int id) {
         code[0] = id;
         code[1] = 0;
     } else {
-        sprintf(code, "(%d)", -id);
+        snprintf(code, sizeof(code), "(%d)", -id);
     }
 
     return code;
@@ -119,10 +119,10 @@ int main(int argc, char **argv) {
         int i, j, n;
         hts_base_mod mods[5];
         for (i = 0; i < b->core.l_qseq; i++) {
-            char line[8192], *lp = line;
+            char line[8192], *lp = line, *ep = line + sizeof(line);
             n = bam_mods_at_next_pos(b, m, mods, 5);
-            lp += sprintf(lp, "%d\t%c\t",
-                          i, seq_nt16_str[bam_seqi(bam_get_seq(b), i)]);
+            lp += snprintf(lp, ep - lp, "%d\t%c\t",
+                           i, seq_nt16_str[bam_seqi(bam_get_seq(b), i)]);
             for (j = 0; j < n && j < 5; j++) {
                 if (extended) {
                     int m_strand, m_implicit;
@@ -134,18 +134,18 @@ int main(int argc, char **argv) {
                         m_canonical != mods[j].canonical_base ||
                         m_strand    != mods[j].strand)
                         goto err;
-                    lp += sprintf(lp, "%c%c%s%c%d ",
-                                  mods[j].canonical_base,
-                                  "+-"[mods[j].strand],
-                                  code(mods[j].modified_base),
-                                  "?."[m_implicit],
-                                  mods[j].qual);
+                    lp += snprintf(lp, ep - lp, "%c%c%s%c%d ",
+                                   mods[j].canonical_base,
+                                   "+-"[mods[j].strand],
+                                   code(mods[j].modified_base),
+                                   "?."[m_implicit],
+                                   mods[j].qual);
                 } else {
-                    lp += sprintf(lp, "%c%c%s%d ",
-                                  mods[j].canonical_base,
-                                  "+-"[mods[j].strand],
-                                  code(mods[j].modified_base),
-                                  mods[j].qual);
+                    lp += snprintf(lp, ep - lp, "%c%c%s%d ",
+                                   mods[j].canonical_base,
+                                   "+-"[mods[j].strand],
+                                   code(mods[j].modified_base),
+                                   mods[j].qual);
                 }
             }
             *lp++ = '\n';
@@ -172,15 +172,15 @@ int main(int argc, char **argv) {
 
         int pos;
         while ((n=bam_next_basemod(b, m, mods, 5, &pos)) > 0) {
-            char line[8192]={0}, *lp = line;
-            lp += sprintf(lp, "%d\t%c\t", pos,
-                          seq_nt16_str[bam_seqi(bam_get_seq(b), pos)]);
+            char line[8192]={0}, *lp = line, *ep = line + sizeof(line);
+            lp += snprintf(lp, ep - lp, "%d\t%c\t", pos,
+                           seq_nt16_str[bam_seqi(bam_get_seq(b), pos)]);
             for (j = 0; j < n && j < 5; j++) {
-                lp += sprintf(lp, "%c%c%s%d ",
-                              mods[j].canonical_base,
-                              "+-"[mods[j].strand],
-                              code(mods[j].modified_base),
-                              mods[j].qual);
+                lp += snprintf(lp, ep - lp, "%c%c%s%d ",
+                               mods[j].canonical_base,
+                               "+-"[mods[j].strand],
+                               code(mods[j].modified_base),
+                               mods[j].qual);
             }
             *lp++ = '\n';
             *lp++ = 0;

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -362,7 +362,8 @@ int main(int argc, char *argv[])
     }
 
     strcpy(modew, "w");
-    if (opts.clevel >= 0 && opts.clevel <= 9) sprintf(modew + 1, "%d", opts.clevel);
+    if (opts.clevel >= 0 && opts.clevel <= 9)
+        snprintf(modew + 1, sizeof(modew) - 1, "%d", opts.clevel);
     if (opts.flag & WRITE_CRAM) strcat(modew, "c");
     else if (opts.flag & WRITE_BINARY_COMP) strcat(modew, "b");
     else if (opts.flag & WRITE_COMPRESSED) strcat(modew, "z");

--- a/textutils.c
+++ b/textutils.c
@@ -453,7 +453,7 @@ const char *
 hts_strprint(char *buf, size_t buflen, char quote, const char *s, size_t len)
 {
     const char *slim = (len < SIZE_MAX)? &s[len] : NULL;
-    char *t = buf;
+    char *t = buf, *bufend = buf + buflen;
 
     size_t qlen = quote? 1 : 0;
     if (quote) *t++ = quote;
@@ -482,7 +482,7 @@ hts_strprint(char *buf, size_t buflen, char quote, const char *s, size_t len)
         }
 
         if (clen == 4) {
-            sprintf(t, "\\x%02X", (unsigned char) c);
+            snprintf(t, bufend - t, "\\x%02X", (unsigned char) c);
             t += clen;
         }
         else {


### PR DESCRIPTION
None of these instances were really a problem, but using it upsets some downstream packagers (notably R).  The easiest way to keep them happy is to stop using it and (mostly) switch to snprintf() instead.

Fixes #1586
