### PR TITLE
Add support for CRAM Zstd compression

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -171,7 +171,7 @@ arm_ubuntu_task:
     apt-get install -y --no-install-suggests --no-install-recommends     \
         ca-certificates clang libc-dev make git autoconf automake        \
         zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev \
-        libdeflate-dev
+        libdeflate-dev libzstd-dev
 
   << : *COMPILE
   << : *TEST

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,7 +81,7 @@ gcc_task:
     apt-get install -y --no-install-suggests --no-install-recommends     \
         ca-certificates libc-dev make git autoconf automake              \
         zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev \
-        cmake
+        cmake libzstd-dev
 
   << : *LIBDEFLATE
   << : *COMPILE
@@ -119,7 +119,7 @@ ubuntu_task:
     apt-get install -y --no-install-suggests --no-install-recommends     \
         ca-certificates clang libc-dev make git autoconf automake        \
         zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev \
-        libdeflate-dev
+        libdeflate-dev libzstd-dev
 
   << : *COMPILE
   << : *TEST

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ config.h:
 	echo '#define HAVE_LIBLZMA 1' >> $@
 	echo '#ifndef __APPLE__' >> $@
 	echo '#define HAVE_LZMA_H 1' >> $@
+	echo '#define HAVE_LIBZSTD 1' >> $@
 	echo '#endif' >> $@
 	echo '#define HAVE_DRAND48 1' >> $@
 	echo '#define HAVE_LIBCURL 1' >> $@

--- a/configure.ac
+++ b/configure.ac
@@ -186,6 +186,11 @@ AC_ARG_ENABLE([lzma],
                   [omit support for LZMA-compressed CRAM files])],
   [], [enable_lzma=yes])
 
+AC_ARG_ENABLE([zstd],
+  [AS_HELP_STRING([--disable-zstd],
+                  [omit support for Zstandard-compressed CRAM files])],
+  [], [enable_zstd=yes])
+
 AC_ARG_ENABLE([plugins],
   [AS_HELP_STRING([--enable-plugins],
                   [enable separately-compiled plugins for file access])],
@@ -397,6 +402,18 @@ produced elsewhere unreadable) or resolve this error to build HTSlib.])
   fi
   pc_requires="$pc_requires liblzma"
   static_LIBS="$static_LIBS -llzma"
