### PR TITLE
Add "uncompressed" in hts_format_description() where appropriate

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -794,6 +794,7 @@ char *hts_format_description(const htsFormat *format)
     case zstd_compression:   kputs(" Zstandard-compressed", &str); break;
     case custom: kputs(" compressed", &str); break;
     case gzip:   kputs(" gzip-compressed", &str); break;
+
     case bgzf:
         switch (format->format) {
         case bam:
@@ -808,6 +809,22 @@ char *hts_format_description(const htsFormat *format)
             break;
         }
         break;
+
+    case no_compression:
+        switch (format->format) {
+        case bam:
+        case bcf:
+        case cram:
+        case csi:
+        case tbi:
+            // These are normally compressed, so emphasise that this one isn't
+            kputs(" uncompressed", &str);
+            break;
+        default:
+            break;
+        }
+        break;
+
     default: break;
     }
 


### PR DESCRIPTION
In samtools/samtools#1884 we saw a BAM file downloaded via a web browser and ungzipped. `htsfile` reported this file as follows:

```
$ htsfile wgEncode-browser.bam
wgEncode-browser.bam:	BAM version 1 sequence data
```

In isolation it's not obvious that this is reporting that the BAM file is **not** BGZF-compressed as normal. (For usual BAM files, `htsfile` reports `BAM version 1 compressed sequence data`, but if you don't have one handy to compare…)

This PR adds “uncompressed” for uncompressed files in formats, like BAM and BCF, that are normally compressed, to make this clear. Thus:

```
$ htsfile wg*.bam
wgEncode-browser.bam:	BAM version 1 uncompressed sequence data
wgEncode-curl.bam:	BAM version 1 compressed sequence data
```