### PR TITLE
Make nibble2base faster using x86-64 pshufb instruction (SSSE3) and using dynamic dispatch.

### DIFF
--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -34,6 +34,10 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_COMPILER_HAS(attribute) __has_attribute(attribute)
 #endif
 
+#ifdef __has_builtin
+#define HTS_COMPILER_HAS_BUILTIN(function) __has_builtin(function)
+#endif
+
 #elif defined __GNUC__
 #define HTS_GCC_AT_LEAST(major, minor) \
     (__GNUC__ > (major) || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor)))
@@ -42,6 +46,10 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef HTS_COMPILER_HAS
 #define HTS_COMPILER_HAS(attribute) 0
 #endif
+#ifndef HTS_COMPILER_HAS_BUILTIN
+#define HTS_COMPILER_HAS_BUILTIN(function) 0
+#endif
+
 #ifndef HTS_GCC_AT_LEAST
 #define HTS_GCC_AT_LEAST(major, minor) 0
 #endif
@@ -116,6 +124,16 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_FORMAT(type, idx, first) __attribute__((__format__ (type, idx, first)))
 #else
 #define HTS_FORMAT(type, idx, first)
+#endif
+
+#define HTS_COMPILER_HAS_TARGET_AND_BUILTIN_CPU_SUPPORTS \
+ ((HTS_COMPILER_HAS(target) && HTS_COMPILER_HAS_BUILTIN(__builtin_cpu_supports)) \
+ || HTS_GCC_AT_LEAST(4, 8))
+
+#if (defined(__x86_64__) || defined(_M_X64))
+#define HTS_BUILD_IS_X86_64 1
+#else
+#define HTS_BUILD_IS_X86_64 0
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)

--- a/sam_internal.h
+++ b/sam_internal.h
@@ -99,7 +99,8 @@ static inline void nibble2base_default(uint8_t *nib, char *seq, int len) {
         seq[i] = seq_nt16_str[bam_seqi(nib, i)];
 }
 
-#if HTS_GCC_AT_LEAST(4,8)
+#if HTS_BUILD_IS_X86_64 && HTS_COMPILER_HAS_TARGET_AND_BUILTIN_CPU_SUPPORTS
+#include "immintrin.h"
 /*
  * Convert a nibble encoded BAM sequence to a string of bases.
  *
@@ -108,7 +109,7 @@ static inline void nibble2base_default(uint8_t *nib, char *seq, int len) {
  * be converted to the IUPAC characters.
  * It falls back on the nibble2base_default function for the remainder.
  */
