### PR TITLE
Enable optimisation level -O3 for SAM QUAL+33 formatting.

### DIFF
--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -58,6 +58,15 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_NORETURN
 #endif
 
+// Enable optimisation level 3, especially for gcc.  To be used
+// where we want to force vectorisation in hot loops and the default -O2
+// just doesn't cut it.
+#if HTS_COMPILER_HAS(optimize) || HTS_GCC_AT_LEAST(4,4)
+#define HTS_OPT3 __attribute__((optimize("O3")))
+#else
+#define HTS_OPT3
+#endif
+
 // GCC introduced warn_unused_result in 3.4 but added -Wno-unused-result later
 #if HTS_COMPILER_HAS(__warn_unused_result__) || HTS_GCC_AT_LEAST(4,5)
 #define HTS_RESULT_USED __attribute__ ((__warn_unused_result__))


### PR DESCRIPTION
On long read data, the time to format SAM files is dominated by sequence and quality.

The qual[i]+33 loop to turn binary quals into printable ASCII is not vectorised by GCC without using -O3.  I would consider this a weakness of the compiler, but nothing I've done has persuaded gcc (before v12) to generate vector instructions.  Not even the "restrict" keyword.

Hence using __attribute__((optimize("O3"))).

The time the new add33 function is approx 15x quicker with gcc -O3 than gcc -O2.  Clang's and icc's default optimisation level gives speeds comparable to the gcc -O3.

With a compressed Illumina BAM this was just 3% overall speed gain to decode to SAM.  The extreme opposite is uncompressed ONT BAM which shows a 23% speed gain.