### PR TITLE
Revert a bug from c1f4b7c where CRAM aux tags were not compressed.

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -953,14 +953,14 @@ static int cram_compress_slice(cram_fd *fd, cram_container *c, cram_slice *s) {
      */
     {
         int i;
-        for (i = 0; i < s->naux_block; i++) {
-            if (!s->aux_block[i] || s->aux_block[i] == s->block[0])
+        for (i = DS_END /*num_blk - naux_blk*/; i < s->hdr->num_blocks; i++) {
+            if (!s->block[i] || s->block[i] == s->block[0])
                 continue;
 
-            if (s->aux_block[i]->method != RAW)
+            if (s->block[i]->method != RAW)
                 continue;
 
-            if (cram_compress_block2(fd, s, s->aux_block[i], s->aux_block[i]->m,
+            if (cram_compress_block2(fd, s, s->block[i], s->block[i]->m,
                                      method, level))
                 return -1;
         }


### PR DESCRIPTION
In an attempt to fix memory leaks during encode of malformed CRAM data, that lead to bailing out early, we attempted to get everything to a uniform state as soon as possible.  Specifically s->aux_blocks get migrated to s->blocks earlier, so if we bail out we don't have the decision to make as to which bit of memory needs freeing.

That worked, but unfortunately I forgot that the compression is applied to s->aux_blocks and not s->blocks for auxiliary tags, so moving the blocks earlier gives uncompressed blocks in CRAM.  The format is valid and all tests pass, but it's overly large for obvious reasons.

Sadly this is a rather serious bug caused by an attempt to fix a really minor bug.

Fixes samtools/samtools#1968