### PR TITLE
fix fuzz integer overflow in cram encoder.

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1984,11 +1984,15 @@ int cram_compress_block2(cram_fd *fd, cram_slice *s,
         // We also get large fluctuations based on genome coordinate for
         // e.g. SA:Z and SC series, but we consider the typical scale of
         // delta between blocks and use this to look for abnormality.
+
+        // Equivalent to (but minus possible integer overflow)
+        //   (b->uncomp_size + 1000)/4 > metrics->input_avg_sz+1000 ||
+        //    b->uncomp_size + 1000    < (metrics->input_avg_sz+1000)/4)
         if (metrics->input_avg_sz &&
-            (b->uncomp_size + 1000 > 4*(metrics->input_avg_sz+1000) ||
-             b->uncomp_size + 1000 < (metrics->input_avg_sz+1000)/4) &&
-            ABS(b->uncomp_size-metrics->input_avg_sz)
-                > 10*metrics->input_avg_delta) {
+            (b->uncomp_size/4 - 750 > metrics->input_avg_sz ||
+             b->uncomp_size         < metrics->input_avg_sz/4 - 750) &&
+            ABS(b->uncomp_size-metrics->input_avg_sz)/10
+                > metrics->input_avg_delta) {
             metrics->next_trial = 0;
         }
 


### PR DESCRIPTION
Input files with very long CIGAR strings and consensus generated embedded reference can lead to exceptionally long CRAM blocks which overflow the check for large size fluctuations (to trigger new compression metric assessments).

Reformulated the expression to avoid scaling up values.

Credit to OSS-Fuzz
Fixes oss-fuzz 68225