### PR TITLE
Mention in INSTALL that using plugins may need -rdynamic

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -129,6 +129,9 @@ various features and specify further optional external requirements:
     any enabled pluggable facilities (such as libcurl file access) are built
     directly within HTSlib.
 
+    Programs that are statically linked to a libhts.a with plugins enabled
+    need to be linked using -rdynamic or a similar linker option.
+
     The <https://github.com/samtools/htslib-plugins> repository contains
     several additional plugins, including the iRODS (<http://irods.org/>)
     file access plugin previously distributed with HTSlib.


### PR DESCRIPTION
Document static linking options needed with current plugin mechanism. Addresses #1600.

There may be platforms where the option is called something other than `-rdynamic`, and the underlying `ld` option is called something else. This could mention what CMake calls it, but they'll only change the name of the property again next week… :smile: