### PR TITLE
Compiler pedantry

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,7 +73,8 @@ gcc_task:
        USE_CONFIG: no
     - environment:
        USE_CONFIG: yes
-       CFLAGS: -std=c99 -pedantic -Wformat=2
+       CFLAGS: -std=c99 -pedantic -Wformat=2 -fsanitize=address
+       LDFLAGS: -fsanitize=address
        USE_LIBDEFLATE: yes
 
   install_script: |
@@ -108,8 +109,7 @@ ubuntu_task:
        DO_UNTRACKED_FILE_CHECK: yes
     - environment:
        USE_CONFIG: yes
-       CFLAGS: -g -Wall -O3 -fsanitize=address
-       LDFLAGS: -fsanitize=address
+       CFLAGS: -g -Wall -O3
        USE_LIBDEFLATE: yes
 
   # NB: we could consider building a docker image with these

--- a/bgzip.c
+++ b/bgzip.c
@@ -57,7 +57,7 @@ static void error(const char *format, ...)
     exit(EXIT_FAILURE);
 }
 
-static int ask_yn()
+static int ask_yn(void)
 {
     char line[1024];
     if (fgets(line, sizeof line, stdin) == NULL)

--- a/header.c
+++ b/header.c
@@ -2358,7 +2358,7 @@ void sam_hdr_incr_ref(sam_hdr_t *bh) {
  * Returns a sam_hrecs_t struct on success (free with sam_hrecs_free())
  *         NULL on failure
  */
-sam_hrecs_t *sam_hrecs_new() {
+sam_hrecs_t *sam_hrecs_new(void) {
     sam_hrecs_t *hrecs = calloc(1, sizeof(*hrecs));
 
     if (!hrecs)

--- a/hfile.c
+++ b/hfile.c
@@ -976,7 +976,7 @@ void hfile_shutdown(int do_close_plugin)
     pthread_mutex_unlock(&plugins_lock);
 }
 
-static void hfile_exit()
+static void hfile_exit(void)
 {
     hfile_shutdown(0);
     pthread_mutex_destroy(&plugins_lock);
@@ -1082,7 +1082,7 @@ static int init_add_plugin(void *obj, int (*init)(struct hFILE_plugin *),
  * Returns 0 on success,
  *        <0 on failure
  */
-static int load_hfile_plugins()
+static int load_hfile_plugins(void)
 {
     static const struct hFILE_scheme_handler
         data = { hopen_mem, hfile_always_local, "built-in", 80 },

--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -277,7 +277,7 @@ static void free_auth(auth_token *tok) {
     free(tok);
 }
 
-static void libcurl_exit()
+static void libcurl_exit(void)
 {
     if (curl_share_cleanup(curl.share) == CURLSHE_OK)
         curl.share = NULL;

--- a/hfile_s3_write.c
+++ b/hfile_s3_write.c
@@ -822,7 +822,7 @@ static hFILE *vhopen_s3_write(const char *url, const char *mode, va_list args) {
 }
 
 
-static void s3_write_exit() {
+static void s3_write_exit(void) {
     if (curl_share_cleanup(curl.share) == CURLSHE_OK)
         curl.share = NULL;
 

--- a/hts.c
+++ b/hts.c
@@ -81,7 +81,7 @@ KHASH_INIT2(s2i,, kh_cstr_t, int64_t, 1, kh_str_hash_func, kh_str_hash_equal)
 HTSLIB_EXPORT
 int hts_verbose = HTS_LOG_WARNING;
 
-const char *hts_version()
+const char *hts_version(void)
 {
     return HTS_VERSION_TEXT;
 }
@@ -5050,7 +5050,7 @@ int hts_resize_array_(size_t item_size, size_t num, size_t size_sz,
     return 0;
 }
 
-void hts_lib_shutdown()
+void hts_lib_shutdown(void)
 {
     hfile_shutdown(1);
 }
@@ -5064,7 +5064,7 @@ void hts_set_log_level(enum htsLogLevel level)
     hts_verbose = level;
 }
 
-enum htsLogLevel hts_get_log_level()
+enum htsLogLevel hts_get_log_level(void)
 {
     return hts_verbose;
 }

--- a/sam.c
+++ b/sam.c
@@ -104,7 +104,7 @@ const int8_t bam_cigar_table[256] = {
     -1, -1, -1, -1,  -1, -1, -1, -1,  -1, -1, -1, -1,  -1, -1, -1, -1
 };
 
-sam_hdr_t *sam_hdr_init()
+sam_hdr_t *sam_hdr_init(void)
 {
     sam_hdr_t *bh = (sam_hdr_t*)calloc(1, sizeof(sam_hdr_t));
     if (bh == NULL) return NULL;
@@ -421,7 +421,7 @@ const char *sam_parse_region(sam_hdr_t *h, const char *s, int *tid,
  *** BAM alignment I/O ***
  *************************/
 
-bam1_t *bam_init1()
+bam1_t *bam_init1(void)
 {
     return (bam1_t*)calloc(1, sizeof(bam1_t));
 }

--- a/test/plugins-dlhts.c
+++ b/test/plugins-dlhts.c
@@ -177,7 +177,7 @@ int main(int argc, char **argv)
 
 #else
 
-int main()
+int main(void)
 {
     printf("Tests skipped due to " SKIP "\n");
     return EXIT_SUCCESS;

--- a/test/sam.c
+++ b/test/sam.c
@@ -1997,7 +1997,7 @@ static void test_mempolicy(void)
     }
 }
 
-static void test_bam_set1_minimal()
+static void test_bam_set1_minimal(void)
 {
     int r;
     bam1_t *bam = NULL;
@@ -2028,7 +2028,7 @@ cleanup:
     if (bam != NULL) bam_destroy1(bam);
 }
 
-static void test_bam_set1_full()
+static void test_bam_set1_full(void)
 {
     const char *qname = "!??AAA~~~~";
     const uint32_t cigar[] = { 6 << BAM_CIGAR_SHIFT | BAM_CMATCH, 2 << BAM_CIGAR_SHIFT | BAM_CINS, 2 << BAM_CIGAR_SHIFT | BAM_CMATCH };
@@ -2075,7 +2075,7 @@ cleanup:
     if (bam != NULL) bam_destroy1(bam);
 }
 
-static void test_bam_set1_even_and_odd_seq_len()
+static void test_bam_set1_even_and_odd_seq_len(void)
 {
     const char *seq_even = "TGGACTACGA";
     const char *seq_odd  = "TGGACTACGAC";
@@ -2105,7 +2105,7 @@ cleanup:
     if (bam != NULL) bam_destroy1(bam);
 }
 
-static void test_bam_set1_with_seq_but_no_qual()
+static void test_bam_set1_with_seq_but_no_qual(void)
 {
     const char *seq = "TGGACTACGA";
 
@@ -2129,7 +2129,7 @@ cleanup:
     if (bam != NULL) bam_destroy1(bam);
 }
 
-static void test_bam_set1_validate_qname()
+static void test_bam_set1_validate_qname(void)
 {
     int r;
     bam1_t *bam = NULL;
@@ -2146,7 +2146,7 @@ cleanup:
     if (bam != NULL) bam_destroy1(bam);
 }
 
-static void test_bam_set1_validate_seq()
+static void test_bam_set1_validate_seq(void)
 {
     int r;
     bam1_t *bam = NULL;
@@ -2163,7 +2163,7 @@ cleanup:
     if (bam != NULL) bam_destroy1(bam);
 }
 
-static void test_bam_set1_validate_cigar()
+static void test_bam_set1_validate_cigar(void)
 {
     const uint32_t cigar[] = { 20 << BAM_CIGAR_SHIFT | BAM_CMATCH };
     const char *seq = "TGGACTACGA";
@@ -2192,7 +2192,7 @@ cleanup:
     if (bam != NULL) bam_destroy1(bam);
 }
 
-static void test_bam_set1_validate_size_limits()
+static void test_bam_set1_validate_size_limits(void)
 {
     const uint32_t cigar[] = { 20 << BAM_CIGAR_SHIFT | BAM_CMATCH };
     const char *seq = "TGGACTACGA";
@@ -2224,7 +2224,7 @@ cleanup:
     if (bam != NULL) bam_destroy1(bam);
 }
 
-static void test_bam_set1_write_and_read_back()
+static void test_bam_set1_write_and_read_back(void)
 {
     const char *qname = "q1";
     const uint32_t cigar[] = { 6 << BAM_CIGAR_SHIFT | BAM_CMATCH, 2 << BAM_CIGAR_SHIFT | BAM_CINS, 2 << BAM_CIGAR_SHIFT | BAM_CMATCH };

--- a/test/test-bcf_set_variant_type.c
+++ b/test/test-bcf_set_variant_type.c
@@ -39,7 +39,7 @@ void error(const char *format, ...)
     exit(-1);
 }
 
-static void test_bcf_set_variant_type()
+static void test_bcf_set_variant_type(void)
 {
     // Test SNVs
     bcf_variant_t var1;

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -625,7 +625,7 @@ void test_invalid_end_tag(void)
     hts_set_log_level(logging);
 }
 
-void test_open_format() {
+void test_open_format(void) {
     char mode[5];
     int ret;
     strcpy(mode, "r");

--- a/test/test_kstring.c
+++ b/test/test_kstring.c
@@ -290,7 +290,7 @@ static char *mock_fgets(char *str, int num, void *p) {
     return str;
 }
 
-static int test_kgetline() {
+static int test_kgetline(void) {
     kstring_t s = KS_INITIALIZE;
     int mock_state = 0;
 
@@ -346,7 +346,7 @@ static ssize_t mock_fgets2(char *str, size_t num, void *p) {
     return strlen(str);
 }
 
-static int test_kgetline2() {
+static int test_kgetline2(void) {
     kstring_t s = KS_INITIALIZE;
     int mock_state = 0;
 

--- a/textutils.c
+++ b/textutils.c
@@ -220,7 +220,7 @@ static char token_type(hts_json_token *token)
 }
 
 HTSLIB_EXPORT
-hts_json_token * hts_json_alloc_token() {
+hts_json_token * hts_json_alloc_token(void) {
     return calloc(1, sizeof(hts_json_token));
 }
 

--- a/vcf.c
+++ b/vcf.c
@@ -1567,7 +1567,7 @@ int bcf_hdr_write(htsFile *hfp, bcf_hdr_t *h)
  *** BCF site I/O ***
  ********************/
 
-bcf1_t *bcf_init()
+bcf1_t *bcf_init(void)
 {
     bcf1_t *v;
     v = (bcf1_t*)calloc(1, sizeof(bcf1_t));


### PR DESCRIPTION
Newer clang's complain about functions declared in `int func() { /* do stuff */ }` style.  They require an explict `func(void)` to be used.

```
header.c:2361:27: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
 2361 | sam_hrecs_t *sam_hrecs_new() {
      |                           ^
      |                            void
1 error generated.
```

I'm not entirely convinced with pandering to such pointless pedantry, especially as it'll go away again in newer C versions, but here it is anyway.