### PR TITLE
Add support for non-standard chromosome names containing [:-] characters

### DIFF
--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -336,6 +336,8 @@ int bcf_sr_set_regions(bcf_srs_t *readers, const char *regions, int is_file);
  *              supply 'from' in place of 'to'. When 'to' is negative, first
  *              abs(to) will be attempted and if that fails, 'from' will be used
  *              instead.
+ *              If chromosome name contains the characters ':' or '-', it should
+ *              be put in curly brackets, for example as "{weird-chr-name:1-2}:1000-2000"
  *
  *  The bcf_sr_regions_t struct returned by a successful call should be freed
  *  via bcf_sr_regions_destroy() when it is no longer needed.

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -1026,6 +1026,9 @@ void _regions_sort_and_merge(bcf_sr_regions_t *reg)
 }
 
 // File name or a list of genomic locations. If file name, NULL is returned.
+// Recognises regions in the form chr, chr:pos, chr:beg-end, chr:beg-, {weird-chr-name}:pos.
+// Cannot use hts_parse_region() as that requires the header and if header is not present,
+// wouldn't learn the chromosome name.
 static bcf_sr_regions_t *_regions_init_string(const char *str)
 {
     bcf_sr_regions_t *reg = (bcf_sr_regions_t *) calloc(1, sizeof(bcf_sr_regions_t));
@@ -1037,9 +1040,23 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
     hts_pos_t from, to;
     while ( 1 )
     {
-        while ( *ep && *ep!=',' && *ep!=':' ) ep++;
         tmp.l = 0;
-        kputsn(sp,ep-sp,&tmp);
+        if ( *ep=='{' )
+        {
+            while ( *ep && *ep!='}' ) ep++;
+            if ( !*ep )
+            {
+                hts_log_error("Could not parse the region, mismatching braces in: \"%s\"", str);
+                goto exit_nicely;
+            }
+            ep++;
+            kputsn(sp+1,ep-sp-2,&tmp);
+        }
+        else
+        {
+            while ( *ep && *ep!=',' && *ep!=':' ) ep++;
+            kputsn(sp,ep-sp,&tmp);
+        }
         if ( *ep==':' )
         {
             sp = ep+1;
@@ -1047,7 +1064,7 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
             if ( sp==ep )
             {
                 hts_log_error("Could not parse the region(s): %s", str);
-                free(reg); free(tmp.s); return NULL;
+                goto exit_nicely;
             }
             if ( !*ep || *ep==',' )
             {
@@ -1058,7 +1075,7 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
             if ( *ep!='-' )
             {
                 hts_log_error("Could not parse the region(s): %s", str);
-                free(reg); free(tmp.s); return NULL;
+                goto exit_nicely;
             }
             ep++;
             sp = ep;
@@ -1066,7 +1083,7 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
             if ( *ep && *ep!=',' )
             {
                 hts_log_error("Could not parse the region(s): %s", str);
-                free(reg); free(tmp.s); return NULL;
+                goto exit_nicely;
             }
             if ( sp==ep ) to = MAX_CSI_COOR-1;
             _regions_add(reg, tmp.s, from, to);
@@ -1082,6 +1099,11 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
     }
     free(tmp.s);
     return reg;
+
+exit_nicely:
+    bcf_sr_regions_destroy(reg);
+    free(tmp.s);
+    return NULL;
 }
 
 // ichr,ifrom,ito are 0-based;

--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -1090,11 +1090,16 @@ static bcf_sr_regions_t *_regions_init_string(const char *str)
             if ( !*ep ) break;
             sp = ep;
         }
-        else
+        else if ( !*ep || *ep==',' )
         {
             if ( tmp.l ) _regions_add(reg, tmp.s, -1, -1);
             if ( !*ep ) break;
             sp = ++ep;
+        }
+        else
+        {
+            hts_log_error("Could not parse the region(s): %s", str);
+            goto exit_nicely;
         }
     }
     free(tmp.s);

--- a/test/bcf-sr/weird-chr-names.1.out
+++ b/test/bcf-sr/weird-chr-names.1.out
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=ref.fa
+##contig=<ID=1>
+##contig=<ID=1:1>
+##contig=<ID=1:1-1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	1	.	C	T	.	.	.
+1	2	.	C	T	.	.	.

--- a/test/bcf-sr/weird-chr-names.2.out
+++ b/test/bcf-sr/weird-chr-names.2.out
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=ref.fa
+##contig=<ID=1>
+##contig=<ID=1:1>
+##contig=<ID=1:1-1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	1	.	C	T	.	.	.

