### PR TITLE
Fix typo in kh_int_hash_func2 macro.

### DIFF
--- a/htslib/khash.h
+++ b/htslib/khash.h
@@ -447,7 +447,7 @@ static kh_inline khint_t __ac_Wang_hash(khint_t key)
     key ^=  (key >> 16);
     return key;
 }
-#define kh_int_hash_func2(k) __ac_Wang_hash((khint_t)key)
+#define kh_int_hash_func2(key) __ac_Wang_hash((khint_t)(key))
 
 /* --- END OF HASH FUNCTIONS --- */
 


### PR DESCRIPTION
This was fixed upstream in attractivechaos/klib@384277a

Fixes #1598