### PR TITLE
Add C++ casts for external headers.

### DIFF
--- a/htslib/klist.h
+++ b/htslib/klist.h
@@ -43,7 +43,7 @@
 		kmptype_t **buf;												\
 	} kmp_##name##_t;													\
 	SCOPE kmp_##name##_t *kmp_init_##name(void) {						\
-		return calloc(1, sizeof(kmp_##name##_t));						\
+		return (kmp_##name##_t *)calloc(1, sizeof(kmp_##name##_t));		\
 	}																	\
 	SCOPE void kmp_destroy_##name(kmp_##name##_t *mp) {					\
 		size_t k;														\
@@ -54,14 +54,14 @@
 	}																	\
 	SCOPE kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) {				\
 		++mp->cnt;														\
-		if (mp->n == 0) return calloc(1, sizeof(kmptype_t));			\
+		if (mp->n == 0) return (kmptype_t *)calloc(1, sizeof(kmptype_t)); \
 		return mp->buf[--mp->n];										\
 	}																	\
 	SCOPE void kmp_free_##name(kmp_##name##_t *mp, kmptype_t *p) {		\
 		--mp->cnt;														\
 		if (mp->n == mp->max) {											\
 			mp->max = mp->max? mp->max<<1 : 16;							\
-			mp->buf = realloc(mp->buf, sizeof(kmptype_t *) * mp->max);	\
+			mp->buf = (kmptype_t **)realloc(mp->buf, sizeof(kmptype_t *) * mp->max); \
 		}																\
 		mp->buf[mp->n++] = p;											\
 	}
@@ -88,7 +88,7 @@
 		size_t size;													\
 	} kl_##name##_t;													\
 	SCOPE kl_##name##_t *kl_init_##name(void) {							\
-		kl_##name##_t *kl = calloc(1, sizeof(kl_##name##_t));			\
+		kl_##name##_t *kl = (kl_##name##_t *)calloc(1, sizeof(kl_##name##_t)); \
 		kl->mp = kmp_init(name);										\
 		kl->head = kl->tail = kmp_alloc(name, kl->mp);					\
 		kl->head->next = 0;												\

--- a/htslib/kseq.h
+++ b/htslib/kseq.h
@@ -110,10 +110,10 @@
 				} else break; \
 			} \
 			if (delimiter == KS_SEP_LINE) {  \
-				unsigned char *sep = memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
+				unsigned char *sep = (unsigned char *)memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
 				i = sep != NULL ? sep - ks->buf : ks->end; \
 			} else if (delimiter > KS_SEP_MAX) { \
-				unsigned char *sep = memchr(ks->buf + ks->begin, delimiter, ks->end - ks->begin); \
+				unsigned char *sep = (unsigned char *)memchr(ks->buf + ks->begin, delimiter, ks->end - ks->begin); \
 				i = sep != NULL ? sep - ks->buf : ks->end; \
 			} else if (delimiter == KS_SEP_SPACE) { \
 				for (i = ks->begin; i < ks->end; ++i) \


### PR DESCRIPTION
Klist.h and kseq.h use calloc, realloc and memchr in static inline code, but if we wish to permit our external headers to be used from a C++ include then these all need explicit casts as "void *" doesn't work the same in C++ as in C.

It's tempting to use `extern "C"` in an `#ifdef __cplusplus` guard, but the nature of these pseudo-template klib headers is such that the code will be expanded up later inside a C++ file so the extern "C" doesn't solve it.

See #1674 and #1682