### PR TITLE
Apply the packed attribute to uint*_u types for Clang

### DIFF
--- a/htslib/hts_endian.h
+++ b/htslib/hts_endian.h
@@ -100,7 +100,7 @@ DEALINGS IN THE SOFTWARE.  */
 #endif
 
 #if HTS_ALLOW_UNALIGNED != 0
-#    if defined (__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+#    if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3)) || defined(__clang__)
 // This prevents problems with gcc's vectoriser generating the wrong
 // instructions for unaligned data.
 typedef uint16_t uint16_u __attribute__ ((__aligned__ (1)));


### PR DESCRIPTION
... so that the following code
```
static inline void u32_to_le(uint32_t val, uint8_t *buf) {
    *((uint32_u *) buf) = val;
...
```

will not cause -fsanitize=alignment failures when building with Clang.