+fi
+
+
+if test "$enable_zstd" != no; then
+  zstd_devel=ok
+  AC_CHECK_HEADERS([zstd.h], [], [zstd_devel=header-missing], [;])
+  AC_CHECK_LIB([zstd], [ZSTD_compress], [], [zstd_devel=missing])
+  if test $zstd_devel = missing; then
+    MSG_ERROR([libzstd development files not found])
+  fi
+  pc_requires="$pc_requires libzstd"
+  static_LIBS="$static_LIBS -lzstd"
 fi
 
 AS_IF([test "x$with_external_htscodecs" != "xno"],

--- a/configure.ac
+++ b/configure.ac
@@ -408,7 +408,7 @@ fi
 if test "$enable_zstd" != no; then
   zstd_devel=ok
   AC_CHECK_HEADERS([zstd.h], [], [zstd_devel=header-missing], [;])
-  AC_CHECK_LIB([zstd], [ZSTD_compress], [], [zstd_devel=missing])
+  AC_CHECK_LIB([zstd], [ZSTD_createDCtx, ZSTD_createCCtx, ZSTD_CCtx_loadDictionary, ZSTD_decompressDCtx, ZSTD_compressCCtx, ZSTD_compressBound], [], [zstd_devel=missing])
   if test $zstd_devel = missing; then
     MSG_ERROR([libzstd development files not found])
   fi

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -812,6 +812,9 @@ static int cram_compress_slice(cram_fd *fd, cram_container *c, cram_slice *s) {
     if (fd->use_bz2)
         method |= 1<<BZIP2;
 
+    if (fd->use_zstd)
+        method |= 1<<ZSTD;
+
     int method_rans   = (1<<RANS0) | (1<<RANS1);
     int method_ranspr = method_rans;
 

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -636,7 +636,8 @@ cram_method_details *cram_expand_method(uint8_t *data, int32_t size,
                 cm->level = 1;
         }
         break;
-
+    case CRAM_COMP_ZSTD:
+        break;
     default:
         break;
     }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -127,7 +127,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ZSTD_CCtx* zstd_cctx = NULL;
 ZSTD_DCtx* zstd_dctx = NULL;
-ZSTD_DDict *zstd_ddict = NULL;
 
 #endif
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2113,6 +2113,7 @@ int cram_compress_block2(cram_fd *fd, cram_slice *s,
             method |= 1<<ZSTD;
     }
 
+#ifdef HAVE_LIBZSTD
     if (!zstd_cctx && method & (1<<ZSTD)) {
         // get zstd ready to go with the correct zstd dictionary
         if (init_zstd(fd->zstd_dict) != 0) {
@@ -2120,6 +2121,7 @@ int cram_compress_block2(cram_fd *fd, cram_slice *s,
             return -1;
         }
     }
+#endif
 
     if (level == -1)
         level = fd->level;

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -228,7 +228,8 @@ enum cram_block_method_int {
     ARITH    = 6, ARITH_PR0 = ARITH,
     FQZ      = 7,
     TOK3     = 8,
-    // BSC = 9, ZSTD = 10
+    // BSC = 9, 
+    ZSTD = 10,
 
     // Methods not externalised, but used in metrics.
     // Externally they become one of the above methods.
@@ -825,6 +826,7 @@ struct cram_fd {
     int no_ref_counter; // decide if permanent switch
     int ignore_md5;
     int use_bz2;
+    int use_zstd;
     int use_rans;
     int use_lzma;
     int use_fqz;

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -885,6 +885,8 @@ struct cram_fd {
     // We suffer with delta to unrelated things (previous pair), but gain
     // in delta between them.  (Ideal would be a per read setting.)
     int ap_delta;
+
+    char    *zstd_dict;
 };
 
 // Translation of required fields to cram data series

--- a/hts.c
+++ b/hts.c
@@ -1060,6 +1060,10 @@ int hts_opt_add(hts_opt **opts, const char *c_arg) {
              strcmp(o->arg, "USE_BZIP2") == 0)
         o->opt = CRAM_OPT_USE_BZIP2, o->val.i = atoi(val);
 
+    else if (strcmp(o->arg, "use_zstd") == 0 ||
+             strcmp(o->arg, "USE_ZSTD") == 0)
+        o->opt = CRAM_OPT_USE_ZSTD, o->val.i = atoi(val);
+
     else if (strcmp(o->arg, "use_rans") == 0 ||
              strcmp(o->arg, "USE_RANS") == 0)
         o->opt = CRAM_OPT_USE_RANS, o->val.i = atoi(val);

--- a/hts.c
+++ b/hts.c
@@ -379,7 +379,6 @@ decompress_peek_xz(hFILE *fp, unsigned char *dest, size_t destsize)
 }
 #endif
 
-#ifdef HAVE_LIBZSTD
 static int
 read_zstd_header(hFILE *fp, unsigned long long *decompressed_size, unsigned int *dictionary_id)
 {
@@ -438,8 +437,6 @@ read_zstd_header(hFILE *fp, unsigned long long *decompressed_size, unsigned int 
 
     return 0;
 }
-#endif
-
 
 // Parse "x.y" text, taking care because the string is not NUL-terminated
 // and filling in major/minor only when the digits are followed by a delimiter,

--- a/htslib/cram.h
+++ b/htslib/cram.h
@@ -98,6 +98,8 @@ enum cram_block_method {
     CRAM_COMP_ARITH    = 6, // aka Range coding
     CRAM_COMP_FQZ      = 7, // FQZComp
     CRAM_COMP_TOK3     = 8, // Name tokeniser
+
+    CRAM_COMP_ZSTD     = 9, // Zstandard
 };
 #endif
 

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -307,6 +307,7 @@ enum hts_fmt_option {
     CRAM_OPT_MULTI_SEQ_PER_SLICE,
     CRAM_OPT_NO_REF,
     CRAM_OPT_USE_BZIP2,
+    CRAM_OPT_USE_ZSTD,
     CRAM_OPT_SHARED_REF,
     CRAM_OPT_NTHREADS,   // deprecated, use HTS_OPT_NTHREADS
     CRAM_OPT_THREAD_POOL,// make general

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -308,6 +308,7 @@ enum hts_fmt_option {
     CRAM_OPT_NO_REF,
     CRAM_OPT_USE_BZIP2,
     CRAM_OPT_USE_ZSTD,
+    CRAM_OPT_ZSTD_DICTIONARY,
     CRAM_OPT_SHARED_REF,
     CRAM_OPT_NTHREADS,   // deprecated, use HTS_OPT_NTHREADS
     CRAM_OPT_THREAD_POOL,// make general


### PR DESCRIPTION
This pull request adds Zstd support to the supported CRAM block compression methods.

I thought (wrongly) that this would have a significant impact on the compression ratio and throughput and generation speed. In reality, the impact is marginal on both and this isn't improved much by 'training' on the [individual block types](https://github.com/matty234/htslib/tree/seperate-zstd-dicts). There was some chat in a few issues that referenced this as a helpful addition though so if anyone from there has any suggestions for further improvements please do feel free to let me know 😄 

A few notes:
1) No worries if this doesn't get merged I appreciate there's a spec and this will introduce backwards incompatible changes
1) If this were to be merged, would it make sense to only include the method in the `methmap` if it is explicitly enabled (but enable decompression regardless)?
1) I haven't adjusted the `meth_cost` value for Zstd which remains at 1.0 - I think this will create a bias to always select Zstd (which probably isn't right) - are the current figures based on a benchmark or just arbitrary?
1) I extended `hts.c` with some more information yanked from the Zstd header - I'm not entirely sure why I did that as I now realise that has nothing to do with the CRAM side of things. There are details regarding the decompressed size and a field that determines whether a checksum can be found at the end of the file though (which might be helpful for other non-CRAM files)

Re: #530 