### PR TITLE
Fix a minor memory leak in malformed CRAM EXTERNAL blocks.

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -482,10 +482,10 @@ cram_codec *cram_external_decode_init(cram_block_compression_hdr *hdr,
             else if (option == E_BYTE || option == E_BYTE_ARRAY)
                 c->decode = cram_external_decode_char;
             else
-                return NULL;
+                goto malformed;
             break;
         default:
-            return NULL;
+            goto malformed;
         }
     } else {
         // CRAM 3 and earlier encodes integers as EXTERNAL.  We need


### PR DESCRIPTION
If we have an unofficial CRAM v4.0 encoded file and are attempting to use non-byte based data in an EXTERNAL encoded block, then we didn't free the cram_codecs structure when failing to parse and initialise.

Credit to OSS-Fuzz
Fixes oss-fuzz 62144