### PR TITLE
Ensure S3 redirects use TLS

### DIFF
--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -578,11 +578,14 @@ static int redirect_endpoint_callback(void *auth, long response,
                 free(url_prefix.s);
             }
             if (ad->region.l && ad->host.l) {
+               int e = 0;
                url->l = 0;
-               kputs(ad->host.s, url);
-               kputsn(ad->bucket, strlen(ad->bucket), url);
+               e |= kputs("https://", url) < 0;
+               e |= kputs(ad->host.s, url) < 0;
+               e |= kputsn(ad->bucket, strlen(ad->bucket), url) < 0;
 
-               ret = 0;
+               if (!e)
+                   ret = 0;
             }
             if (ad->user_query_string.l) {
                 kputc('?', url);


### PR DESCRIPTION
When following a 3xx redirection from AWS, `redirect_endpoint_callback()` wasn't putting `https://` on the new URL.  The redirection worked, but dropped back to http.  Obviously, this is not desirable.

Fix by prepending `https://` to ensure it uses TLS, and adding a bit of error checking to ensure all parts of the new url have been included.

Fixes #1760 