--- a/test/bcf-sr/weird-chr-names.3.out
+++ b/test/bcf-sr/weird-chr-names.3.out
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=ref.fa
+##contig=<ID=1>
+##contig=<ID=1:1>
+##contig=<ID=1:1-1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1:1	1	.	C	T	.	.	.
+1:1	2	.	C	T	.	.	.

--- a/test/bcf-sr/weird-chr-names.4.out
+++ b/test/bcf-sr/weird-chr-names.4.out
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=ref.fa
+##contig=<ID=1>
+##contig=<ID=1:1>
+##contig=<ID=1:1-1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1:1	1	.	C	T	.	.	.

--- a/test/bcf-sr/weird-chr-names.5.out
+++ b/test/bcf-sr/weird-chr-names.5.out
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=ref.fa
+##contig=<ID=1>
+##contig=<ID=1:1>
+##contig=<ID=1:1-1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1:1-1	1	.	C	T	.	.	.
+1:1-1	2	.	C	T	.	.	.

--- a/test/bcf-sr/weird-chr-names.6.out
+++ b/test/bcf-sr/weird-chr-names.6.out
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=ref.fa
+##contig=<ID=1>
+##contig=<ID=1:1>
+##contig=<ID=1:1-1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1:1-1	1	.	C	T	.	.	.

--- a/test/bcf-sr/weird-chr-names.vcf
+++ b/test/bcf-sr/weird-chr-names.vcf
@@ -1,0 +1,12 @@
+##fileformat=VCFv4.3
+##reference=ref.fa
+##contig=<ID=1>
+##contig=<ID=1:1>
+##contig=<ID=1:1-1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+1	1	.	C	T	.	.	.
+1	2	.	C	T	.	.	.
+1:1	1	.	C	T	.	.	.
+1:1	2	.	C	T	.	.	.
+1:1-1	1	.	C	T	.	.	.
+1:1-1	2	.	C	T	.	.	.

--- a/test/test-bcf-sr.c
+++ b/test/test-bcf-sr.c
@@ -28,12 +28,17 @@
 
 #include <config.h>
 
+#include <stdlib.h>
 #include <getopt.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <inttypes.h>
+#include <strings.h>
+#include <errno.h>
 
 #include "../htslib/synced_bcf_reader.h"
+#include "../htslib/hts.h"
+#include "../htslib/vcf.h"
 
 void error(const char *format, ...)
 {
@@ -41,16 +46,78 @@ void error(const char *format, ...)
     va_start(ap, format);
     vfprintf(stderr, format, ap);
     va_end(ap);
-    exit(-1);
+    exit(EXIT_FAILURE);
 }
 
-void usage(void)
+void usage(int exit_code)
 {
     fprintf(stderr, "Usage: test-bcf-sr [OPTIONS] vcf-list.txt\n");
+    fprintf(stderr, "       test-bcf-sr [OPTIONS] -args file1.bcf [...]\n");
     fprintf(stderr, "Options:\n");
+    fprintf(stderr, "       --args                   pass filenames directly in argument list\n");
+    fprintf(stderr, "       --no-index               allow streaming\n");
+    fprintf(stderr, "   -o, --output <file>          output file (stdout if not set)\n");
+    fprintf(stderr, "   -O, --output-fmt <fmt>       fmt: vcf,bcf,summary\n");
     fprintf(stderr, "   -p, --pair <logic[+ref]>     logic: snps,indels,both,snps+ref,indels+ref,both+ref,exact,some,all\n");
+    fprintf(stderr, "   -r, --regions <reg_list>     comma-separated list of regions\n");
+    fprintf(stderr, "   -t, --targets <reg_list>     comma-separated list of targets\n");
     fprintf(stderr, "\n");
-    exit(-1);
+    exit(exit_code);
+}
+
+void write_summary_format(bcf_srs_t *sr, FILE *out)
+{
+    int n, i, j;
+    while ((n = bcf_sr_next_line(sr)) > 0) {
+        for (i=0; i<sr->nreaders; i++)
+        {
+            if ( !bcf_sr_has_line(sr,i) ) continue;
+            bcf1_t *rec = bcf_sr_get_line(sr, i);
+            if (!rec) error("bcf_sr_get_line() unexpectedly returned NULL\n");
+            fprintf(out, "%s:%"PRIhts_pos,
+                    bcf_seqname_safe(bcf_sr_get_header(sr,i),rec),rec->pos+1);
+            break;
+        }
+
+        for (i=0; i<sr->nreaders; i++)
+        {
+            fprintf(out, "\t");
+
+            if ( !bcf_sr_has_line(sr,i) )
+            {
+                fprintf(out, "%s","-");
+                continue;
+            }
+
+            bcf1_t *rec = bcf_sr_get_line(sr, i);
+            if (!rec) error("bcf_sr_get_line() unexpectedly returned NULL\n");
+            fprintf(out, "%s", rec->n_allele > 1 ? rec->d.allele[1] : ".");
+            for (j=2; j<rec->n_allele; j++)
+            {
+                fprintf(out, ",%s", rec->d.allele[j]);
+            }
+        }
+        fprintf(out, "\n");
+    }
+}
+
+void write_vcf_bcf_format(bcf_srs_t *sr, bcf_hdr_t *hdr, vcfFile *vcf_out,
+                          const char *fmt_type)
+{
+    int i, n;
+    if (bcf_hdr_write(vcf_out, hdr) != 0)
+        error("Couldn't write %s header\n", fmt_type);
+
+    while ((n = bcf_sr_next_line(sr)) > 0) {
+        for (i=0; i<sr->nreaders; i++)
+        {
+            if ( !bcf_sr_has_line(sr,i) ) continue;
+            bcf1_t *rec = bcf_sr_get_line(sr, i);
+            if (!rec) error("bcf_sr_get_line() unexpectedly returned NULL\n");
+            if (vcf_write(vcf_out, hdr, rec) < 0)
+                error("vcf_write() failed\n");
+        }
+    }
 }
 
 int main(int argc, char *argv[])
