### PR TITLE
fix for incorrect failure message with invalid reference file and crash fix

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -446,7 +446,7 @@ static int fai_build3_core(const char *fn, const char *fnfai, const char *fngzi)
     bgzf = bgzf_open(fn, "r");
 
     if ( !bgzf ) {
-        hts_log_error("Failed to open the file %s", fn);
+        hts_log_error("Failed to open the file %s : %s", fn, strerror(errno));
         goto fail;
     }
 


### PR DESCRIPTION
This change is for #1723 where misleading failure message is displayed.
The error number is reset if it is due to reference file access before reporting the error, to avoid misleading message.
Another change is made to avoid crash/invalid access in hts_close.
A change in samtools will also be raised to do null check before invoking hts_close.