### PR TITLE
 Drop duplicate FORMAT tags and fix an error with dropping large tags

### DIFF
--- a/test/noroundtrip-out.vcf
+++ b/test/noroundtrip-out.vcf
@@ -3,7 +3,7 @@
 ##contig=<ID=3>
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA1
-3	50	.	A	T	0	PASS	.	GT:GT	2,4:.
+3	50	.	A	T	0	PASS	.	GT	0/1
 3	60	.	T	C	0	PASS	.	GT	0/1
-3	70	.	G	A	0	PASS	.	GT:GT	2,4:.
-3	80	.	C	G	0	PASS	.	GT:GT	2,4:0/1
+3	70	.	G	A	0	PASS	.	GT	0/1
+3	80	.	C	G	0	PASS	.	GT	0/1


### PR DESCRIPTION
The removal of large tags introduced by https://github.com/samtools/htslib/commit/b49eea478114759efe19e718c38e7deb00614b21 and https://github.com/samtools/htslib/commit/9db565de3d89235f625de07363f1cd726c43f8f2 could not work correctly, the memmove pointers were wrong!

Resolves https://github.com/samtools/htslib/issues/1733

This is a fix of the botched pull request https://github.com/samtools/htslib/pull/1736