### PR TITLE
Fix over-lenient check in bam_aux_first() / bam_aux_next()

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -4693,7 +4693,7 @@ uint8_t *bam_aux_first(const bam1_t *b)
 {
     uint8_t *s = bam_get_aux(b);
     uint8_t *end = b->data + b->l_data;
-    if (s >= end) { errno = ENOENT; return NULL; }
+    if (end - s <= 2) { errno = ENOENT; return NULL; }
     return s+2;
 }
 
@@ -4702,7 +4702,7 @@ uint8_t *bam_aux_next(const bam1_t *b, const uint8_t *s)
     uint8_t *end = b->data + b->l_data;
     uint8_t *next = s? skip_aux((uint8_t *) s, end) : end;
     if (next == NULL) goto bad_aux;
-    if (next >= end) { errno = ENOENT; return NULL; }
+    if (end - next <= 2) { errno = ENOENT; return NULL; }
     return next+2;
 
  bad_aux:


### PR DESCRIPTION
After calling these, bam_aux_get() expects three bytes to be available (two before the returned pointer).  While a test to prevent running off the end of the aux data was present, it didn't account for incrementing the returned pointer by 2.  The new version ensures that the expected data is available.

The bug could lead to a read of up to two bytes beyond the end of the aux data in bam_aux_get().  As a later call to skip_aux() would have correctly detect that the tag is invalid, bam_aux_get() should still have returned NULL, making it difficult to exploit the out-of-bounds access.

Credit to OSS-Fuzz
Fixes oss-fuzz 65820