### PR TITLE
cram/cram_external.c: fix external htscodecs include

### DIFF
--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 
 #if defined(HAVE_EXTERNAL_LIBHTSCODECS)
-#include <htscodecs/rANS_static4x16.h.h>
+#include <htscodecs/rANS_static4x16.h>
 #else
 #include "../htscodecs/htscodecs/rANS_static4x16.h"
 #endif


### PR DESCRIPTION
This patch fixes a duplicate file extension, causing otherwise the following build failure when building htslib against an externally built htscodecs:

	gcc -g -O2 -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -ffat-lto-objects -ffat-lto-objects  -I. -I. -DSAMTOOLS=1 -Wdate-time -D_FORTIFY_SOURCE=2 -c -o cram/cram_external.o cram/cram_external.c
	cram/cram_external.c:46:10: fatal error: htscodecs/rANS_static4x16.h.h: No such file or directory
	   46 | #include <htscodecs/rANS_static4x16.h.h>
	      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~