### PR TITLE
Fix possible shift of negative value in cram_encode_aux()

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -2844,7 +2844,9 @@ static sam_hrec_rg_t *cram_encode_aux(cram_fd *fd, bam_seq_t *b,
 
         // Container level tags_used, for TD series
         // Maps integer key ('X0i') to cram_tag_map struct.
-        int key = (aux[0]<<16)|(aux[1]<<8)|aux[2];
+        int key = (((unsigned char *) aux)[0]<<16 |
+                   ((unsigned char *) aux)[1]<<8  |
+                   ((unsigned char *) aux)[2]);
         k = kh_put(m_tagmap, c->tags_used, key, &r);
         if (-1 == r)
             goto err;


### PR DESCRIPTION
Prevent undefined behaviour albeit on invalid aux tag keys.  Fixed in the style of similar code [later in the same function](https://github.com/samtools/htslib/blob/958e70416c046ec5140101a65c532570a79fff45/cram/cram_encode.c#L3101).

Credit to OSS-Fuzz
Fixes oss-fuzz 64463