### PR TITLE
Avoid possible race when selecting nibble2base implementation

### DIFF
--- a/sam_internal.h
+++ b/sam_internal.h
@@ -166,19 +166,15 @@ static inline void nibble2base_ssse3(uint8_t *nib, char *seq, int len) {
     }
     nibble2base_default(nibble_cursor, seq_cursor, seq_end_ptr - seq_cursor);
 }
-static void (*nibble2base)(uint8_t *nib, char *seq, int len);
 
-static void nibble2base_dispatch(uint8_t *nib, char *seq, int len) {
+static void (*nibble2base)(uint8_t *nib, char *seq, int len) = nibble2base_default;
+
+__attribute__((constructor))
+static void nibble2base_resolve(void) {
     if (__builtin_cpu_supports("ssse3")) {
         nibble2base = nibble2base_ssse3;
     }
-    else {
-        nibble2base = nibble2base_default;
-    }
-    nibble2base(nib, seq, len);
 }
-
-static void (*nibble2base)(uint8_t *nib, char *seq, int len) = nibble2base_dispatch;
 
 #else
 static inline void nibble2base(uint8_t *nib, char *seq, int len) {


### PR DESCRIPTION
Selecting which version of nibble2base() to use on first call is fine in a single thread, but may lead to a race in multi-threaded code.  While this is likely harmless (the value stored to the function pointer will always be the same, and the update will probably be a single store), it is best to avoid the problem by making the selection at library initialisation, before any threads have started.

As the optimised nibble2base_ssse3() already uses gcc function attributes, it seems reasonable to use __attribute__((constructor)) on the function that selects the version to use.  If the constructor does not run, it will use the non-optimised version, which is a safe default.