### PR TITLE
Speed up sam_parse_B_vals

### DIFF
--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -67,6 +67,12 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_OPT3
 #endif
 
+#if HTS_COMPILER_HAS(aligned) || HTS_GCC_AT_LEAST(4,3)
+#define HTS_ALIGN32 __attribute__((aligned(32)))
+#else
+#define HTS_ALIGN32
+#endif
+
 // GCC introduced warn_unused_result in 3.4 but added -Wno-unused-result later
 #if HTS_COMPILER_HAS(__warn_unused_result__) || HTS_GCC_AT_LEAST(4,5)
 #define HTS_RESULT_USED __attribute__ ((__warn_unused_result__))


### PR DESCRIPTION
There are a few issues with this.

hts_str2int and hts_str2uint are slightly inefficient.

- The use of unsigned char for "d" causes type conversions which are unnecessary.  All we care about is wrap around to positive values.

- The check on !fast normally passes for values that aren't huge, as we nearly always end before hitting that loop.  Hence we then pointlessly do devisions and a while loop with zero cycles, so we can lift that check up one left.

- Simplification of the overflow conditions.  This is not necessary as every possible positive number can be negated to negative without overflow.  (Overflow can only possibly occur when doing the reverse.)

The sam_parse_B_vals function is more tricky to nail. In attempting to speed up the str2int functions I found huge variation in speeds based on compiler (gcc, clang), version, and optimisation levels.  Sometimes wildly different.  The most minor changes would flip speed.

After a lot of trial and error I realised gcc -falign-loops=5 also wildly changes things, and that most speed changes were down to instruction cache line boundaries and their interplay with the uOPS caches.  A lot of "perf" analysis later showed the main culprit to be the skip_to_comma_ loop, so the code was restructed so this isn't normally executed.

In the process I also discovered and fixed a bug.

    Bi:B:I,-2147483648,-2147483647,0,2147483647

is meant to detect overlaps and rewrite it as

    Bi:B:i,-2147483648,-2147483647,0,2147483647

However the detection of '-' sign for unsigned values is incorrect as it's pointing to ',' instead, so an entire chunk of logic was never executed and those out-of-bounds negatives got modified to zero.

Note this does change behaviour.  Previously an aux tag of XX:B:C,1,2#3,4 would silently return 1,2,4.  It now errors on the 2#3 instead.  I believe this is an improvement over silently changing broken inputs.

--------------------------------------------------

Perf stat cycles on an ONT sam file with 4685 records of :B:C, and :B:c, using "test_view -B ont.sam" as a benchmark.

    gcc7    -O2: 5565824443
    gcc7    -O3: 5779736469
    gcc13   -O2: 5565893109
    gcc13   -O3: 5392426978
    clang10 -O2: 5344657729
    clang10 -O3: 5348030140
    clang16 -O2: 4563321159
    clang16 -O3: 4575986193

For reference, some stats on the develop branch on the same file:

    gcc13   -O3: 9724589000
    clang16 -O3: 6398268577

So the effective speed of samtools is 80% and 40% slower respectively! That's total time spent, including everything else being executed too, so the sam_parse_B_vals speed up is considerably higher.

Investigating with specific counters for the gcc13 case we see this.

develop:

     9724589000      cycles
     3308765106      stalled-cycles-frontend   #   34.02% frontend cycles idle
     1898104974      stalled-cycles-backend    #   19.52% backend cycles idle
    17596774767      instructions              #    1.81  insn per cycle
                                               #    0.19  stalled cycles/insn
     1629365133      idq.empty
    13489362500      idq_uops_not_delivered.core

    3.259651973 seconds time elapsed

This PR:

     5397541312      cycles
     1438049271      stalled-cycles-frontend   #   26.64% frontend cycles idle
      514817530      stalled-cycles-backend    #    9.54% backend cycles idle
    15125819343      instructions              #    2.80  insn per cycle
                                               #    0.10  stalled cycles/insn
      164253475      idq.empty
     2653272955      idq_uops_not_delivered.core

    1.809554598 seconds time elapsed

We can clearly see the frontend was being bottlenecked on on the instruction decode queue, which is caused by the aforementioned spanning of instruction cache lines.

Different architectures will be affected in different ways, and newer ones probably less badly affected.  I haven't benchmarked on other hardware.