### PR TITLE
bgzip - modified and access time as in source file

### DIFF
--- a/bgzip.1
+++ b/bgzip.1
@@ -71,7 +71,9 @@ otherwise when compressing bgzip will write to a new file with a .gz
 suffix and remove the original.  When decompressing the input file must
 have a .gz suffix, which will be removed to make the output name.  Again
 after decompression completes the input file will be removed. When multiple
-files are given as input, the operation is performed on all of them.
+files are given as input, the operation is performed on all of them. Access
+and modification time of input file from filesystem is set to output file. 
+Note, access time may get updated by system when it deems appropriate.
 
 .SH OPTIONS
 .TP 10


### PR DESCRIPTION
Fixes #1718 
Updated bgzip to retain the file modification and access time during compression and decompression.
In Mac/linux it retains upto microsecond and in windows it does with second precision.
