### PR TITLE
Make BAM zero-length intervals work like CRAM

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -3258,7 +3258,7 @@ static inline int reg2intervals(hts_itr_t *iter, const hts_idx_t *idx, int tid, 
     size_t reg_bin_count = 0, hash_bin_count;
     int res;
 
-    if (!iter || !idx || (bidx = idx->bidx[tid]) == NULL || beg >= end)
+    if (!iter || !idx || (bidx = idx->bidx[tid]) == NULL || beg > end)
         return -1;
 
     hash_bin_count = kh_n_buckets(bidx);


### PR DESCRIPTION
For a BED file with:
_chr1 1000 1000_

`samtools view -M -L intervals.bed $infile` worked with CRAM multi-region iterator but not with BAM.  This change makes them work the same.  Fixes samtools/samtools#2060.

NB Even though BED file format ([spec](https://samtools.github.io/hts-specs/BEDv1.pdf)) has a 0-based, half-open coordinate system, having the same beginning and end coordinate is valid.

