### PR TITLE
Refactor SIMD code and add ARM Neon nibble2base() implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ shlib-exports-*.txt
 /test/test_kfunc
 /test/test_kstring
 /test/test_mod
+/test/test_nibbles
 /test/test-parse-reg
 /test/test_realn
 /test/test-regidx

--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,8 @@ config.h:
 	    echo '#define HAVE_AVX512 1' >> $@ ; \
 	fi
 	echo '#if (defined(__x86_64__) || defined(_M_X64))' >> $@
+	echo '#define HAVE_ATTRIBUTE_CONSTRUCTOR 1' >> $@
+	echo '#define HAVE_ATTRIBUTE_TARGET 1' >> $@
 	echo '#define HAVE_BUILTIN_CPU_SUPPORT_SSSE3 1' >> $@
 	echo '#endif' >> $@
 

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,7 @@ LIBHTS_OBJS = \
 	region.o \
 	sam.o \
 	sam_mods.o \
+	simd.o \
 	synced_bcf_reader.o \
 	vcf_sweep.o \
 	tbx.o \
@@ -458,6 +459,7 @@ hts_os.o hts_os.pico: hts_os.c config.h $(htslib_hts_defs_h) os/rand.c
 vcf.o vcf.pico: vcf.c config.h $(fuzz_settings_h) $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_hfile_h) $(hts_internal_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_sam_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_hts_endian_h)
 sam.o sam.pico: sam.c config.h $(fuzz_settings_h) $(htslib_hts_defs_h) $(htslib_sam_h) $(htslib_bgzf_h) $(cram_h) $(hts_internal_h) $(sam_internal_h) $(htslib_hfile_h) $(htslib_hts_endian_h) $(htslib_hts_expr_h) $(header_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_kstring_h)
 sam_mods.o sam_mods.pico: sam_mods.c config.h $(htslib_sam_h) $(textutils_internal_h)
+simd.o simd.pico: simd.c config.h $(htslib_sam_h) $(sam_internal_h)
 tbx.o tbx.pico: tbx.c config.h $(htslib_tbx_h) $(htslib_bgzf_h) $(htslib_hts_endian_h) $(hts_internal_h) $(htslib_khash_h)
 faidx.o faidx.pico: faidx.c config.h $(htslib_bgzf_h) $(htslib_faidx_h) $(htslib_hfile_h) $(htslib_khash_h) $(htslib_kstring_h) $(hts_internal_h)
 bcf_sr_sort.o bcf_sr_sort.pico: bcf_sr_sort.c config.h $(bcf_sr_sort_h) $(htslib_khash_str2int_h) $(htslib_kbitset_h)

--- a/Makefile
+++ b/Makefile
@@ -298,8 +298,10 @@ config.h:
 	if [ "x$(HTS_BUILD_AVX512)" != "x" ] ; then \
 	    echo '#define HAVE_AVX512 1' >> $@ ; \
 	fi
-	echo '#if (defined(__x86_64__) || defined(_M_X64))' >> $@
+	echo '#if defined __x86_64__ || defined __arm__ || defined __aarch64__' >> $@
 	echo '#define HAVE_ATTRIBUTE_CONSTRUCTOR 1' >> $@
+	echo '#endif' >> $@
+	echo '#if (defined(__x86_64__) || defined(_M_X64))' >> $@
 	echo '#define HAVE_ATTRIBUTE_TARGET 1' >> $@
 	echo '#define HAVE_BUILTIN_CPU_SUPPORT_SSSE3 1' >> $@
 	echo '#endif' >> $@

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ BUILT_TEST_PROGRAMS = \
 	test/test_kfunc \
 	test/test_kstring \
 	test/test_mod \
+	test/test_nibbles \
 	test/test_realn \
 	test/test-regidx \
 	test/test_str2int \
@@ -603,6 +604,7 @@ check test: all $(HTSCODECS_TEST_TARGETS)
 	test/test_expr
 	test/test_kfunc
 	test/test_kstring
+	test/test_nibbles -v
 	test/test_str2int
 	test/test_time_funcs
 	test/fieldarith test/fieldarith.sam
@@ -670,6 +672,9 @@ test/test_kstring: test/test_kstring.o libhts.a
 
 test/test_mod: test/test_mod.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_mod.o libhts.a $(LIBS) -lpthread
+
+test/test_nibbles: test/test_nibbles.o libhts.a
+	$(CC) $(LDFLAGS) -o $@ test/test_nibbles.o libhts.a $(LIBS) -lpthread
 
 test/test_realn: test/test_realn.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ test/test_realn.o libhts.a $(LIBS) -lpthread
