### PR TITLE
Avoid really closing stdin/stdout in hclose()/hts_close()/et al

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -524,7 +524,7 @@ void hclose_abruptly(hFILE *fp)
 typedef struct {
     hFILE base;
     int fd;
-    unsigned is_socket:1;
+    unsigned is_socket:1, is_shared:1;
 } hFILE_fd;
 
 static ssize_t fd_read(hFILE *fpv, void *buffer, size_t nbytes)
@@ -599,6 +599,10 @@ static int fd_close(hFILE *fpv)
 {
     hFILE_fd *fp = (hFILE_fd *) fpv;
     int ret;
+
+    // If we don't own the fd, return successfully without actually closing it
+    if (fp->is_shared) return 0;
+
     do {
 #ifdef HAVE_CLOSESOCKET
         ret = fp->is_socket? closesocket(fp->fd) : close(fp->fd);
@@ -636,6 +640,7 @@ static hFILE *hopen_fd(const char *filename, const char *mode)
 
     fp->fd = fd;
     fp->is_socket = 0;
+    fp->is_shared = 0;
     fp->base.backend = &fd_backend;
     return &fp->base;
 
@@ -702,6 +707,7 @@ hFILE *hdopen(int fd, const char *mode)
 
     fp->fd = fd;
     fp->is_socket = (strchr(mode, 's') != NULL);
+    fp->is_shared = (strchr(mode, 'S') != NULL);
     fp->base.backend = &fd_backend;
     return &fp->base;
 }
@@ -723,10 +729,12 @@ static hFILE *hopen_fd_fileuri(const char *url, const char *mode)
 static hFILE *hopen_fd_stdinout(const char *mode)
 {
     int fd = (strchr(mode, 'r') != NULL)? STDIN_FILENO : STDOUT_FILENO;
+    char mode_shared[101];
+    snprintf(mode_shared, sizeof mode_shared, "S%s", mode);
 #if defined HAVE_SETMODE && defined O_BINARY
     if (setmode(fd, O_BINARY) < 0) return NULL;
 #endif
-    return hdopen(fd, mode);
+    return hdopen(fd, mode_shared);
 }
 
 HTSLIB_EXPORT

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -80,6 +80,10 @@ Note that the file must be opened in binary mode, or else
 there will be problems on platforms that make a difference
 between text and binary mode.
 
+By default, the returned hFILE "takes ownership" of the file descriptor
+and _fd_ will be closed by hclose(). When _mode_ contains `S` (shared fd),
+hclose() will destroy the hFILE but not close the underlying _fd_.
+
 For socket descriptors (on Windows), _mode_ should contain `s`.
 */
 HTSLIB_EXPORT

--- a/test/test_view.c
+++ b/test/test_view.c
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <config.h>
 
+#include <errno.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -429,6 +430,11 @@ int main(int argc, char *argv[])
 
     if (p.pool)
         hts_tpool_destroy(p.pool);
+
+    if (fclose(stdout) != 0 && errno != EBADF) {
+        fprintf(stderr, "Error closing standard output.\n");
+        exit_code = EXIT_FAILURE;
+    }
 
     return exit_code;
 }


### PR DESCRIPTION
Revisiting the `stdin`/`stdout`/`dup` conversation from #1658:

>> Specifically the stdin/stdout code feels inherently wrong and I don't entirely understand why it's not just dealt with automatically as any other filename.
>
> `hopen_fd_stdinout()` just creates an `hFILE_fd` with an fd of 0 or 1. Hence `in = hopen("-", "r") … hclose(in) … in2 = hopen("-", "r")` would fail because fd 0 is no longer open or no longer refers to the original stdin. […] really this has caused no significant problems in all the years since it was implemented so far — largely because reading two BAM files from stdin or writing two BAM files to stdout just isn't a useful operation.

Reconsidering this… In fact it **has** caused some problems over the years: _htsfile.c_ needed some circumlocutions because it too wants to write several SAM/VCF (i.e. textual) `htsFile` streams to `stdout`, and pysam has had trouble due to `stdout` being closed by samtools and bcftools. Moreover, as stdin and stdout are already open and hence are not opened by `hts_open`/`hopen`, it's not really morally right for them to be closed by `hts_close`/`hclose`.

Hence this pull request, which adds a `mode` option letter to `hdopen()` to signal that the fd should not be closed by `hclose()`, and uses it in `hopen_fd_stdinout()` which underlies `hopen("-", …)`.

This enables repeated `hopen("-")` / `hclose()` / `hopen("-")` where previously the underlying `STDIN`/`OUT_FILENO` would have been prematurely closed. This will mean that the linked _bgzip.c_ pull request would not need to treat `"-"` specially.

This also means that stdout is never really closed and `hclose()`'s return value does not reflect closing the underlying fd. Hence particularly paranoid programs that have written significant data to stdout will want to close and check it themselves just before the end of main():

```c
if (fclose(stdout) != 0 && errno != EBADF) perror("closing stdout")
```

(Ignoring EBADF as stdout may already have been closed and checked, e.g. if the program has been linked to an earlier HTSlib where `hclose()` still closes STDOUT_FILENO.)

The second commit simplifies _htsfile.c_'s file opening and adds a final `fclose(stdout)` check accordingly.