### PR TITLE
Check interval start to avoid overflowing bin numbers

### DIFF
--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -1534,6 +1534,13 @@ static inline int hts_bin_bot(int bin, int n_lvls)
     return (bin - hts_bin_first(l)) << (n_lvls - l) * 3;
 }
 
+/// Compute the (0-based exclusive) maximum position covered by a binning index
+static inline hts_pos_t hts_bin_maxpos(int min_shift, int n_lvls)
+{
+    hts_pos_t one = 1;
+    return one << (min_shift + n_lvls * 3);
+}
+
 /**************
  * Endianness *
  **************/

--- a/tbx.c
+++ b/tbx.c
@@ -321,7 +321,7 @@ static void adjust_max_ref_len_sam(const char *str, int64_t *max_ref_len)
 // files with very large contigs.
 static int adjust_n_lvls(int min_shift, int n_lvls, int64_t max_len)
 {
-    int64_t s = 1LL << (min_shift + n_lvls * 3);
+    int64_t s = hts_bin_maxpos(min_shift, n_lvls);
     max_len += 256;
     for (; max_len > s; ++n_lvls, s <<= 3) {}
     return n_lvls;

--- a/vcf.c
+++ b/vcf.c
@@ -4288,7 +4288,7 @@ static int idx_calc_n_lvls_ids(const bcf_hdr_t *h, int min_shift,
     }
     if ( !max_len ) max_len = (1LL<<31) - 1;  // In case contig line is broken.
     max_len += 256;
-    s = 1LL << (min_shift + starting_n_lvls * 3);
+    s = hts_bin_maxpos(min_shift, starting_n_lvls);
     for (n_lvls = starting_n_lvls; max_len > s; ++n_lvls, s <<= 3);
 
     if (nids_out) *nids_out = nids;


### PR DESCRIPTION
As noted on https://github.com/samtools/samtools/pull/2032 (which includes test queries exhibiting the problem):

> Additionally with this data file samtools goes into an infinite(?) loop when given [a particular location / query interval]: […]
>
> This can be traced to the `do … while` loop in `hts_itr_query()`, which loops perhaps forever through negative bin numbers. Possibly this code should check for a `beg` value massively beyond the maximum position covered by the index's bins and sidestep most of its processing. 

This PR checks start positions of query intervals against the maximum position representable in the index's geometry, to avoid negative bin numbers and the resulting infinite loops in the `do...while` loop. It's effectively the `beg` equivalent of #1595.

I considered implementing the “massively beyond” bit by e.g. adding 256 as various parts of the code do for somewhat different reasons. However tracing the guarded code in `hts_itr_query()` and `hts_itr_multi_bam()` (and looking at the checks for data getting into the index at all) suggests that the result would be a finished / unchanged iterator for `beg` immediately past `maxpos` anyway — so having the bound exactly at `maxpos` is fine.

Introduces `hts_bin_maxpos()` and `hts_idx_maxpos()`, and uses them wherever the `maxpos` calculation appears. I've left the latter private, at least for now.

This also changes the existing `end` checks to `<=` as `end` is **exclusive** -- note it is used as `end-1` in the code guarded by the checks. In practice this probably won't make much difference to anything.