### PR TITLE
Apply seqtk PR to improve kseq.h parsing performance

### DIFF
--- a/htslib/kseq.h
+++ b/htslib/kseq.h
@@ -110,8 +110,8 @@
 				} else break; \
 			} \
 			if (delimiter == KS_SEP_LINE) {  \
-				for (i = ks->begin; i < ks->end; ++i)  \
-					if (ks->buf[i] == '\n') break; \
+				unsigned char *sep = memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
+				i = sep != NULL ? sep - ks->buf : ks->end; \
 			} else if (delimiter > KS_SEP_MAX) { \
 				for (i = ks->begin; i < ks->end; ++i) \
 					if (ks->buf[i] == delimiter) break; \

--- a/htslib/kseq.h
+++ b/htslib/kseq.h
@@ -113,8 +113,8 @@
 				unsigned char *sep = memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
 				i = sep != NULL ? sep - ks->buf : ks->end; \
 			} else if (delimiter > KS_SEP_MAX) { \
-				for (i = ks->begin; i < ks->end; ++i) \
-					if (ks->buf[i] == delimiter) break; \
+				unsigned char *sep = memchr(ks->buf + ks->begin, delimiter, ks->end - ks->begin); \
+				i = sep != NULL ? sep - ks->buf : ks->end; \
 			} else if (delimiter == KS_SEP_SPACE) { \
 				for (i = ks->begin; i < ks->end; ++i) \
 					if (isspace(ks->buf[i])) break; \


### PR DESCRIPTION
Port of @kloetzl's lh3/seqtk#123 and attractivechaos/klib#173 to HTSlib's copy of _kseq.h_.

Per the original PR: “Doubles throughput; can now parse FASTA at 2GB/s”.

For one large data file on my machine, this reduces klib's _kseq_bench2_'s `kstream` time from ~1.65s to ~0.92s.

(I have not heavily tested it otherwise.)

As [noted here](https://twitter.com/jomarnz/status/1661586585769611270), HTSlib doesn't use `kseq` itself though a few samtools commands do use it to read a few small BED files etc.