### PR TITLE
Fix duplicated but missing FORMAT bug

### DIFF
--- a/test/noroundtrip-out.vcf
+++ b/test/noroundtrip-out.vcf
@@ -2,8 +2,10 @@
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##contig=<ID=3>
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=S,Number=1,Type=String,Description="Non-GT string">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA1
 3	50	.	A	T	0	PASS	.	GT	0/1
 3	60	.	T	C	0	PASS	.	GT	0/1
 3	70	.	G	A	0	PASS	.	GT	0/1
 3	80	.	C	G	0	PASS	.	GT	0/1
+3	90	.	A	G	0	PASS	.	GT:S	0/1:.

--- a/test/noroundtrip.vcf
+++ b/test/noroundtrip.vcf
@@ -1,8 +1,10 @@
 ##fileformat=VCFv4.3
 ##contig=<ID=3>
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=S,Number=1,Type=String,Description="Non-GT string">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA1
 3	50	.	A	T	0	PASS	.	GT:GT	0/1
 3	60	.	T	C	0	PASS	.	GT	0/1
 3	70	.	G	A	0	PASS	.	GT:GT	0/1:.
 3	80	.	C	G	0	PASS	.	GT:GT	0/1:0/1
+3	90	.	A	G	0	PASS	.	GT:S:S	0/1

--- a/vcf.c
+++ b/vcf.c
@@ -3234,6 +3234,10 @@ static int vcf_parse_format_fill5(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v,
             fmt_aux_t *z = &fmt[j];
             const int htype = z->y>>4&0xf;
             int l;
+
+            if (z->size == -1) // this field is to be ignored
+                continue;
+
             if (htype == BCF_HT_STR) {
                 if (z->is_gt) {
                     int32_t *x = (int32_t*)(z->buf + z->size * (size_t)m);


### PR DESCRIPTION
7ce510c added code to drop duplicate FORMAT tags, but missed the case where the duplicated entry was off the end of the per-sample data, so it hit the part that put in MISSING values.  This lead to an attempt to call memset() with a negative size.  Fixed by adding code to skip the duplicated FORMAT tag.
