### PR TITLE
Increase the input block size for bgzip.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -326,7 +326,7 @@ HTS_HIDE_DYNAMIC_SYMBOLS
 
 dnl FIXME This pulls in dozens of standard header checks
 AC_FUNC_MMAP
-AC_CHECK_FUNCS([gmtime_r fsync drand48 srand48_deterministic getauxval elf_aux_info])
+AC_CHECK_FUNCS([gmtime_r fsync drand48 srand48_deterministic getauxval elf_aux_info posix_memalign])
 
 # Darwin has a dubious fdatasync() symbol, but no declaration in <unistd.h>
 AC_CHECK_DECL([fdatasync(int)], [AC_CHECK_FUNCS(fdatasync)])

--- a/hfile.c
+++ b/hfile.c
@@ -113,8 +113,14 @@ hFILE *hfile_init(size_t struct_size, const char *mode, size_t capacity)
     // FIXME For now, clamp input buffer sizes so mpileup doesn't eat memory
     if (strchr(mode, 'r') && capacity > maxcap) capacity = maxcap;
 
+#ifdef HAVE_POSIX_MEMALIGN
+    fp->buffer = NULL;
+    if (posix_memalign((void **)&fp->buffer, 256, capacity) < 0)
+        goto error;
+#else
     fp->buffer = (char *) malloc(capacity);
     if (fp->buffer == NULL) goto error;
+#endif
 
     fp->begin = fp->end = fp->buffer;
     fp->limit = &fp->buffer[capacity];


### PR DESCRIPTION
Commit e495718 changed bgzip from unix raw POSIX read() calls to hread().  Unfortunately hread gets its buffer size from stat of the input file descriptor, which can be 4kb for a pipe.  We're reading 0xff00 bytes, so this ends up being split over two reads mostly, with one or both involving additional memcpys.  This makes the buffered I/O worse performing than non-buffered.  In the most extreme cases (cat data | bgzip -l0 > /dev/null) this is a two fold slow down.

The easy solution is just to increase the buffer size to something sensible.  It's a little messy as we have to use hfile_internal.h to get hfile_set_blksize, but it works.  I'm not sure why we didn't elect to make that API more public.  Probably simply out of caution.

Fixes #1767