### PR TITLE
Fix crypt4gh redirection

### DIFF
--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -57,7 +57,7 @@ typedef struct hFILE {
     char *buffer, *begin, *end, *limit;
     const struct hFILE_backend *backend;
     off_t offset;
-    unsigned at_eof:1, mobile:1, readonly:1;
+    unsigned at_eof:1, mobile:1, readonly:1, preserve:1;
     int has_errno;
     // @endcond
 } hFILE;


### PR DESCRIPTION
Commit b8cf3463 was a fix to make crypt4gh redirection work with htsget.  Unfortunately it had  side effect of breaking crypt4gh redirection on other types of input because hts_hopen() makes the crypt4gh hFILE use the input hFILE as a parent, but then goes on to close it because it had been redirected.  (Before b8cf3463 it didn't matter because crypt4gh was incorrectly reopening the file instead of using the handle passed in to it).

Fixing this is a bit tricky because crypt4gh and htsget redirections work in rather different ways.  For htsget we get a completely new handle, and want to close the original because it's no longer needed.  For crypt4gh the original handle is wrapped by the new one and needs to stay open.  There are added complications should an error occur after a redirection, as then hts_hopen() returns NULL and expects the caller to close the hFILE that was passed to it.

The solution is to add a preserve bit to the hFILE struct bitfield, which makes hclose() and hclose_abruptly() ignore the file (although hclose() will still flush it).  This bit is then set on the input handle by hts_hopen() if it's wrapped inside a cyrpt4gh handle, allowing error handling to clean up any handles that happen to have been made by hts_hopen() while leaving the original one intact.  File clean-up for htsget redirects is also changed slightly so that the correct handles get closed on a successful return.

The can currently be tested using the https://github.com/daviesrob/htslib-crypt4gh/tree/extra_tests branch in my fork of the htslib-crypt4gh plug-in.  The changes in there will be merged into samtools/htslib-crypt4gh once this PR has gone into HTSlib.  I may also make a follow-up PR in this repository so HTSlib pulls, builds and tests the crypt4gh plug-in to ensure the changes here stick.

Fixes grbot/crypt4gh-tutorial#2