@@ -58,16 +125,31 @@ int main(int argc, char *argv[])
     static struct option loptions[] =
     {
         {"help",no_argument,NULL,'h'},
+        {"output-fmt",required_argument,NULL,'O'},
         {"pair",required_argument,NULL,'p'},
+        {"regions",required_argument,NULL,'r'},
+        {"targets",required_argument,NULL,'t'},
         {"no-index",no_argument,NULL,1000},
+        {"args",no_argument,NULL,1001},
         {NULL,0,NULL,0}
     };
 
-    int c, pair = 0, use_index = 1;
-    while ((c = getopt_long(argc, argv, "p:h", loptions, NULL)) >= 0)
+    int c, pair = 0, use_index = 1, use_fofn = 1;
+    enum htsExactFormat out_fmt = text_format; // for original pos + alleles
+    const char *out_fn = NULL, *regions = NULL, *targets = NULL;
+    while ((c = getopt_long(argc, argv, "o:O:p:r:t:h", loptions, NULL)) >= 0)
     {
         switch (c)
         {
+            case 'o':
+                out_fn = optarg;
+                break;
+            case 'O':
+                if (!strcasecmp(optarg, "vcf"))          out_fmt = vcf;
+                else if (!strcasecmp(optarg, "bcf"))     out_fmt = bcf;
+                else if (!strcasecmp(optarg, "summary")) out_fmt = text_format;
+                else error("Unknown output format \"%s\"\n", optarg);
+                break;
             case 'p':
                 if ( !strcmp(optarg,"snps") )            pair |= BCF_SR_PAIR_SNPS;
                 else if ( !strcmp(optarg,"snp+ref") )    pair |= BCF_SR_PAIR_SNPS|BCF_SR_PAIR_SNP_REF;
@@ -83,68 +165,103 @@ int main(int argc, char *argv[])
                 else if ( !strcmp(optarg,"exact") )      pair  = BCF_SR_PAIR_EXACT;
                 else error("The --pair logic \"%s\" not recognised.\n", optarg);
                 break;
+            case 'r':
+                regions = optarg;
+                break;
+            case 't':
+                targets = optarg;
+                break;
             case 1000:
                 use_index = 0;
                 break;
-            default: usage();
+            case 1001:
+                use_fofn = 0;
+                break;
+            case 'h':
+                usage(EXIT_SUCCESS);
+            default: usage(EXIT_FAILURE);
         }
     }
     if ( !pair ) pair = BCF_SR_PAIR_EXACT;
-    if ( optind == argc ) usage();
+    if ( optind == argc ) usage(EXIT_FAILURE);
 
-    int i, j, n, nvcf;
-    char **vcf = hts_readlist(argv[optind], 1, &nvcf);
-    if ( !vcf ) error("Could not parse %s\n", argv[optind]);
+    int i, nvcf;
+    char **vcfs = NULL;
+    if (use_fofn) {
+        vcfs = hts_readlist(argv[optind], 1, &nvcf);
+        if ( !vcfs ) error("Could not parse %s\n", argv[optind]);
+    } else {
+        vcfs = &argv[optind];
+        nvcf = argc - optind;
+    }
 
     bcf_srs_t *sr = bcf_sr_init();
