### PR TITLE
Add fai_thread_pool interface.

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -975,6 +975,11 @@ void fai_set_cache_size(faidx_t *fai, int cache_size) {
     bgzf_set_cache_size(fai->bgzf, cache_size);
 }
 
+// Adds a thread pool to the underlying BGZF layer.
+int fai_thread_pool(faidx_t *fai, struct hts_tpool *pool, int qsize) {
+    return bgzf_thread_pool(fai->bgzf, pool, qsize);
+}
+
 char *fai_path(const char *fa) {
     char *fai = NULL;
     if (!fa) {

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -322,6 +322,8 @@ typedef struct BGZF BGZF;
      *
      * @param fp          BGZF file handler
      * @param pool        The thread pool (see hts_create_threads)
+     * @param qsize       The size of the job queue.  If 0 this is twice the
+     *                    number of threads in the pool.
      */
     HTSLIB_EXPORT
     int bgzf_thread_pool(BGZF *fp, struct hts_tpool *pool, int qsize);

--- a/htslib/faidx.h
+++ b/htslib/faidx.h
@@ -70,6 +70,9 @@ struct faidx_t;
 /// Opaque structure representing FASTA index
 typedef struct faidx_t faidx_t;
 
+/// Opaque structure; sole item needed from htslib/thread_pool.h
+struct hts_tpool;
+
 /// File format to be dealing with.
 enum fai_format_options {
     FAI_NONE,
@@ -356,6 +359,15 @@ int fai_adjust_region(const faidx_t *fai, int tid,
  */
 HTSLIB_EXPORT
 void fai_set_cache_size(faidx_t *fai, int cache_size);
+
+/// Adds a thread pool to the underlying BGZF layer.
+/** @param fai         FAI file handler
+ *  @param pool        The thread pool (see hts_create_threads)
+ *  @param qsize       The size of the job queue.  If 0 this is twice the
+ *                     number of threads in the pool.
+ */
+HTSLIB_EXPORT
+int fai_thread_pool(faidx_t *fai, struct hts_tpool *pool, int qsize);
 
 /// Determines the path to the reference index file
 /** @param  fa    String with the path to the reference file


### PR DESCRIPTION
This is a simple skim around bgzf_thread_pool.

Also added a missing `@param qsize` to the bgzf_thread_pool documentation.

Fixes #1638