### PR TITLE
Fix a couple of unused value warnings when built with NDEBUG

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -826,8 +826,13 @@ int cram_index_build(cram_fd *fd, const char *fn_base, const char *fn_idx) {
             return -1;
         }
 
-        cpos = htell(fd->fp);
-        assert(cpos == hpos + c->length);
+        off_t next_cpos = htell(fd->fp);
+        if (next_cpos != hpos + c->length) {
+            hts_log_error("Length %"PRId32" in container header at offset %lld does not match block lengths (%lld)",
+                          c->length, (long long) cpos, (long long) next_cpos - hpos);
+            return -1;
+        }
+        cpos = next_cpos;
 
         cram_free_container(c);
     }

--- a/cram/cram_stats.c
+++ b/cram/cram_stats.c
@@ -132,8 +132,9 @@ void cram_stats_dump(cram_stats *st) {
  * Returns the best codec to use.
  */
 enum cram_encoding cram_stats_encoding(cram_fd *fd, cram_stats *st) {
-    int nvals, i, ntot = 0, max_val = 0, min_val = INT_MAX;
+    int nvals, i, max_val = 0, min_val = INT_MAX;
     int *vals = NULL, *freqs = NULL, vals_alloc = 0;
+    int ntot HTS_UNUSED = 0;
 
 #if DEBUG_CRAM_STATS
     cram_stats_dump(st);


### PR DESCRIPTION
The warnings appeared due to the values only being used for `assert()` statements.  The one in `cram_stats_encoding()` is just checking some counts, so the variable is just annotated with `HTS_UNUSED` to silence the warning.

The `assert()` in `cram_index_build()` could actually be triggered with a suitably-adjusted cram file.  As it therefore detects bad inputs, it is replaced with code to write a better error message and return the documented value for read errors in this function.

The attached [bad_len.zip](https://github.com/samtools/htslib/files/13311396/bad_len.zip) file contains an example that can be used to test `cram_index_build()` via
```
./test/test_index bad_len.cram
```
