### PR TITLE
Fix arithmetic overflow in load_ref_portion() on very long refs

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3221,7 +3221,8 @@ void cram_ref_decr(refs_t *r, int id) {
  * Returns all or part of a reference sequence on success (malloced);
  *         NULL on failure.
  */
-static char *load_ref_portion(BGZF *fp, ref_entry *e, int start, int end) {
+static char *load_ref_portion(BGZF *fp, ref_entry *e,
+                              hts_pos_t start, hts_pos_t end) {
     off_t offset, len;
     char *seq;
 
@@ -3317,7 +3318,7 @@ static char *load_ref_portion(BGZF *fp, ref_entry *e, int start, int end) {
  */
 ref_entry *cram_ref_load(refs_t *r, int id, int is_md5) {
     ref_entry *e = r->ref_id[id];
-    int start = 1, end = e->length;
+    hts_pos_t start = 1, end = e->length;
     char *seq;
 
     if (e->seq) {
@@ -3401,7 +3402,7 @@ ref_entry *cram_ref_load(refs_t *r, int id, int is_md5) {
  * Returns reference on success,
  *         NULL on failure
  */
-char *cram_get_ref(cram_fd *fd, int id, int start, int end) {
+char *cram_get_ref(cram_fd *fd, int id, hts_pos_t start, hts_pos_t end) {
     ref_entry *r;
     char *seq;
     int ostart = start;
@@ -4928,7 +4929,7 @@ int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr) {
             if (!sam_hrecs_find_key(ty, "M5", NULL)) {
                 char unsigned buf[16];
                 char buf2[33];
-                int rlen;
+                hts_pos_t rlen;
                 hts_md5_context *md5;
 
                 if (!fd->refs ||
@@ -4956,7 +4957,19 @@ int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr) {
                 rlen = fd->refs->ref_id[i]->length; /* In case it just loaded */
                 if (!(md5 = hts_md5_init()))
                     return -1;
-                hts_md5_update(md5, ref, rlen);
+                if (HTS_POS_MAX <= ULONG_MAX) {
+                    // Platforms with 64-bit unsigned long update in one go
+                    hts_md5_update(md5, ref, rlen);
+                } else {
+                    // Those with 32-bit ulong (Windows) may have to loop
+                    // over epic references
+                    hts_pos_t pos = 0;
+                    while (rlen - pos > ULONG_MAX) {
+                        hts_md5_update(md5, ref + pos, ULONG_MAX);
+                        pos += ULONG_MAX;
+                    }
+                    hts_md5_update(md5, ref + pos, (unsigned long)(rlen - pos));
+                }
                 hts_md5_final(buf, md5);
                 hts_md5_destroy(md5);
                 cram_ref_decr(fd->refs, i);

--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -391,7 +391,7 @@ void refs_free(refs_t *r);
  * Returns reference on success;
  *         NULL on failure
  */
-char *cram_get_ref(cram_fd *fd, int id, int start, int end);
+char *cram_get_ref(cram_fd *fd, int id, hts_pos_t start, hts_pos_t end);
 void cram_ref_incr(refs_t *r, int id);
 void cram_ref_decr(refs_t *r, int id);
 /**@}*/


### PR DESCRIPTION
While the Mistletoe reference has been chopped into segments of less than 2^31 bases, they were still long enough to cause an overflow in the load_ref_portion() `len` calculation.  This was due to the line endings taking the total over INT_MAX.  Fix be changing the data type of `start` and `end` to `hts_pos_t` so the entire calculation is done on 64-bit values.

Callers to load_ref_portion() are also updated where necessary to use `hts_pos_t`, making long references more likely to work should they ever be supported in CRAM.  All callers of callers were already using 64-bit values due to earlier upgrades.

There's a potential complication over calculating the MD5 checksums as the exported hts_md5_update() function takes an unsigned long for the length.  On 64-bit platforms with 32-bit unsigned long (i.e. [Windows](https://learn.microsoft.com/en-us/cpp/cpp/data-type-ranges?view=msvc-170)) it is necessary to add a loop if the reference is a very long one.  On platforms with 64-bit long a single call is still used, and the loop should be optimised out.

Fixes #1734 (CRAM load_ref_portion() fails on some Mistletoe references)