### PR TITLE
Make faidx error messages slightly more enlightening

### DIFF
--- a/faidx.c
+++ b/faidx.c
@@ -190,7 +190,7 @@ static faidx_t *fai_build_core(BGZF *bgzf) {
                 kputsn("", 0, &name);
 
                 if (c < 0) {
-                    hts_log_error("The last entry '%s' has no sequence", name.s);
+                    hts_log_error("The last entry '%s' has no sequence at line %d", name.s, line_num);
                     goto fail;
                 }
 
@@ -247,7 +247,7 @@ static faidx_t *fai_build_core(BGZF *bgzf) {
                         state = SEQ_END;
 
                 } else if (line_len < ll) {
-                    hts_log_error("Different line length in sequence '%s'", name.s);
+                    hts_log_error("Different line length in sequence '%s' at line %d", name.s, line_num);
                     goto fail;
                 }
 
@@ -269,7 +269,7 @@ static faidx_t *fai_build_core(BGZF *bgzf) {
             case IN_QUAL:
                 if (c == '\n') {
                     if (!read_done) {
-                        hts_log_error("Inlined empty line is not allowed in quality of sequence '%s'", name.s);
+                        hts_log_error("Inlined empty line is not allowed in quality of sequence '%s' at line %d", name.s, line_num);
                         goto fail;
                     }
 
@@ -312,6 +312,7 @@ static faidx_t *fai_build_core(BGZF *bgzf) {
         if (fai_insert_index(idx, name.s, seq_len, line_len, char_len, seq_offset, qual_offset) != 0)
             goto fail;
     } else {
+        hts_log_error("File truncated at line %d", line_num);
         goto fail;
     }
 


### PR DESCRIPTION
This adds a small amount of extra information to errors when running `samtools faidx`, specifically it adds a helpful message when dealing with zero-length compressed data, which can occur eg: when downloading a file from the internet fails.

before:
```
$ bgzip < /dev/null > empty.gz
$ ls -l empty.gz
-rw-rw-r-- 1 nick nick 28 Feb  8 11:41 empty.gz
$ samtools faidx empty.gz
[faidx] Could not build fai index empty.gz.fai
$
```

after:
```
$ ./samtools faidx empty.gz
[E::fai_build_core] File truncated at line 1
[faidx] Could not build fai index empty.gz.fai
$
```

which is a pretty big hint that something has gone wrong in your tool chain somewhere.

... and also line numbers to some of the other error messages to make it easier to track down the problematic lines.