### PR TITLE
Fix B aux tag length check in cram_encode_aux

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -3102,11 +3102,12 @@ static sam_hrec_rg_t *cram_encode_aux(cram_fd *fd, bam_seq_t *b,
             if (aux_end - aux < 4+4)
                 goto err;
 
-            int type = aux[3], blen;
-            uint32_t count = (((uint32_t)((unsigned char *)aux)[4]) << 0 |
-                              ((uint32_t)((unsigned char *)aux)[5]) << 8 |
-                              ((uint32_t)((unsigned char *)aux)[6]) <<16 |
-                              ((uint32_t)((unsigned char *)aux)[7]) <<24);
+            int type = aux[3];
+            uint64_t count = (((uint64_t)((unsigned char *)aux)[4]) << 0 |
+                              ((uint64_t)((unsigned char *)aux)[5]) << 8 |
+                              ((uint64_t)((unsigned char *)aux)[6]) <<16 |
+                              ((uint64_t)((unsigned char *)aux)[7]) <<24);
+            uint64_t blen;
             if (!tm->blk) {
                 if (!(tm->blk = cram_new_block(EXTERNAL, key)))
                     goto err;
@@ -3141,10 +3142,10 @@ static sam_hrec_rg_t *cram_encode_aux(cram_fd *fd, bam_seq_t *b,
             }
 
             blen += 5; // sub-type & length
-            if (aux_end - aux < blen)
+            if (aux_end - aux < blen || blen > INT_MAX)
                 goto err;
 
-            if (codec->encode(s, codec, aux, blen) < 0)
+            if (codec->encode(s, codec, aux, (int) blen) < 0)
                 goto err;
             aux += blen;
             break;

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -3099,7 +3099,7 @@ static sam_hrec_rg_t *cram_encode_aux(cram_fd *fd, bam_seq_t *b,
         }
 
         case 'B': {
-            if (aux_end - aux < 3+4)
+            if (aux_end - aux < 4+4)
                 goto err;
 
             int type = aux[3], blen;


### PR DESCRIPTION
B tags need [eight bytes](https://samtools.github.io/hts-specs/SAMv1.pdf#subsubsection.4.2.4).  Previously this only checked for at least seven, which could lead to a single byte out of bounds read.  The impact of this is mostly limited by a [later check](https://github.com/samtools/htslib/blob/61b037bb881e85259f8df30c78d99ad3a357ed52/cram/cram_encode.c#L3144) on `blen`; however it was also possible that `blen` could overflow, allowing the check to incorrectly pass.  A second commit expands `blen` so it can't overflow, and ensures it has an acceptable value before passing it to the encode function.

