### PR TITLE
Make bam_parse_cigar able to modify existing BAM records rather than partially parsed ones.

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1133,6 +1133,12 @@ ssize_t sam_parse_cigar(const char *in, char **end, uint32_t **a_cigar, size_t *
                        can be NULL
  @param  b       [in/out]  address of the destination bam1_t struct
  @return         number of processed CIGAR operators; -1 on error
+
+ @discussion The BAM record may be partial and empty of existing cigar, seq
+ and quality, as is the case during SAM parsing, or it may be an existing
+ BAM record in which case this function replaces the existing CIGAR field
+ and shuffles data accordingly.  A CIGAR of "*" will remove the CIGAR,
+ returning zero.
  */
 HTSLIB_EXPORT
 ssize_t bam_parse_cigar(const char *in, char **end, bam1_t *b);

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1713,11 +1713,11 @@ static inline int bam_aux_get_str(const bam1_t *b,
 HTSLIB_EXPORT
 int64_t bam_aux2i(const uint8_t *s);
 
-/// Get an integer aux value
+/// Get a float aux value
 /** @param s Pointer to the tag data, as returned by bam_aux_get()
-    @return The value, or 0 if the tag was not an integer type
+    @return The value, or 0 if the tag was not a float type
     If the tag is not an numeric type, errno is set to EINVAL.  The value of
-    integer flags will be returned cast to a double.
+    the float will be returned cast to a double.
 */
 HTSLIB_EXPORT
 double bam_aux2f(const uint8_t *s);


### PR DESCRIPTION
It makes little sense for this to exist as a public API when it's only capable of handling the internal during-SAM-parse situation, and the changes are relatively minor.
    
Also removes an undocumented assumption that end == &in, and fixes cut and paste errors in bam_aux2f API docs.
    
Fixes #1650
