### PR TITLE
Allow renaming of the default -a annotations

### DIFF
--- a/annot-tsv.c
+++ b/annot-tsv.c
@@ -516,17 +516,17 @@ void init_data(args_t *args)
             if ( !strcasecmp(args->src.annots->off[i],"nbp") )
             {
                 args->dst.annots_idx[i] = ANN_NBP;
-                cols_append(args->dst.hdr.cols,"nbp");
+                cols_append(args->dst.hdr.cols,tmp->n==2?args->dst.annots->off[i]:"nbp");
             }
             else if ( !strcasecmp(args->src.annots->off[i],"frac") )
             {
                 args->dst.annots_idx[i] = ANN_FRAC;
-                cols_append(args->dst.hdr.cols,"frac");
+                cols_append(args->dst.hdr.cols,tmp->n==2?args->dst.annots->off[i]:"frac");
             }
             else if ( !strcasecmp(args->src.annots->off[i],"cnt") )
             {
                 args->dst.annots_idx[i] = ANN_CNT;
-                cols_append(args->dst.hdr.cols,"cnt");
+                cols_append(args->dst.hdr.cols,tmp->n==2?args->dst.annots->off[i]:"cnt");
             }
             else error("The annotation \"%s\" is not recognised\n", args->src.annots->off[i]);
         }


### PR DESCRIPTION
Similarly to -c, -f, and -m, also the -a option is supposed to allow renaming of the source vs tagrget columns, for example as
    -a frac:fraction

The code was half-ready but unfinished, this commit fixes that