-#include "tmmintrin.h"
+
 __attribute__((target("ssse3")))
 static inline void nibble2base_ssse3(uint8_t *nib, char *seq, int len) {
     seq[0] = 0;

--- a/sam_internal.h
+++ b/sam_internal.h
@@ -26,7 +26,9 @@ DEALINGS IN THE SOFTWARE.  */
 #include <errno.h>
 #include <stdint.h>
 #include "htslib/sam.h"
-
+#ifdef __SSSE3__
+#include "tmmintrin.h"
+#endif
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -87,15 +89,71 @@ static inline void nibble2base(uint8_t *nib, char *seq, int len) {
         "B=BABCBMBGBRBSBVBTBWBYBHBKBDBBBN"
         "N=NANCNMNGNRNSNVNTNWNYNHNKNDNBNN";
 
-    int i, len2 = len/2;
     seq[0] = 0;
+    const char *seq_end_ptr = seq + len;
+    char *seq_cursor = seq;
+    const uint8_t *nibble_cursor = nib;
+    const char *seq_end_ptr_twoatatime = seq + (len & (~1ULL));
+    #ifdef __SSSE3__
+    const char *seq_vec_end_ptr = seq_end_ptr - (2 * sizeof(__m128i));
+    __m128i first_upper_shuffle = _mm_setr_epi8(
+        0, 0xff, 1, 0xff, 2, 0xff, 3, 0xff, 4, 0xff, 5, 0xff, 6, 0xff, 7, 0xff);
+    __m128i first_lower_shuffle = _mm_setr_epi8(
+        0xff, 0, 0xff, 1, 0xff, 2, 0xff, 3, 0xff, 4, 0xff, 5, 0xff, 6, 0xff, 7);
+    __m128i second_upper_shuffle = _mm_setr_epi8(
+        8, 0xff, 9, 0xff, 10, 0xff, 11, 0xff, 12, 0xff, 13, 0xff, 14, 0xff, 15, 0xff);
+    __m128i second_lower_shuffle = _mm_setr_epi8(
+        0xff, 8, 0xff, 9, 0xff, 10, 0xff, 11, 0xff, 12, 0xff, 13, 0xff, 14, 0xff, 15);
+    __m128i nuc_lookup_vec = _mm_lddqu_si128((__m128i *)seq_nt16_str);
+    /* Work on 16 encoded characters at the time resulting in 32 decoded characters
+       Examples are given for 8 encoded characters A until H to keep it readable.
+        Encoded stored as |AB|CD|EF|GH|
+        Shuffle into |AB|00|CD|00|EF|00|GH|00| and
+                     |00|AB|00|CD|00|EF|00|GH|
+        Shift upper to the right resulting into
+                     |0A|B0|0C|D0|0E|F0|0G|H0| and
+                     |00|AB|00|CD|00|EF|00|GH|
+        Merge with or resulting into (X stands for garbage)
+                     |0A|XB|0C|XD|0E|XF|0G|XH|
+        Bitwise and with 0b1111 leads to:
+                     |0A|0B|0C|0D|0E|0F|0G|0H|
+        We can use the resulting 4-bit integers as indexes for the shuffle of
+        the nucleotide lookup. */
+    while (seq_cursor < seq_vec_end_ptr) {
+        __m128i encoded = _mm_lddqu_si128((__m128i *)nibble_cursor);
 
-    for (i = 0; i < len2; i++)
+        __m128i first_upper = _mm_shuffle_epi8(encoded, first_upper_shuffle);
+        __m128i first_lower = _mm_shuffle_epi8(encoded, first_lower_shuffle);
+        __m128i shifted_first_upper = _mm_srli_epi64(first_upper, 4);
+        __m128i first_merged = _mm_or_si128(shifted_first_upper, first_lower);
+        __m128i first_indexes = _mm_and_si128(first_merged, _mm_set1_epi8(0b1111));
+        __m128i first_nucleotides = _mm_shuffle_epi8(nuc_lookup_vec, first_indexes);
+        _mm_storeu_si128((__m128i *)seq_cursor, first_nucleotides);
+
+        __m128i second_upper = _mm_shuffle_epi8(encoded, second_upper_shuffle);
+        __m128i second_lower = _mm_shuffle_epi8(encoded, second_lower_shuffle);
+        __m128i shifted_second_upper = _mm_srli_epi64(second_upper, 4);
+        __m128i second_merged = _mm_or_si128(shifted_second_upper, second_lower);
+        __m128i second_indexes = _mm_and_si128(second_merged, _mm_set1_epi8(0b1111));
+        __m128i second_nucleotides = _mm_shuffle_epi8(nuc_lookup_vec, second_indexes);
+        _mm_storeu_si128((__m128i *)(seq_cursor + 16), second_nucleotides);
+
+        nibble_cursor += sizeof(__m128i);
+        seq_cursor += 2 * sizeof(__m128i);
+    }
+    #endif
+    while (seq_cursor < seq_end_ptr_twoatatime) {
         // Note size_t cast helps gcc optimiser.
-        memcpy(&seq[i*2], &code2base[(size_t)nib[i]*2], 2);
-
-    if ((i *= 2) < len)
-        seq[i] = seq_nt16_str[bam_seqi(nib, i)];
+        memcpy(seq_cursor, code2base + ((size_t)*nibble_cursor * 2), 2);
+        seq_cursor += 2;
+        nibble_cursor += 1;
+    }
+    if (seq_cursor != seq_end_ptr) {
+        /* There is a single encoded nuc left */
+        uint8_t nibble_c = *nibble_cursor;
+        uint8_t upper_nuc_index = nibble_c >> 4;
+        seq_cursor[0] = seq_nt16_str[upper_nuc_index];
+    }
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
See https://github.com/samtools/htslib/pull/1677 for prior discussion.

I made the PR such that nibble2base is dynamically dispatched on x86-64 cpus with SSSE3 instructions. 

No build options need to be changed and nibble2base gets a nice speed up on the majority of the install base.