### PR TITLE
Pull in latest htscodecs and improve portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -732,17 +732,17 @@ htscodecs/tests/tokenise_name3: htscodecs/tests/tokenise_name3_test.o $(HTSCODEC
 htscodecs/tests/varint: htscodecs/tests/varint_test.o $(HTSCODECS_OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS) -lm -lpthread
 
-htscodecs/tests/arith_dynamic_test.o: CPPFLAGS += -Ihtscodecs -D_POSIX_C_SOURCE=200112L
+htscodecs/tests/arith_dynamic_test.o: CPPFLAGS += -Ihtscodecs
 htscodecs/tests/arith_dynamic_test.o: htscodecs/tests/arith_dynamic_test.c $(htscodecs_arith_dynamic_h)
-htscodecs/tests/fqzcomp_qual_test.o: CPPFLAGS += -Ihtscodecs -D_POSIX_C_SOURCE=200112L
+htscodecs/tests/fqzcomp_qual_test.o: CPPFLAGS += -Ihtscodecs
 htscodecs/tests/fqzcomp_qual_test.o: htscodecs/tests/fqzcomp_qual_test.c $(htscodecs_fqzcomp_qual_h) $(htscodecs_varint_h)
-htscodecs/tests/rANS_static4x16pr_test.o: CPPFLAGS += -Ihtscodecs -D_POSIX_C_SOURCE=200112L
+htscodecs/tests/rANS_static4x16pr_test.o: CPPFLAGS += -Ihtscodecs
 htscodecs/tests/rANS_static4x16pr_test.o: htscodecs/tests/rANS_static4x16pr_test.c $(htscodecs_rANS_static4x16_h)
-htscodecs/tests/rANS_static_test.o: CPPFLAGS += -Ihtscodecs -D_POSIX_C_SOURCE=200112L
+htscodecs/tests/rANS_static_test.o: CPPFLAGS += -Ihtscodecs
 htscodecs/tests/rANS_static_test.o: htscodecs/tests/rANS_static_test.c $(htscodecs_rANS_static_h)
-htscodecs/tests/tokenise_name3_test.o: CPPFLAGS += -Ihtscodecs -D_POSIX_C_SOURCE=200112L
+htscodecs/tests/tokenise_name3_test.o: CPPFLAGS += -Ihtscodecs
 htscodecs/tests/tokenise_name3_test.o: htscodecs/tests/tokenise_name3_test.c $(htscodecs_tokenise_name3_h)
-htscodecs/tests/varint_test.o: CPPFLAGS += -Ihtscodecs -D_POSIX_C_SOURCE=200112L
+htscodecs/tests/varint_test.o: CPPFLAGS += -Ihtscodecs
 htscodecs/tests/varint_test.o: htscodecs/tests/varint_test.c $(htscodecs_varint_h)
 
 test/hts_endian.o: test/hts_endian.c config.h $(htslib_hts_endian_h)

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,19 @@ dnl Flags to treat warnings as errors.  These need to be applied to CFLAGS
 dnl later as they can interfere with some of the tests (notably AC_SEARCH_LIBS)
 HTS_PROG_CC_WERROR(hts_late_cflags)
 
+# HTSlib uses X/Open-only facilities (M_SQRT2 etc, drand48() etc), and
+# various POSIX functions that are provided by various _POSIX_C_SOURCE values
+# or by _XOPEN_SOURCE >= 500. It also uses usleep(), which is removed when
+# _XOPEN_SOURCE >= 700. Additionally, some definitions may require
+# _XOPEN_SOURCE >= 600 on some platforms (snprintf on MinGW,
+# PTHREAD_MUTEX_RECURSIVE on some Linux distributions). Hence we set it to 600.
+
+# Define _XOPEN_SOURCE unless the user has already done so via $CPPFLAGS etc.
+AC_CHECK_DECL([_XOPEN_SOURCE], [],
+  [AC_DEFINE([_XOPEN_SOURCE], [600], [Specify X/Open requirements])],
+  [])
+
+
 dnl Check for various compiler flags to enable SIMD features
 dnl Options for rANS32x16 sse4.1 version - ssse3
 hts_cflags_sse4=""
@@ -263,7 +276,9 @@ case $basic_host in
     # This also sets __USE_MINGW_ANSI_STDIO which in turn makes PRId64,
     # %lld and %z printf formats work.  It also enforces the snprintf to
     # be C99 compliant so it returns the correct values (in kstring.c).
-    CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=600"
+
+    # Now set by default, so no need to do it here.
+    # CPPFLAGS="$CPPFLAGS -D_XOPEN_SOURCE=600"
     ;;
   *)
     host_result="plain .so"
