### PR TITLE
Windows builds via GitHub Actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,3 +24,14 @@ test/index_dos.sam -text
 # Remove the text attribute from various faidx test files
 test/faidx/faidx*.fa* -text
 test/faidx/fastqs*.fq* -text
+test/fastq/*.fa -text
+test/fastq/*.fq -text
+*.tst -text
+*.out -text
+*.crai    -text
+*.bai     -text
+*.csi     -text
+*.gzi     -text
+*.bcf     -text
+*.sam     -text
+*.sam.gz  -text

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,40 @@
+name: Windows/MinGW-W64 CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Set up MSYS2 MinGW-W64
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: mingw64
+        update: false
+        install: >-
+          git
+          zlib-devel
+          libbz2-devel
+          liblzma-devel
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-autotools
+          mingw-w64-x86_64-tools-git
+          mingw-w64-x86_64-libdeflate
+    - name: Compile htslib
+      shell: msys2 {0}
+      run: |
+        export PATH=/mingw64/bin:$PATH
+        export MSYSTEM=MINGW64
+        autoreconf -i
+        ./configure
+        make -j6
+    - name: Check Htslib
+      shell: msys2 {0}
+      run: |
+        export PATH=/mingw64/bin:$PATH
+        export MSYSTEM=MINGW64
+        make test-shlib-exports && make check
+

--- a/test/header_syms.pl
+++ b/test/header_syms.pl
@@ -60,6 +60,7 @@ sub extract_symbols {
 
     open(my $f, '<', $file) || die "Couldn't open $file : $!\n";
     my $text = <$f>;
+    $text =~ tr/\r//d;
     close($f) || die "Error reading $file : $!\n";
 
     # Get rid of comments


### PR DESCRIPTION
The AppVeyor builds have become slower to launch and they're also a bit slow on execution.  GitHub Actions runs in about half the time.

Note this needs https://github.com/samtools/htscodecs/pull/123 merging first, but for purposes of testing I just incorporated it in this PR via an extra commit to change the submodule commit.  If the htscodecs PR gets modified in any way, changing the hash, then I'll update this appropriately.

Also, if you wish to see these tests in-situ here, we could copy this PR branch to samtools/htslib from jkbonfield/htslib as otherwise it won't enable the workflow.  (As I did for htscodecs)