### PR TITLE
Add test case compiling the public headers as C++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -566,10 +566,12 @@ htscodecs/htscodecs/version.h: force
 	fi
 endif
 
+# Maintainer extra targets built
+# - compile public headers as C++
 # Maintainer source code checks
 # - copyright boilerplate presence
 # - tab and trailing space detection
-maintainer-check:
+maintainer-check: test/usepublic.o
 	test/maintainer/check_copyright.pl .
 	test/maintainer/check_spaces.pl .
 
@@ -775,6 +777,11 @@ test/test-bcf-sr.o: test/test-bcf-sr.c config.h $(htslib_synced_bcf_reader_h) $(
 test/test-bcf-translate.o: test/test-bcf-translate.c config.h $(htslib_vcf_h)
 test/test_introspection.o: test/test_introspection.c config.h $(htslib_hts_h) $(htslib_hfile_h)
 test/test-bcf_set_variant_type.o: test/test-bcf_set_variant_type.c config.h $(htslib_hts_h) vcf.c
+
+# Standalone target not added to $(BUILT_TEST_PROGRAMS) as some may not
+# have a compiler that compiles as C++ when given a .cpp source file.
+test/usepublic.o: test/usepublic.cpp config.h $(htslib_bgzf_h) $(htslib_cram_h) $(htslib_faidx_h) $(htslib_hfile_h) $(htslib_hts_h) $(htslib_hts_defs_h) $(htslib_hts_endian_h) $(htslib_hts_expr_h) $(htslib_hts_log_h) $(htslib_hts_os_h) $(htslib_kbitset_h) $(htslib_kfunc_h) $(htslib_khash_h) $(htslib_khash_str2int_h) $(htslib_klist_h) $(HTSPREFIX)htslib/knetfile.h $(htslib_kroundup_h) $(htslib_kseq_h) $(htslib_ksort_h) $(htslib_kstring_h) $(htslib_regidx_h) $(htslib_sam_h) $(htslib_synced_bcf_reader_h) $(htslib_tbx_h) $(htslib_thread_pool_h) $(htslib_vcf_h) $(htslib_vcf_sweep_h) $(htslib_vcfutils_h)
+	$(CC) $(CFLAGS) $(TARGET_CFLAGS) $(ALL_CPPFLAGS) -c -o $@ test/usepublic.cpp
 
 
 test/thrash_threads1: test/thrash_threads1.o libhts.a

--- a/test/usepublic.cpp
+++ b/test/usepublic.cpp
@@ -1,0 +1,75 @@
+/*  test/usepublic.cpp -- Test compiling public headers with a C++ compiler.
+
+    Copyright (C) 2023 Centre for Population Genomics.
+
+    Author: John Marshall <jmarshall@hey.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <config.h>
+
+// Include *all* the public HTSlib headers.
+
+#include "../htslib/bgzf.h"
+#include "../htslib/cram.h"
+#include "../htslib/faidx.h"
+#include "../htslib/hfile.h"
+#include "../htslib/hts.h"
+#include "../htslib/hts_defs.h"
+#include "../htslib/hts_endian.h"
+#include "../htslib/hts_expr.h"
+#include "../htslib/hts_log.h"
+#include "../htslib/hts_os.h"
+#include "../htslib/kbitset.h"
+#include "../htslib/kfunc.h"
+#include "../htslib/khash.h"
+#include "../htslib/khash_str2int.h"
+#include "../htslib/klist.h"
+#include "../htslib/knetfile.h"
+#include "../htslib/kroundup.h"
+#include "../htslib/kseq.h"
+#include "../htslib/ksort.h"
+#include "../htslib/kstring.h"
+#include "../htslib/regidx.h"
+#include "../htslib/sam.h"
+#include "../htslib/synced_bcf_reader.h"
+#include "../htslib/tbx.h"
+#include "../htslib/thread_pool.h"
+#include "../htslib/vcf.h"
+#include "../htslib/vcf_sweep.h"
+#include "../htslib/vcfutils.h"
+
+// Instantiate macro-based klib facilities so the resulting function
+// definitions are seen by the C++ compiler.
+
+KHASH_SET_INIT_STR(strhash)
+
+#define noop_free(ptr)
+KLIST_INIT(intlist, int, noop_free)
+
+KSORT_INIT_STR
+
+struct myFILE;
+extern int myread(struct myFILE *, void *, int);
+KSEQ_INIT2(, struct myFILE *, myread)
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
Add a C++ test file that includes all the public HTSlib headers, to verify that the headers compile cleanly when compiled as C++. At present they do not compile cleanly, due to the new problem identified in https://github.com/samtools/htslib/pull/1674#issuecomment-1743740305 and similar pre-existing problems in _klist.h_.

Rather than adding configury to find a C++ compiler, take advantage of Clang and GCC's drivers using C++ when given a _.cpp_ file. As this may not be true in general, add this test to `maintainer-check` only.