@@ -583,7 +598,8 @@ AC_SEARCH_LIBS(regcomp, regex, [libregex=needed], [])
 
 dnl Look for PTHREAD_MUTEX_RECURSIVE.
 dnl This is normally in pthread.h except on some broken glibc implementations.
-AC_CHECK_DECL(PTHREAD_MUTEX_RECURSIVE, [], [AC_DEFINE([_XOPEN_SOURCE],[600], [Needed for PTHREAD_MUTEX_RECURSIVE])], [[#include <pthread.h>]])
+dnl Now set by default
+dnl AC_CHECK_DECL(PTHREAD_MUTEX_RECURSIVE, [], [AC_DEFINE([_XOPEN_SOURCE],[600], [Needed for PTHREAD_MUTEX_RECURSIVE])], [[#include <pthread.h>]])
 
 if test "$s3" = enabled ; then
    AC_DEFINE([ENABLE_S3], 1, [Define if HTSlib should enable S3 support.])

--- a/configure.ac
+++ b/configure.ac
@@ -136,8 +136,7 @@ dnl Propagate HTSlib's unaligned access preference to htscodecs
 /* Prevent unaligned access in htscodecs SSE4 rANS codec */
 #if defined(HTS_ALLOW_UNALIGNED) && HTS_ALLOW_UNALIGNED == 0
 #undef UBSAN
-#endif
-  ])
+#endif])
   AC_DEFINE([UBSAN],1,[])
 ])
 AC_SUBST([hts_cflags_sse4])

--- a/test/compare_sam.pl
+++ b/test/compare_sam.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 #    Copyright (C) 2013-2018 Genome Research Ltd.
 #
@@ -26,6 +26,7 @@
 # Optionally can skip header or ignore specific types of diff.
 
 use strict;
+use warnings;
 use Getopt::Long;
 
 my %opts;

--- a/test/maintainer/check_copyright.pl
+++ b/test/maintainer/check_copyright.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # check_copyright.pl : Basic source file checks for copyright boilerplate
 #
 #     Author : Rob Davies <rmd@sanger.ac.uk>

--- a/test/maintainer/check_copyright.pl
+++ b/test/maintainer/check_copyright.pl
@@ -49,6 +49,7 @@ sub check {
     # Exclusions:
     my %exclude = map { ("$root/$_", 1) } (
 'config.h',         # Auto-generated
+'config_vars.h',    # Auto-generated
 'version.h',        # Auto-generated
 'cram/rANS_byte.h', # "Public domain"
 'os/lzma_stub.h',   # "Public domain"

--- a/test/maintainer/check_spaces.pl
+++ b/test/maintainer/check_spaces.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # check_spaces.pl : Check source files for tabs and trailing spaces
 #
 #     Author : Rob Davies <rmd@sanger.ac.uk>


### PR DESCRIPTION
Pulls in the latest version of htscodecs, including a change to add `#include "config.h"` to the htscodecs test sources, allowing a hack (which didn't work on FreeBSD) that set `_POSIX_C_SOURCE` when building them to be removed.  `configure` is also changed so that it adds `#define _XOPEN_SOURCE 600` by default to `config.h` instead of relying on the `PTHREAD_MUTEX_RECURSIVE` test to do it, which allows that test and various other places that set `_XOPEN_SOURCE` to be removed.  I've set the author of the commit that does this to @jmarshall as it's mostly his work - hopefully that's OK.

The other commits fix some minor annoyances when running `make maintainer-check` on a repository where `configure` has been run; and makes all the perl scripts use `#!/usr/bin/env perl` (some already did) so that they work on platforms like FreeBSD which put perl in `/usr/local/bin`.

Fixes #1606 
Closes #1608 