### PR TITLE
Fix two occurrences of undefined behaviour in sam.c

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -423,7 +423,11 @@ const char *sam_parse_region(sam_hdr_t *h, const char *s, int *tid,
 
 bam1_t *bam_init1(void)
 {
-    return (bam1_t*)calloc(1, sizeof(bam1_t));
+    bam1_t* ptr = calloc(1, sizeof(bam1_t));
+    if (ptr) {
+        *ptr = (bam1_t){0};
+    }
+    return ptr;
 }
 
 int sam_realloc_bam_data(bam1_t *b, size_t desired)
@@ -4874,6 +4878,7 @@ static inline uint8_t *skip_aux(uint8_t *s, uint8_t *end)
 
 uint8_t *bam_aux_first(const bam1_t *b)
 {
+    if (!b->data) { errno = ENOENT; return NULL; }
     uint8_t *s = bam_get_aux(b);
     uint8_t *end = b->data + b->l_data;
     if (end - s <= 2) { errno = ENOENT; return NULL; }


### PR DESCRIPTION
In bam_init1() we would initialize a new bam1_t using calloc(). Thereby all bytes are automatically set to zero including the pointer members such as data. However, the C standard allows for NULL to have a different bit pattern than all zeros. Hence, we need to zero the fields explicitly.

In bam_aux_first() we first have to check whether b->data is a NULL pointer before doing any arithmetic on it as that is undefined behaviour according to the C standard. (Even NULL+0 is disallowed.)

I presume that there are other occurrences of these issues in htslib. The question is do you care or do you rely on the implementation to define sane behavior where the C standard doesn't?