### PR TITLE
htslib-s3-plugin.7: fix whatis entry

### DIFF
--- a/htslib-s3-plugin.7
+++ b/htslib-s3-plugin.7
@@ -1,6 +1,6 @@
 .TH htslib-s3-plugin 7 "21 February 2023" "htslib-1.17" "Bioinformatics tools"
 .SH NAME
-s3 plugin \- htslib AWS S3 plugin
+htslib-s3-plugin \- htslib AWS S3 plugin
 .\"
 .\" Copyright (C) 2021-2022 Genome Research Ltd.
 .\"


### PR DESCRIPTION
When preparing the htslib 1.17 upload in Debian, lintian caught a bad-whatis-entry issue.  Looking closer, whatis(1) and apropos(1) commands fail to locate htslib-s3-plugin(7) manual and the parsing of the page fails with:

	$ lexgrog htslib-s3-plugin.7
	htslib-s3-plugin.7: parse failed

It seems to stem from the two words "s3 plugin" in the name of the manual, instead of having a single word as needed.  This change names the manual page "htslib-s3-plugin" instead, making the mandb, the lexgrog parser, and lintian happy:

	$ lexgrog htslib-s3-plugin.7
	htslib-s3-plugin.7: "htslib-s3-plugin - htslib AWS S3 plugin"

The name could also simply be "s3-plugin", but having htslib in the name felt more apropos.  :)