### PR TITLE
Vcf write speed

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -1456,7 +1456,14 @@ which works for both BCF and VCF.
 #define bcf_int16_missing    (-32767-1)      /* INT16_MIN */
 #define bcf_int32_missing    (-2147483647-1) /* INT32_MIN */
 #define bcf_int64_missing    (-9223372036854775807LL - 1LL)  /* INT64_MIN */
-#define bcf_str_missing      0x07
+
+// All of the above are values, which may occur multiple times in lists of
+// integers or lists of floating point.  Strings in VCF don't have
+// lists - a list of strings is just another (comma-separated) string.
+//
+// Hence bcf_str_missing is the whole string being missing rather than
+// an element of a list.  Ie a string of length zero: (0<<4)|BCF_BT_CHAR.
+#define bcf_str_missing      BCF_BT_CHAR
 
 // Limits on BCF values stored in given types.  Max values are the same
 // as for the underlying type.  Min values are slightly different as

--- a/kstring.c
+++ b/kstring.c
@@ -63,78 +63,77 @@ int kputd(double d, kstring_t *s) {
 		return len;
 	}
 
-	uint64_t i = d*10000000000LL;
 	// Correction for rounding - rather ugly
-
 	// Optimised for small numbers.
-	// Better still would be __builtin_clz on hi/lo 32 and get the
-	// starting point very rapidly.
-	if (d<.0001)
-		i+=0;
-	else if (d<0.001)
-		i+=5;
-	else if (d < 0.01)
-		i+=50;
-	else if (d < 0.1)
-		i+=500;
-	else if (d < 1)
-		i+=5000;
-	else if (d < 10)
-		i+=50000;
-	else if (d < 100)
-		i+=500000;
-	else if (d < 1000)
-		i+=5000000;
-	else if (d < 10000)
-		i+=50000000;
-	else if (d < 100000)
-		i+=500000000;
-	else
-		i+=5000000000LL;
 
-	do {
-		*--cp = '0' + i%10;
-		i /= 10;
-	} while (i >= 1);
-	buf[20] = 0;
+	uint32_t i;
+	if (d<0.001)         i = rint(d*1000000000), cp -= 1;
+	else if (d < 0.01)   i = rint(d*100000000),  cp -= 2;
+	else if (d < 0.1)    i = rint(d*10000000),   cp -= 3;
+	else if (d < 1)      i = rint(d*1000000),    cp -= 4;
+	else if (d < 10)     i = rint(d*100000),     cp -= 5;
+	else if (d < 100)    i = rint(d*10000),      cp -= 6;
+	else if (d < 1000)   i = rint(d*1000),       cp -= 7;
+	else if (d < 10000)  i = rint(d*100),        cp -= 8;
+	else if (d < 100000) i = rint(d*10),         cp -= 9;
+	else                 i = rint(d),            cp -= 10;
+
+	// integer i is always 6 digits, so print it 2 at a time.
+	static const char kputuw_dig2r[] =
+		"00010203040506070809"
+		"10111213141516171819"
+		"20212223242526272829"
+		"30313233343536373839"
+		"40414243444546474849"
+		"50515253545556575859"
+		"60616263646566676869"
+		"70717273747576777879"
+		"80818283848586878889"
+		"90919293949596979899";
+
+	memcpy(cp-=2, &kputuw_dig2r[2*(i%100)], 2); i /= 100;
+	memcpy(cp-=2, &kputuw_dig2r[2*(i%100)], 2); i /= 100;
+	memcpy(cp-=2, &kputuw_dig2r[2*(i%100)], 2);
+
+	// Except when it rounds up (d=0.009999999 is i=1000000)
+	if (i >= 100)
+		*--cp = '0' + (i/100);
+
+
 	int p = buf+20-cp;
