### PR TITLE
Fix possible double frees in bcf_hdr_add_hrec() error handling

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -691,6 +691,22 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     HTSLIB_EXPORT
     int bcf_hrec_format(const bcf_hrec_t *hrec, kstring_t *str);
 
+    /// Add a header record into a header
+    /**
+     *  @param hdr  Destination header
+     *  @param hrec Header record
+     *  @return 0 on success, -1 on failure
+     *
+     *  If this function returns success, ownership of @p hrec will have
+     *  been transferred to the header structure.  It may also have been
+     *  freed if it was a duplicate of a record already in the header.
+     *  Therefore the @p hrec pointer should not be used after a successful
+     *  return from this function.
+     *
+     *  If this function returns failure, ownership will not have been taken
+     *  and the caller is responsible for cleaning up @p hrec.
+     */
+
     HTSLIB_EXPORT
     int bcf_hdr_add_hrec(bcf_hdr_t *hdr, bcf_hrec_t *hrec);
 

--- a/vcf.c
+++ b/vcf.c
@@ -974,23 +974,27 @@ int bcf_hdr_add_hrec(bcf_hdr_t *hdr, bcf_hrec_t *hrec)
             return 0;
         }
     }
+
+    // New record, needs to be added
+    int n = hdr->nhrec + 1;
+    bcf_hrec_t **new_hrec = realloc(hdr->hrec, n*sizeof(bcf_hrec_t*));
+    if (!new_hrec) {
+        free(str.s);
+        return -1;
+    }
+    hdr->hrec = new_hrec;
+
     if ( str.s )
     {
         khint_t k = kh_put(hdict, aux->gen, str.s, &res);
         if ( res<0 )
         {
-            bcf_hrec_destroy(hrec);
             free(str.s);
             return -1;
         }
         kh_val(aux->gen,k) = hrec;
     }
 
-    // New record, needs to be added
-    int n = hdr->nhrec + 1;
-    bcf_hrec_t **new_hrec = realloc(hdr->hrec, n*sizeof(bcf_hrec_t*));
-    if (!new_hrec) return -1;
-    hdr->hrec = new_hrec;
     hdr->hrec[hdr->nhrec] = hrec;
     hdr->dirty = 1;
     hdr->nhrec = n;


### PR DESCRIPTION
Spotted while looking at the VCF parser.  `bcf_hdr_add_hrec()` should neither call `bcf_hrec_destroy(hrec)` nor store any pointers to `hrec` when it returns -1, otherwise double frees or stale pointer dereferences may result.

Remove `bcf_hrec_destroy(hrec)` call that was incorrectly made when handling a hash table insert failure, and move `hdr->hrec` reallocation so that all possible failures occur before `hrec` is added into the header.

Add `bcf_hdr_add_hrec()` documentation, including a warning that the caller should not touch `hrec` after a successful return.

It looks like the bug appeared in 3fe2a59034.  You'd have to be very unlucky to actually trigger it as it requires a particular allocation to fail, but it's best to ensure that the problem can't occur.