### PR TITLE
Fix example in docs for sam_hdr_add_line

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -485,7 +485,7 @@ int sam_hdr_add_lines(sam_hdr_t *h, const char *lines, size_t len);
 /// Adds a single line to an existing header.
 /*!
  * Specify type and one or more key,value pairs, ending with the NULL key.
- * Eg. sam_hdr_add_line(h, "SQ", "ID", "foo", "LN", "100", NULL).
+ * Eg. sam_hdr_add_line(h, "SQ", "SN", "foo", "LN", "100", NULL).
  *
  * @param type  Type of the added line. Eg. "SQ"
  * @return      0 on success, -1 on failure


### PR DESCRIPTION
Hi!

I am glad to have the opportunity to send you another pull request.
In the example in the `sam_hdr_add_line` documentation, I propose changing "ID" to "SN."

```
[E::sam_hrecs_update_hashes] Header includes @SQ line with no SN: tag
```

https://github.com/samtools/htslib/blob/279cc9ec8d3fd5ad94aa0df730dac6e9ec0ead8f/htslib/sam.h#L471

Best regards.