-	if (p <= 10) { // d < 1
-		//assert(d/1);
-		cp[6] = 0; ep = cp+5;// 6 precision
-		while (p < 10) {
+	if (p <= 10) { /* d < 1 */
+		// 0.00123 is 123, so add leading zeros and 0.
+		ep = cp+5; // 6 precision
+		while (p < 10) { // aka d < 1
 			*--cp = '0';
 			p++;
 		}
 		*--cp = '.';
 		*--cp = '0';
 	} else {
+		// 123.001 is 123001 with p==13, so move 123 down and add "."
+		// Equiv to memmove(cp-1, cp, p-10); cp--;
 		char *xp = --cp;
+		ep = cp+6;
 		while (p > 10) {
 			xp[0] = xp[1];
-			p--;
 			xp++;
+			p--;
 		}
 		xp[0] = '.';
-		cp[7] = 0; ep=cp+6;
-		if (cp[6] == '.') cp[6] = 0;
 	}
 
 	// Cull trailing zeros
 	while (*ep == '0' && ep > cp)
 		ep--;
-	char *z = ep+1;
-	while (ep > cp) {
-		if (*ep == '.') {
-			if (z[-1] == '.')
-				z[-1] = 0;
-			else
-				z[0] = 0;
-			break;
-		}
-		ep--;
-	}
 
-	int sl = strlen(cp);
+	// End can be 1 out due to the mostly-6 but occasionally 7 (i==1) case.
+	// Also code with "123." which should be "123"
+	if (*ep && *ep != '.')
+		ep++;
+	*ep = 0;
+
+	int sl = ep-cp;
 	len += sl;
 	kputsn(cp, sl, s);
 	return len;

--- a/vcf.c
+++ b/vcf.c
@@ -2724,20 +2724,13 @@ int bcf_fmt_array(kstring_t *s, int n, int type, void *data)
     {
         char *p = (char *)data;
 
-        // Can bcf_str_missing only occur at the start of a CHAR array?
-        // We use these as strings only I believe, and INT8 for numerics.
-        // Checking further however, I'm not sure bcf_str_missing can occur
-        // even there.  I think it's likely an unimplemented feature, whose
-        // only existance in the specification is a single line mention in
-        // an example (for the "ID" field).
-        if (n >= 8 && *p != bcf_str_missing) {
+        // Note bcf_str_missing is already accounted for in n==0 above.
+        if (n >= 8) {
             char *p_end = memchr(p, 0, n);
             e |= kputsn(p, p_end ? p_end-p : n, s) < 0;
         } else {
-            for (j = 0; j < n && *p; ++j, ++p) {
-                if ( *p==bcf_str_missing ) e |= kputc_('.', s) < 0;
-                else e |= kputc_(*p, s) < 0;
-            }
+            for (j = 0; j < n && *p; ++j, ++p)
+               e |= kputc(*p, s) < 0;
         }
     }
     else
@@ -2749,7 +2742,7 @@ int bcf_fmt_array(kstring_t *s, int n, int type, void *data)
                 type_t v = convert(p); \
                 if ( is_vector_end ) break; \
                 if ( j ) e |= kputc_(',', s) < 0; \
-                e |= (is_missing ? kputc_('.', s) : kprint) < 0; \
+                e |= (is_missing ? kputc('.', s) : kprint) < 0; \
             } \
         }
         switch (type) {


### PR DESCRIPTION
Speeds up the VCF writer.  The main changes are:

- VCF writer can handle packed BCF objects, meaning we don't have to unpack before writing as VCF.
- Improve the GT formatting loop so once we've found it (often early on) we don't continue the penalty of looking again.  This assumes it only ever turns up once, but the VCF specification forbids duplicate keys.
- Optimise `bcf_fmt_array` on character arrays, treating them only as strings.  This is a bit vague in the spec, but I believe this code to be valid.
- Cache header key lengths to avoid repeated calls to strlen everywhere (`kputsn` over `kputs`).

Benchmarks showing 3 trials of "perf stat" cycle counts, in millions to make it easier to read, for develop (1st) vs this PR (2nd) on a variety of data sets.  The third number in parentheses is the number of cycles spent during the read portion of test_view, so for the true write speed up that could be subtracted from both the Dev vs PR values.  Host was an old Intel box, using the system gcc (7).

```
=== bcftools ===                                                                
  24,756   22,725    (3,992)     M.cycles  #    2.983 GHz                       
  25,892   22,445    (3,961)     M.cycles  #    2.983 GHz                       
  25,039   22,741    (4,037)     M.cycles  #    2.983 GHz                       
=== freebayes ===                                                               
  75,838   59,067   (11,068)     M.cycles  #    2.982 GHz                       
  75,342   59,437   (10,359)     M.cycles  #    2.983 GHz                       
  78,406   60,511   (10,309)     M.cycles  #    2.983 GHz                       
=== gatk ===                                                                    
   2,823    2,703      (387)     M.cycles  #    2.983 GHz                       
   2,680    2,248      (387)     M.cycles  #    2.983 GHz                       
   2,662    2,245      (386)     M.cycles  #    2.981 GHz                       
=== info ===                                                                    
  12,555    7,693    (1,724)     M.cycles  #    2.983 GHz                       
  12,562    7,947    (1,724)     M.cycles  #    2.983 GHz                       
  12,365    7,970    (1,734)     M.cycles  #    2.983 GHz                       
=== fmt ===                                                                     
  25,125   22,917    (3,395)     M.cycles  #    2.977 GHz                       
  25,074   22,604    (3,421)     M.cycles  #    2.981 GHz                       
  25,228   22,450    (3,408)     M.cycles  #    2.967 GHz                       
=== GIAB ===                                                                    
  43,056   26,989    (7,488)     M.cycles  #    2.972 GHz                       
  43,959   27,237    (7,409)     M.cycles  #    2.975 GHz                       
  47,072   28,113    (7,475)     M.cycles  #    2.979 GHz                       

```

"GIAB" is the GIAB HG002 truth set. "info" and "fmt" are INFO heavy and FORMAT 1000 genomes heavy files from GNOMAD.  Bcftools, Freebayes and GATK are calls made by the repsective tools on SynDip (CHM1/CHM13), so represent real-world single-sample tool outputs.

My test timings were `./test/test_view /tmp/_$i.bcf -p /tmp/_.vcf` where the BCF file is an uncompressed BCF, so causing the minimum of read/decode time.  The read-portion in the above chart came from `test_view -B /tmp/_$i.bcf`.

Most files are 10-20% faster at writing, with the GIAB data being 40% faster for some reason (probably due to being dominated by very long strings in INFO).  All files were md5sumed to validate the output matched.