### PR TITLE
Allow repeated calls of bcf_sr_set_regions

### DIFF
--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -1,7 +1,7 @@
 /// @file htslib/synced_bcf_reader.h
 /// Stream through multiple VCF files.
 /*
-    Copyright (C) 2012-2017, 2019-2021 Genome Research Ltd.
+    Copyright (C) 2012-2017, 2019-2023 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>
 
@@ -306,8 +306,10 @@ int bcf_sr_set_samples(bcf_srs_t *readers, const char *samples, int is_file);
  *  Targets (but not regions) can be prefixed with "^" to request logical complement,
  *  for example "^X,Y,MT" indicates that sequences X, Y and MT should be skipped.
  *
- *  API note: bcf_sr_set_regions/bcf_sr_set_targets MUST be called before the
- *  first call to bcf_sr_add_reader().
+ *  API notes:
+ *  - bcf_sr_set_targets MUST be called before the first call to bcf_sr_add_reader()
+ *  - bcf_sr_set_regions AFTER readers where initialized will reposition the readers
+ *    and discard all previous regions.
  */
 HTSLIB_EXPORT
 int bcf_sr_set_targets(bcf_srs_t *readers, const char *targets, int is_file, int alleles);

--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -308,8 +308,8 @@ int bcf_sr_set_samples(bcf_srs_t *readers, const char *samples, int is_file);
  *
  *  API notes:
  *  - bcf_sr_set_targets MUST be called before the first call to bcf_sr_add_reader()
- *  - bcf_sr_set_regions AFTER readers where initialized will reposition the readers
- *    and discard all previous regions.
+ *  - calling bcf_sr_set_regions AFTER readers have been initialized will
+ *    reposition the readers and discard all previous regions.
  */
 HTSLIB_EXPORT
 int bcf_sr_set_targets(bcf_srs_t *readers, const char *targets, int is_file, int alleles);


### PR DESCRIPTION
and make repeated bcf_sr_seek()+next_line() calls consistent.

Resolves #1623 and https://github.com/samtools/bcftools/issues/1918