@@ -773,6 +778,7 @@ test/test_expr.o: test/test_expr.c config.h $(htslib_hts_expr_h)
 test/test_kfunc.o: test/test_kfunc.c config.h $(htslib_kfunc_h)
 test/test_kstring.o: test/test_kstring.c config.h $(htslib_kstring_h)
 test/test_mod.o: test/test_mod.c config.h $(htslib_sam_h)
+test/test_nibbles.o: test/test_nibbles.c config.h $(htslib_sam_h) $(sam_internal_h)
 test/test-parse-reg.o: test/test-parse-reg.c config.h $(htslib_hts_h) $(htslib_sam_h)
 test/test_realn.o: test/test_realn.c config.h $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h)
 test/test-regidx.o: test/test-regidx.c config.h $(htslib_kstring_h) $(htslib_regidx_h) $(htslib_hts_defs_h) $(textutils_internal_h)

--- a/configure.ac
+++ b/configure.ac
@@ -340,6 +340,16 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
             [Define if __attribute__((constructor)) is available.])
 ], [AC_MSG_RESULT([no])])
 
+AC_MSG_CHECKING([for clock_gettime with CLOCK_PROCESS_CPUTIME_ID])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <time.h>]], [[
+  struct timespec ts;
+  clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+]])], [
+  AC_MSG_RESULT([yes])
+  AC_DEFINE([HAVE_CLOCK_GETTIME_CPUTIME], 1,
+            [Define if clock_gettime exists and accepts CLOCK_PROCESS_CPUTIME_ID.])
+], [AC_MSG_RESULT([no])])
+
 if test $enable_plugins != no; then
   AC_SEARCH_LIBS([dlsym], [dl], [],
     [MSG_ERROR([dlsym() not found

--- a/configure.ac
+++ b/configure.ac
@@ -173,6 +173,21 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([],[
   AC_MSG_RESULT([no])
 ])
 
+dnl Check for function attribute used in conjunction with __builtin_cpu_supports
+AC_MSG_CHECKING([for __attribute__((target))])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+  __attribute__((target("ssse3")))
+  int zero(void) {
+    return 0;
+  }
+]], [[zero();]])], [
+  AC_MSG_RESULT([yes])
+  AC_DEFINE([HAVE_ATTRIBUTE_TARGET], 1,
+            [Define if __attribute__((target(...))) is available.])
+], [
+  AC_MSG_RESULT([no])
+])
+
 ]) dnl End of AS_IF(hts_have_cpuid)
 
 dnl Avoid chicken-and-egg problem where pkg-config supplies the
@@ -315,6 +330,15 @@ AC_CHECK_FUNCS([gmtime_r fsync drand48 srand48_deterministic])
 
 # Darwin has a dubious fdatasync() symbol, but no declaration in <unistd.h>
 AC_CHECK_DECL([fdatasync(int)], [AC_CHECK_FUNCS(fdatasync)])
+
+AC_MSG_CHECKING([for __attribute__((constructor))])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+  static __attribute__((constructor)) void noop(void) {}
+]], [])], [
+  AC_MSG_RESULT([yes])
+  AC_DEFINE([HAVE_ATTRIBUTE_CONSTRUCTOR], 1,
+            [Define if __attribute__((constructor)) is available.])
+], [AC_MSG_RESULT([no])])
 
 if test $enable_plugins != no; then
   AC_SEARCH_LIBS([dlsym], [dl], [],

--- a/htslib/hts_defs.h
+++ b/htslib/hts_defs.h
@@ -34,10 +34,6 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_COMPILER_HAS(attribute) __has_attribute(attribute)
 #endif
 
-#ifdef __has_builtin
-#define HTS_COMPILER_HAS_BUILTIN(function) __has_builtin(function)
-#endif
-
 #elif defined __GNUC__
 #define HTS_GCC_AT_LEAST(major, minor) \
     (__GNUC__ > (major) || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor)))
@@ -46,10 +42,6 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef HTS_COMPILER_HAS
 #define HTS_COMPILER_HAS(attribute) 0
 #endif
-#ifndef HTS_COMPILER_HAS_BUILTIN
-#define HTS_COMPILER_HAS_BUILTIN(function) 0
-#endif
-
 #ifndef HTS_GCC_AT_LEAST
 #define HTS_GCC_AT_LEAST(major, minor) 0
 #endif
@@ -124,16 +116,6 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_FORMAT(type, idx, first) __attribute__((__format__ (type, idx, first)))
 #else
 #define HTS_FORMAT(type, idx, first)
-#endif
-
-#define HTS_COMPILER_HAS_TARGET_AND_BUILTIN_CPU_SUPPORTS \
- ((HTS_COMPILER_HAS(target) && HTS_COMPILER_HAS_BUILTIN(__builtin_cpu_supports)) \
- || HTS_GCC_AT_LEAST(4, 8))
-
-#if (defined(__x86_64__) || defined(_M_X64))
-#define HTS_BUILD_IS_X86_64 1
-#else
-#define HTS_BUILD_IS_X86_64 0
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)

