### PR TITLE
Fix hfile_libcurl small seek bug

### DIFF
--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -837,7 +837,7 @@ static ssize_t libcurl_read(hFILE *fpv, void *bufferv, size_t nbytes)
         got = fp->buffer.ptr.rd - buffer;
 
         if (to_skip >= 0) { // Skipping over a small seek
-            if (got < to_skip) { // Need to skip more data
+            if (got <= to_skip) { // Need to skip more data
                 to_skip -= got;
             } else {
                 got -= to_skip;


### PR DESCRIPTION
Ensure that `to_skip` is updated correctly when handling a small seek by skipping data in libcurl_read().  In particular, if the number of bytes returned by wait_perform() exactly matches the number left to skip, `to_skip` needs to be set to zero, and wait_perform() needs to be called again to get some data for the function to return.

Fixes samtools/samtools#1918; possibly also #1037, #1625 and samtools/samtools#1622

@jmarshall I've made you author of ths commit, as it was your patch.  Let me know if you'd like to change anything before it gets merged.