+    if (!sr) error("bcf_sr_init() failed\n");
     bcf_sr_set_opt(sr, BCF_SR_PAIR_LOGIC, pair);
     if (use_index) {
         bcf_sr_set_opt(sr, BCF_SR_REQUIRE_IDX);
     } else {
         bcf_sr_set_opt(sr, BCF_SR_ALLOW_NO_IDX);
     }
-    for (i=0; i<nvcf; i++)
-        if ( !bcf_sr_add_reader(sr,vcf[i]) ) error("Failed to open %s: %s\n", vcf[i],bcf_sr_strerror(sr->errnum));
 
-    kstring_t str = {0,0,0};
-    while ( (n=bcf_sr_next_line(sr)) )
+    if (regions)
     {
-        for (i=0; i<sr->nreaders; i++)
-        {
-            if ( !bcf_sr_has_line(sr,i) ) continue;
-            bcf1_t *rec = bcf_sr_get_line(sr, i);
-            printf("%s:%"PRIhts_pos, bcf_seqname_safe(bcf_sr_get_header(sr,i),rec),rec->pos+1);
-            break;
-        }
-
-        for (i=0; i<sr->nreaders; i++)
-        {
-            printf("\t");
-
-            if ( !bcf_sr_has_line(sr,i) )
-            {
-                printf("%s","-");
-                continue;
-            }
-
-            str.l = 0;
-            bcf1_t *rec = bcf_sr_get_line(sr, i);
-            kputs(rec->n_allele > 1 ? rec->d.allele[1] : ".", &str);
-            for (j=2; j<rec->n_allele; j++)
-            {
-                kputc(',', &str);
-                kputs(rec->d.allele[j], &str);
-            }
-            printf("%s",str.s);
-        }
-        printf("\n");
+        if (bcf_sr_set_regions(sr, regions, 0) != 0)
+            error("Failed to set regions\n");
     }
 
-    free(str.s);
-    bcf_sr_destroy(sr);
+    if (targets)
+    {
+        if (bcf_sr_set_targets(sr, targets, 0, 0) != 0)
+            error("Failed to set targets\n");
+    }
+
     for (i=0; i<nvcf; i++)
-        free(vcf[i]);
-    free(vcf);
+        if ( !bcf_sr_add_reader(sr,vcfs[i]) ) error("Failed to open %s: %s\n", vcfs[i],bcf_sr_strerror(sr->errnum));
+
+    if (!sr->readers || sr->nreaders < 1)
+        error("No readers set, even though one was added\n");
+
+    if (out_fmt == text_format) {
+        FILE *out = stdout;
+        if (out_fn)
+        {
+            out = fopen(out_fn, "w");
+            if (!out) error("Couldn't open \"%s\" for writing: %s\n",
+                            out_fn, strerror(errno));
+        }
+        write_summary_format(sr, out);
+        if (out_fn)
+        {
+            if (fclose(out) != 0)
+                error("Error on closing %s : %s\n",
+                      out_fn, strerror(errno));
+        }
+    } else {
+        const char *fmt_type = out_fmt == vcf ? "VCF" : "BCF";
+
+        bcf_hdr_t *hdr = bcf_sr_get_header(sr, 0);
+        if (!hdr) error("%s output, but don't have a header\n", fmt_type);
+
+        if (!out_fn) { out_fn = "-"; }
+        vcfFile *vcf_out = vcf_open(out_fn, out_fmt == vcf ? "w" : "wb");
+        if (!vcf_out) error("Couldn't open \"%s\" for writing: %s\n",
+                            out_fn, strerror(errno));
+        write_vcf_bcf_format(sr, hdr, vcf_out, fmt_type);
+        if (vcf_close(vcf_out) != 0)
+            error("Error on closing \"%s\"\n", out_fn);
+    }
+
+    if (sr->errnum) error("Synced reader error: %s\n",
+                          bcf_sr_strerror(sr->errnum));
+
+    bcf_sr_destroy(sr);
+    if (use_fofn)
+    {
+        for (i=0; i<nvcf; i++)
+            free(vcfs[i]);
+        free(vcfs);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Note hts_parse_region() cannot be used because it requires the header and without the header the caller does not learn the contig name.

Resolves #1620