--- a/sam_internal.h
+++ b/sam_internal.h
@@ -103,16 +103,6 @@ static inline void nibble2base_default(uint8_t *nib, char *seq, int len) {
     && HTS_COMPILER_HAS_TARGET_AND_BUILTIN_CPU_SUPPORTS \
     && HAVE_BUILTIN_CPU_SUPPORT_SSSE3
 #include "simd.c"
-
-static void (*nibble2base)(uint8_t *nib, char *seq, int len) = nibble2base_default;
-
-__attribute__((constructor))
-static void nibble2base_resolve(void) {
-    if (__builtin_cpu_supports("ssse3")) {
-        nibble2base = nibble2base_ssse3;
-    }
-}
-
 #else
 static inline void nibble2base(uint8_t *nib, char *seq, int len) {
     nibble2base_default(nib, seq, len);

--- a/sam_internal.h
+++ b/sam_internal.h
@@ -102,12 +102,18 @@ static inline void nibble2base_default(uint8_t *nib, char *seq, int len) {
 #if HTS_BUILD_IS_X86_64 \
     && HTS_COMPILER_HAS_TARGET_AND_BUILTIN_CPU_SUPPORTS \
     && HAVE_BUILTIN_CPU_SUPPORT_SSSE3
-#include "simd.c"
-#else
-static inline void nibble2base(uint8_t *nib, char *seq, int len) {
-    nibble2base_default(nib, seq, len);
-}
+#define BUILDING_SIMD_NIBBLE2BASE
 #endif
+
+static inline void nibble2base(uint8_t *nib, char *seq, int len) {
+#ifdef BUILDING_SIMD_NIBBLE2BASE
+    extern void (*htslib_nibble2base)(uint8_t *nib, char *seq, int len);
+    htslib_nibble2base(nib, seq, len);
+#else
+    nibble2base_default(nib, seq, len);
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/sam_internal.h
+++ b/sam_internal.h
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <errno.h>
 #include <stdint.h>
-#include "htslib/hts_defs.h"
+
 #include "htslib/sam.h"
 
 #ifdef __cplusplus
@@ -99,9 +99,8 @@ static inline void nibble2base_default(uint8_t *nib, char *seq, int len) {
         seq[i] = seq_nt16_str[bam_seqi(nib, i)];
 }
 
-#if HTS_BUILD_IS_X86_64 \
-    && HTS_COMPILER_HAS_TARGET_AND_BUILTIN_CPU_SUPPORTS \
-    && HAVE_BUILTIN_CPU_SUPPORT_SSSE3
+#if defined HAVE_ATTRIBUTE_CONSTRUCTOR && \
+    defined __x86_64__ && defined HAVE_ATTRIBUTE_TARGET && defined HAVE_BUILTIN_CPU_SUPPORT_SSSE3
 #define BUILDING_SIMD_NIBBLE2BASE
 #endif
 

--- a/sam_internal.h
+++ b/sam_internal.h
@@ -102,70 +102,7 @@ static inline void nibble2base_default(uint8_t *nib, char *seq, int len) {
 #if HTS_BUILD_IS_X86_64 \
     && HTS_COMPILER_HAS_TARGET_AND_BUILTIN_CPU_SUPPORTS \
     && HAVE_BUILTIN_CPU_SUPPORT_SSSE3
-#include "immintrin.h"
-/*
- * Convert a nibble encoded BAM sequence to a string of bases.
- *
- * Using SSSE3 instructions, 16 codepoints that hold 2 bases each can be
- * unpacked into 32 indexes from 0-15. Using the pshufb instruction these can
- * be converted to the IUPAC characters.
- * It falls back on the nibble2base_default function for the remainder.
- */
-
-__attribute__((target("ssse3")))
-static inline void nibble2base_ssse3(uint8_t *nib, char *seq, int len) {
-    seq[0] = 0;
-    const char *seq_end_ptr = seq + len;
-    char *seq_cursor = seq;
-    uint8_t *nibble_cursor = nib;
-    const char *seq_vec_end_ptr = seq_end_ptr - (2 * sizeof(__m128i));
-    __m128i first_upper_shuffle = _mm_setr_epi8(
-        0, -1, 1, -1, 2, -1, 3, -1, 4, -1, 5, -1, 6, -1, 7, -1);
-    __m128i first_lower_shuffle = _mm_setr_epi8(
-        -1, 0, -1, 1, -1, 2, -1, 3, -1, 4, -1, 5, -1, 6, -1, 7);
-    __m128i second_upper_shuffle = _mm_setr_epi8(
-        8, -1, 9, -1, 10, -1, 11, -1, 12, -1, 13, -1, 14, -1, 15, -1);
-    __m128i second_lower_shuffle = _mm_setr_epi8(
-        -1, 8, -1, 9, -1, 10, -1, 11, -1, 12, -1, 13, -1, 14, -1, 15);
-    __m128i nuc_lookup_vec = _mm_lddqu_si128((__m128i *)seq_nt16_str);
-    /* Work on 16 encoded characters at the time resulting in 32 decoded characters
-       Examples are given for 8 encoded characters A until H to keep it readable.
-        Encoded stored as |AB|CD|EF|GH|
-        Shuffle into |AB|00|CD|00|EF|00|GH|00| and
-                     |00|AB|00|CD|00|EF|00|GH|
-        Shift upper to the right resulting into
-                     |0A|B0|0C|D0|0E|F0|0G|H0| and
-                     |00|AB|00|CD|00|EF|00|GH|
-        Merge with or resulting into (X stands for garbage)
-                     |0A|XB|0C|XD|0E|XF|0G|XH|
-        Bitwise and with 0b1111 leads to:
-                     |0A|0B|0C|0D|0E|0F|0G|0H|
-        We can use the resulting 4-bit integers as indexes for the shuffle of
-        the nucleotide lookup. */
-    while (seq_cursor < seq_vec_end_ptr) {
-        __m128i encoded = _mm_lddqu_si128((__m128i *)nibble_cursor);
-
-        __m128i first_upper = _mm_shuffle_epi8(encoded, first_upper_shuffle);
-        __m128i first_lower = _mm_shuffle_epi8(encoded, first_lower_shuffle);
-        __m128i shifted_first_upper = _mm_srli_epi64(first_upper, 4);
-        __m128i first_merged = _mm_or_si128(shifted_first_upper, first_lower);
-        __m128i first_indexes = _mm_and_si128(first_merged, _mm_set1_epi8(15));
-        __m128i first_nucleotides = _mm_shuffle_epi8(nuc_lookup_vec, first_indexes);
-        _mm_storeu_si128((__m128i *)seq_cursor, first_nucleotides);
-
-        __m128i second_upper = _mm_shuffle_epi8(encoded, second_upper_shuffle);
-        __m128i second_lower = _mm_shuffle_epi8(encoded, second_lower_shuffle);
-        __m128i shifted_second_upper = _mm_srli_epi64(second_upper, 4);
-        __m128i second_merged = _mm_or_si128(shifted_second_upper, second_lower);
-        __m128i second_indexes = _mm_and_si128(second_merged, _mm_set1_epi8(15));
-        __m128i second_nucleotides = _mm_shuffle_epi8(nuc_lookup_vec, second_indexes);
-        _mm_storeu_si128((__m128i *)(seq_cursor + 16), second_nucleotides);
-
-        nibble_cursor += sizeof(__m128i);
-        seq_cursor += 2 * sizeof(__m128i);
-    }
-    nibble2base_default(nibble_cursor, seq_cursor, seq_end_ptr - seq_cursor);
-}
+#include "simd.c"
 
 static void (*nibble2base)(uint8_t *nib, char *seq, int len) = nibble2base_default;
 

--- a/sam_internal.h
+++ b/sam_internal.h
@@ -100,7 +100,8 @@ static inline void nibble2base_default(uint8_t *nib, char *seq, int len) {
 }
 
 #if defined HAVE_ATTRIBUTE_CONSTRUCTOR && \
-    defined __x86_64__ && defined HAVE_ATTRIBUTE_TARGET && defined HAVE_BUILTIN_CPU_SUPPORT_SSSE3
+    ((defined __x86_64__ && defined HAVE_ATTRIBUTE_TARGET && defined HAVE_BUILTIN_CPU_SUPPORT_SSSE3) || \
+     (defined __ARM_NEON))
 #define BUILDING_SIMD_NIBBLE2BASE
 #endif
 

--- a/simd.c
+++ b/simd.c
@@ -23,12 +23,90 @@ DEALINGS IN THE SOFTWARE.  */
 #define HTS_BUILDING_LIBRARY // Enables HTSLIB_EXPORT, see htslib/hts_defs.h
 #include <config.h>
 
+// These must be defined before the first system include to ensure that legacy
+// BSD types needed by <sys/sysctl.h> remain defined when _XOPEN_SOURCE is set.
+#if defined __APPLE__
+#define _DARWIN_C_SOURCE
+#elif defined __NetBSD__
+#define _NETBSD_SOURCE
+#endif
+
 #include "htslib/sam.h"
 #include "sam_internal.h"
 
+#if defined __x86_64__
 #include <immintrin.h>
+#elif defined __ARM_NEON
+#include <arm_neon.h>
+#endif
+
+#if defined __arm__ || defined __aarch64__
+
+#if defined __linux__ || defined __FreeBSD__
+#include <sys/auxv.h>
+#elif defined __APPLE__
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#elif defined __NetBSD__
+#include <stddef.h>
+#include <sys/param.h>
+#include <sys/sysctl.h>
+#ifdef __aarch64__
+#include <aarch64/armreg.h>
+#else
+#include <arm/armreg.h>
+#endif
+#elif defined _WIN32
+#include <processthreadsapi.h>
+#endif
+
+static inline int cpu_supports_neon(void) {
+#if defined __linux__ && defined __arm__ && defined HWCAP_NEON
+    return (getauxval(AT_HWCAP) & HWCAP_NEON) != 0;
+#elif defined __linux__ && defined __arm__ && defined HWCAP_ARM_NEON
+    return (getauxval(AT_HWCAP) & HWCAP_ARM_NEON) != 0;
+#elif defined __linux__ && defined __aarch64__ && defined HWCAP_ASIMD
+    return (getauxval(AT_HWCAP) & HWCAP_ASIMD) != 0;
+#elif defined __APPLE__ && defined __aarch64__
+    int32_t ctl;
+    size_t ctlsize = sizeof ctl;
+    if (sysctlbyname("hw.optional.AdvSIMD", &ctl, &ctlsize, NULL, 0) != 0) return 0;
+    if (ctlsize != sizeof ctl) return 0;
+    return ctl;
+#elif defined __FreeBSD__ && defined __arm__ && defined HWCAP_NEON
+    unsigned long cap;
+    if (elf_aux_info(AT_HWCAP, &cap, sizeof cap) != 0) return 0;
+    return (cap & HWCAP_NEON) != 0;
+#elif defined __FreeBSD__ && defined __aarch64__ && defined HWCAP_ASIMD
+    unsigned long cap;
+    if (elf_aux_info(AT_HWCAP, &cap, sizeof cap) != 0) return 0;
+    return (cap & HWCAP_ASIMD) != 0;
+#elif defined __NetBSD__ && defined __arm__ && defined ARM_MVFR0_ASIMD_MASK
+    uint32_t buf[16];
+    size_t buflen = sizeof buf;
+    if (sysctlbyname("machdep.id_mvfr", buf, &buflen, NULL, 0) != 0) return 0;
+    if (buflen < sizeof(uint32_t)) return 0;
+    return (buf[0] & ARM_MVFR0_ASIMD_MASK) == 0x00000002;
+#elif defined __NetBSD__ && defined __aarch64__ && defined ID_AA64PFR0_EL1_ADVSIMD
+    struct aarch64_sysctl_cpu_id buf;
+    size_t buflen = sizeof buf;
+    if (sysctlbyname("machdep.cpu0.cpu_id", &buf, &buflen, NULL, 0) != 0) return 0;
+    if (buflen < offsetof(struct aarch64_sysctl_cpu_id, ac_aa64pfr0) + sizeof(uint64_t)) return 0;
+    return (buf.ac_aa64pfr0 & ID_AA64PFR0_EL1_ADVSIMD & 0x00e00000) == 0;
+#elif defined _WIN32
+    return IsProcessorFeaturePresent(PF_ARM_V8_INSTRUCTIONS_AVAILABLE) != 0;
+#else
+    return 0;
+#endif
+}
+
+#endif
 
 #ifdef BUILDING_SIMD_NIBBLE2BASE
+
+void (*htslib_nibble2base)(uint8_t *nib, char *seq, int len) = nibble2base_default;
+
+#if defined __x86_64__
 
 /*
  * Convert a nibble encoded BAM sequence to a string of bases.
@@ -93,14 +171,67 @@ static void nibble2base_ssse3(uint8_t *nib, char *seq, int len) {
     nibble2base_default(nibble_cursor, seq_cursor, seq_end_ptr - seq_cursor);
 }
 
-void (*htslib_nibble2base)(uint8_t *nib, char *seq, int len) = nibble2base_default;
-
 __attribute__((constructor))
 static void nibble2base_resolve(void) {
     if (__builtin_cpu_supports("ssse3")) {
         htslib_nibble2base = nibble2base_ssse3;
     }
 }
+
+#elif defined __ARM_NEON
+
+static void nibble2base_neon(uint8_t *nib, char *seq0, int len) {
+    uint8x16_t low_nibbles_mask = vdupq_n_u8(0x0f);
+    uint8x16_t nuc_lookup_vec = vld1q_u8((const uint8_t *) seq_nt16_str);
+#ifndef __aarch64__
+    uint8x8x2_t nuc_lookup_vec2 = {{ vget_low_u8(nuc_lookup_vec), vget_high_u8(nuc_lookup_vec) }};
+#endif
+
+    uint8_t *seq = (uint8_t *) seq0;
+    int blocks;
+
+    for (blocks = len / 32; blocks > 0; --blocks) {
+        uint8x16_t encoded = vld1q_u8(nib);
+        nib += 16;
+
+        /* Translate the high and low nibbles to nucleotide letters separately,
+           then interleave them back together via vzipq for writing. */
+
+        uint8x16_t high_nibbles = vshrq_n_u8(encoded, 4);
+        uint8x16_t low_nibbles  = vandq_u8(encoded, low_nibbles_mask);
+
+#ifdef __aarch64__
+        uint8x16_t high_nucleotides = vqtbl1q_u8(nuc_lookup_vec, high_nibbles);
+        uint8x16_t low_nucleotides  = vqtbl1q_u8(nuc_lookup_vec, low_nibbles);
+#else
+        uint8x8_t high_low  = vtbl2_u8(nuc_lookup_vec2, vget_low_u8(high_nibbles));
+        uint8x8_t high_high = vtbl2_u8(nuc_lookup_vec2, vget_high_u8(high_nibbles));
+        uint8x16_t high_nucleotides = vcombine_u8(high_low, high_high);
+
+        uint8x8_t low_low  = vtbl2_u8(nuc_lookup_vec2, vget_low_u8(low_nibbles));
+        uint8x8_t low_high = vtbl2_u8(nuc_lookup_vec2, vget_high_u8(low_nibbles));
+        uint8x16_t low_nucleotides = vcombine_u8(low_low, low_high);
+#endif
+
+#ifdef __aarch64__
+        vst1q_u8_x2(seq, vzipq_u8(high_nucleotides, low_nucleotides));
+#else
+        // Avoid vst1q_u8_x2 as GCC erroneously omits it on 32-bit ARM
+        uint8x16x2_t nucleotides = {{ high_nucleotides, low_nucleotides }};
+        vst2q_u8(seq, nucleotides);
+#endif
+        seq += 32;
+    }
+
+    if (len % 32 != 0)
+        nibble2base_default(nib, (char *) seq, len % 32);
+}
+
+static __attribute__((constructor)) void nibble2base_resolve(void) {
+    if (cpu_supports_neon()) htslib_nibble2base = nibble2base_neon;
+}
+
+#endif
 
 #endif // BUILDING_SIMD_NIBBLE2BASE
 

--- a/simd.c
+++ b/simd.c
@@ -1,3 +1,25 @@
+/*  simd.c -- SIMD optimised versions of various internal functions.
+
+    Copyright (C) 2024 Genome Research Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
 #include "immintrin.h"
 /*
  * Convert a nibble encoded BAM sequence to a string of bases.
@@ -61,4 +83,13 @@ static inline void nibble2base_ssse3(uint8_t *nib, char *seq, int len) {
         seq_cursor += 2 * sizeof(__m128i);
     }
     nibble2base_default(nibble_cursor, seq_cursor, seq_end_ptr - seq_cursor);
+}
+
+static void (*nibble2base)(uint8_t *nib, char *seq, int len) = nibble2base_default;
+
+__attribute__((constructor))
+static void nibble2base_resolve(void) {
+    if (__builtin_cpu_supports("ssse3")) {
+        nibble2base = nibble2base_ssse3;
+    }
 }

--- a/simd.c
+++ b/simd.c
@@ -1,0 +1,64 @@
+#include "immintrin.h"
+/*
+ * Convert a nibble encoded BAM sequence to a string of bases.
+ *
+ * Using SSSE3 instructions, 16 codepoints that hold 2 bases each can be
+ * unpacked into 32 indexes from 0-15. Using the pshufb instruction these can
+ * be converted to the IUPAC characters.
+ * It falls back on the nibble2base_default function for the remainder.
+ */
+
+__attribute__((target("ssse3")))
+static inline void nibble2base_ssse3(uint8_t *nib, char *seq, int len) {
+    seq[0] = 0;
+    const char *seq_end_ptr = seq + len;
+    char *seq_cursor = seq;
+    uint8_t *nibble_cursor = nib;
+    const char *seq_vec_end_ptr = seq_end_ptr - (2 * sizeof(__m128i));
+    __m128i first_upper_shuffle = _mm_setr_epi8(
+        0, -1, 1, -1, 2, -1, 3, -1, 4, -1, 5, -1, 6, -1, 7, -1);
+    __m128i first_lower_shuffle = _mm_setr_epi8(
+        -1, 0, -1, 1, -1, 2, -1, 3, -1, 4, -1, 5, -1, 6, -1, 7);
+    __m128i second_upper_shuffle = _mm_setr_epi8(
+        8, -1, 9, -1, 10, -1, 11, -1, 12, -1, 13, -1, 14, -1, 15, -1);
+    __m128i second_lower_shuffle = _mm_setr_epi8(
+        -1, 8, -1, 9, -1, 10, -1, 11, -1, 12, -1, 13, -1, 14, -1, 15);
+    __m128i nuc_lookup_vec = _mm_lddqu_si128((__m128i *)seq_nt16_str);
+    /* Work on 16 encoded characters at the time resulting in 32 decoded characters
+       Examples are given for 8 encoded characters A until H to keep it readable.
+        Encoded stored as |AB|CD|EF|GH|
+        Shuffle into |AB|00|CD|00|EF|00|GH|00| and
+                     |00|AB|00|CD|00|EF|00|GH|
+        Shift upper to the right resulting into
+                     |0A|B0|0C|D0|0E|F0|0G|H0| and
+                     |00|AB|00|CD|00|EF|00|GH|
+        Merge with or resulting into (X stands for garbage)
+                     |0A|XB|0C|XD|0E|XF|0G|XH|
+        Bitwise and with 0b1111 leads to:
+                     |0A|0B|0C|0D|0E|0F|0G|0H|
+        We can use the resulting 4-bit integers as indexes for the shuffle of
+        the nucleotide lookup. */
+    while (seq_cursor < seq_vec_end_ptr) {
+        __m128i encoded = _mm_lddqu_si128((__m128i *)nibble_cursor);
+
+        __m128i first_upper = _mm_shuffle_epi8(encoded, first_upper_shuffle);
+        __m128i first_lower = _mm_shuffle_epi8(encoded, first_lower_shuffle);
+        __m128i shifted_first_upper = _mm_srli_epi64(first_upper, 4);
+        __m128i first_merged = _mm_or_si128(shifted_first_upper, first_lower);
+        __m128i first_indexes = _mm_and_si128(first_merged, _mm_set1_epi8(15));
+        __m128i first_nucleotides = _mm_shuffle_epi8(nuc_lookup_vec, first_indexes);
+        _mm_storeu_si128((__m128i *)seq_cursor, first_nucleotides);
+
+        __m128i second_upper = _mm_shuffle_epi8(encoded, second_upper_shuffle);
+        __m128i second_lower = _mm_shuffle_epi8(encoded, second_lower_shuffle);
+        __m128i shifted_second_upper = _mm_srli_epi64(second_upper, 4);
+        __m128i second_merged = _mm_or_si128(shifted_second_upper, second_lower);
+        __m128i second_indexes = _mm_and_si128(second_merged, _mm_set1_epi8(15));
+        __m128i second_nucleotides = _mm_shuffle_epi8(nuc_lookup_vec, second_indexes);
+        _mm_storeu_si128((__m128i *)(seq_cursor + 16), second_nucleotides);
+
+        nibble_cursor += sizeof(__m128i);
+        seq_cursor += 2 * sizeof(__m128i);
+    }
+    nibble2base_default(nibble_cursor, seq_cursor, seq_end_ptr - seq_cursor);
+}

--- a/simd.c
+++ b/simd.c
@@ -26,7 +26,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/sam.h"
 #include "sam_internal.h"
 
-#include "immintrin.h"
+#include <immintrin.h>
 
 #ifdef BUILDING_SIMD_NIBBLE2BASE
 
@@ -41,11 +41,10 @@ DEALINGS IN THE SOFTWARE.  */
 
 __attribute__((target("ssse3")))
 static void nibble2base_ssse3(uint8_t *nib, char *seq, int len) {
-    seq[0] = 0;
     const char *seq_end_ptr = seq + len;
     char *seq_cursor = seq;
     uint8_t *nibble_cursor = nib;
-    const char *seq_vec_end_ptr = seq_end_ptr - (2 * sizeof(__m128i));
+    const char *seq_vec_end_ptr = seq_end_ptr - (2 * sizeof(__m128i) - 1);
     __m128i first_upper_shuffle = _mm_setr_epi8(
         0, -1, 1, -1, 2, -1, 3, -1, 4, -1, 5, -1, 6, -1, 7, -1);
     __m128i first_lower_shuffle = _mm_setr_epi8(

--- a/test/test_nibbles.c
+++ b/test/test_nibbles.c
@@ -1,0 +1,164 @@
+/*  test/test_nibbles.c -- Test SIMD optimised function implementations.
+
+    Copyright (C) 2024 Centre for Population Genomics.
+
+    Author: John Marshall <jmarshall@hey.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifdef HAVE_CLOCK_GETTIME_CPUTIME
+#include <time.h>
+#else
+#include <sys/time.h>
+#endif
+
+#include "../htslib/sam.h"
+#include "../sam_internal.h"
+
+long long gettime(void) {
+#ifdef HAVE_CLOCK_GETTIME_CPUTIME
+    struct timespec ts;
+    clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts);
+    return ts.tv_sec * 1000000000LL + ts.tv_nsec;
+#else
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return tv.tv_sec * 1000000LL + tv.tv_usec;
+#endif
+}
+
+char *fmttime(long long elapsed) {
+    static char buf[64];
+
+#ifdef HAVE_CLOCK_GETTIME_CPUTIME
+    long long sec = elapsed / 1000000000;
+    long long nsec = elapsed % 1000000000;
+    sprintf(buf, "%lld.%09lld processor seconds", sec, nsec);
+#else
+    long long sec = elapsed / 1000000;
+    long long usec = elapsed % 1000000;
+    sprintf(buf, "%lld.%06lld wall-time seconds", sec, usec);
+#endif
+
+    return buf;
+}
+
+void nibble2base_single(uint8_t *nib, char *seq, int len) {
+    int i;
+    for (i = 0; i < len; i++)
+        seq[i] = seq_nt16_str[bam_seqi(nib, i)];
+}
+
+unsigned char nibble[5000];
+char buf[10000];
+
+int validate_nibble2base(void) {
+    char defbuf[500];
+    int i, start, len;
+    unsigned long long total = 0, failed = 0;
+
+    for (i = 0; i < sizeof nibble; i++)
+        nibble[i] = i % 256;
+
+    for (start = 0; start < 80; start++)
+        for (len = 0; len < 400; len++) {
+            memset(defbuf, '\0', sizeof defbuf);
+            nibble2base_single(&nibble[start], defbuf, len);
+
+            memset(buf, '\0', sizeof defbuf);
+            nibble2base(&nibble[start], buf, len);
+
+            total++;
+            if (strcmp(defbuf, buf) != 0) {
+                printf("%s expected\n%s FAIL\n\n", defbuf, buf);
+                failed++;
+            }
+        }
+
+    if (failed > 0) {
+        fprintf(stderr, "Failures: %llu (out of %llu tests)\n", failed, total);
+        return 1;
+    }
+
+    return 0;
+}
+
+int time_nibble2base(int length, unsigned long count) {
+    unsigned long i, total = 0;
+
+    for (i = 0; i < length; i++)
+        nibble[i] = i % 256;
+
+    printf("Timing %lu nibble2base iterations with read length %d...\n", count, length);
+    long long start = gettime();
+
+    for (i = 0; i < count; i++) {
+        nibble2base(nibble, buf, length);
+        total += buf[i % length];
+    }
+
+    long long stop = gettime();
+    printf("%s (summing to %lu)\n", fmttime(stop - start), total);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    int readlen = 5000;
+    unsigned long count = 1000000;
+    int status = 0;
+    int c;
+
+    if (argc == 1)
+        printf(
+"Usage: test_nibbles [-c NUM] [-r NUM] [-n|-v]...\n"
+"Options:\n"
+"  -c NUM  Specify number of iterations [%lu]\n"
+"  -n      Run nibble2base speed tests\n"
+"  -r NUM  Specify read length [%d]\n"
+"  -v      Run all validation tests\n"
+"", count, readlen);
+
+    while ((c = getopt(argc, argv, "c:nr:v")) >= 0)
+        switch (c) {
+        case 'c':
+            count = strtoul(optarg, NULL, 0);
+            break;
+
+        case 'n':
+            status += time_nibble2base(readlen, count);
+            break;
+
+        case 'r':
+            readlen = atoi(optarg);
+            break;
+
+        case 'v':
+            status += validate_nibble2base();
+            break;
+        }
+
+    return status;
+}


### PR DESCRIPTION
This PR moves `nibble2base_ssse3()` from an internal header file to a new source file, _simd.c_, and adds an ARM implementation `nibble2base_neon()` alongside. Because these functions are always called via a pointer, they are never inlined so there is nothing gained (other than build complexity!) by having them in a header.

I initially translated the SSSE3 algorithm directly to Neon, during which I noticed some tweaks that could be usefully applied to the SSSE3 version — see the “Minor improvements” commit below. I then realised that the Neon implementation could be simplified by using Neon's rather excellent interleaved load/store instructions, which I then replaced by an in-register zip as it is (sadly) faster (on aarch64 at least). (It may be possible to apply a similar approach for Intel via the unpack instruction.)

Indicative timings for various versions of the Neon implementation, on ARM and, for interest, an iteration count on x86_64 that makes the nibble2base_default time comparable — numbers are comparable vertically, but not directly horizontally:

```
Apple M2  i5 SSSE3
 seconds   seconds

 262.389   916.215   nibble2base_single (i.e., scalar code doing one nucleotide at a time)
 186.283   186.778   nibble2base_default (i.e., scalar code doing two nucleotides at a time)
  36.053    46.700   Ruben's nibble2base_ssse3 algorithm
  24.783             interleaved using vst2q_u8
  19.287             interleaved using vzipq_u8
```

I moved the existing code to the new source file in a pair of commits marked as authored by @rhpvorderman and @daviesrob, so that `git blame` preserves the authorship of their untouched lines. Hence ideally this PR would be merged via a merge commit rather than squashed.