### PR TITLE
Miscellaneous minor build infrastructure and code fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,9 @@ shlib-exports-*.txt
 /bgzip
 /htsfile
 /tabix
+/test/*/FAIL*
 /test/bgzf_boundaries/*.tmp.*
 /test/faidx/*.tmp*
-/test/faidx/FAIL*
 /test/fieldarith
 /test/hfile
 /test/hts_endian
@@ -57,7 +57,6 @@ shlib-exports-*.txt
 /test/plugins-dlhts
 /test/sam
 /test/tabix/*.tmp.*
-/test/tabix/FAIL*
 /test/test-bcf-sr
 /test/test-bcf-translate
 /test/test-bcf_set_variant_type

--- a/Makefile
+++ b/Makefile
@@ -529,7 +529,7 @@ tabix: tabix.o libhts.a
 annot-tsv.o: annot-tsv.c config.h $(htslib_hts_h) $(htslib_hts_defs_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_regidx_h)
 bgzip.o: bgzip.c config.h $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_hfile_h)
 htsfile.o: htsfile.c config.h $(htslib_hfile_h) $(htslib_hts_h) $(htslib_sam_h) $(htslib_vcf_h)
-tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_regidx_h) $(htslib_hts_defs_h) $(htslib_hts_log_h)
+tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_regidx_h) $(htslib_hts_defs_h) $(htslib_hts_log_h) $(htslib_thread_pool_h)
 
 # Runes to check that the htscodecs submodule is present
 ifdef HTSCODECS_SOURCES

--- a/Makefile
+++ b/Makefile
@@ -924,9 +924,9 @@ htslib-uninstalled.pc: htslib.pc.tmp
 
 
 testclean:
-	-rm -f test/*.tmp test/*.tmp.* test/faidx/*.tmp* test/faidx/FAIL* \
-               test/longrefs/*.tmp.* test/tabix/*.tmp.* test/tabix/FAIL* \
-               test/bgzf_boundaries/*.tmp.* \
+	-rm -f test/*.tmp test/*.tmp.* test/faidx/*.tmp* \
+               test/longrefs/*.tmp.* test/tabix/*.tmp.* \
+               test/bgzf_boundaries/*.tmp.* test/*/FAIL* \
                header-exports.txt shlib-exports-$(SHLIB_FLAVOUR).txt
 	-rm -rf htscodecs/tests/test.out
 

--- a/Makefile
+++ b/Makefile
@@ -526,7 +526,7 @@ htsfile: htsfile.o libhts.a
 tabix: tabix.o libhts.a
 	$(CC) $(LDFLAGS) -o $@ tabix.o libhts.a $(LIBS) -lpthread
 
-annot-tsv.o: annot-tsv.c config.h $(htslib_hts_h) $(htslib_hts_defs_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_regidx_h)
+annot-tsv.o: annot-tsv.c config.h $(htslib_hts_h) $(htslib_hts_defs_h) $(htslib_khash_str2int_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_regidx_h) $(textutils_internal_h)
 bgzip.o: bgzip.c config.h $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_hfile_h)
 htsfile.o: htsfile.c config.h $(htslib_hfile_h) $(htslib_hts_h) $(htslib_sam_h) $(htslib_vcf_h)
 tabix.o: tabix.c config.h $(htslib_tbx_h) $(htslib_sam_h) $(htslib_vcf_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_hts_h) $(htslib_regidx_h) $(htslib_hts_defs_h) $(htslib_hts_log_h) $(htslib_thread_pool_h)

--- a/annot-tsv.c
+++ b/annot-tsv.c
@@ -44,6 +44,7 @@
 #include "htslib/kseq.h"
 #include "htslib/bgzf.h"
 #include "htslib/regidx.h"
+#include "textutils_internal.h"
 
 #define ANN_NBP     1
 #define ANN_FRAC    2
@@ -409,15 +410,15 @@ void parse_header(dat_t *dat, char *fname, int nth_row, int autodetect)
     for (i=0; i<cols->n; i++)
     {
         char *ss = cols->off[i];
-        while ( *ss && (*ss=='#' || isspace(*ss)) ) ss++;
+        while ( *ss && (*ss=='#' || isspace_c(*ss)) ) ss++;
         if ( !*ss ) error("Could not parse the header field \"%s\": %s\n", cols->off[i],dat->line.s);
         if ( *ss=='[' )
         {
             char *se = ss+1;
-            while ( *se && isdigit(*se) ) se++;
+            while ( *se && isdigit_c(*se) ) se++;
             if ( *se==']' ) ss = se + 1;
         }
-        while ( *ss && (*ss=='#' || isspace(*ss)) ) ss++;
+        while ( *ss && (*ss=='#' || isspace_c(*ss)) ) ss++;
         if ( !*ss ) error("Could not parse the header field \"%s\": %s\n", cols->off[i],dat->line.s);
         cols->off[i] = ss;
         khash_str2int_set(dat->hdr.name2idx, cols->off[i], i);

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -49,7 +49,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #include "../htslib/hfile.h"
-#include "../hfile_internal.h"
 #include "cram.h"
 
 /*

--- a/hts_internal.h
+++ b/hts_internal.h
@@ -123,18 +123,6 @@ const char *hts_plugin_path(void);
  */
 int bgzf_idx_push(BGZF *fp, hts_idx_t *hidx, int tid, hts_pos_t beg, hts_pos_t end, uint64_t offset, int is_mapped);
 
-/*
- * bgzf analogue to hts_idx_amend_last.
- *
- * This is needed when multi-threading and writing indices on the fly.
- * At the point of writing a record we know the virtual offset for start
- * and end, but that end virtual offset may be the end of the current
- * block.  In standard indexing our end virtual offset becomes the start
- * of the next block.  Thus to ensure bit for bit compatibility we
- * detect this boundary case and fix it up here.
- */
-void bgzf_idx_amend_last(BGZF *fp, hts_idx_t *hidx, uint64_t offset);
-
 static inline int find_file_extension(const char *fn, char ext_out[static HTS_MAX_EXT_LEN])
 {
     const char *delim = fn ? strstr(fn, HTS_IDX_DELIM) : NULL, *ext;

--- a/test/base_mods/MM-explicit.sam
+++ b/test/base_mods/MM-explicit.sam
@@ -19,7 +19,7 @@
 @CO	ATCATCATTCCTACCGCTATAGCCT  r3; mixture
 @CO	  -  -   .   -. -     --
 @CO	         M    M
-@CO       -  -   ??  ?? ?     --
+@CO	  -  -   ??  ?? ?     --
 @CO	         hH  hh h     --
 @CO	
 r1	0	*	0	0	*	*	0	0	ATCATCATTCCTACCGCTATAGCCT	*	Mm:Z:C+mh,2,0,1;	Ml:B:C,200,10,50,170,160,20


### PR DESCRIPTION
Accumulated extremely squashable minor build infrastructure and code fixes:

* Ignore and clean `test/*/FAIL*` for six subdirectories — these files can appear in base_mods, fastq, mpileup, and sam_filter as well as faidx and tabix.

* Fix _MM-explicit.sam_ comment header to use `@CO\t` as per other comment headers.

*    Remove extraneous inclusion and add missing dependency.

*    Remove last traces of previously deleted `bgzf_idx_amend_last()` — as noted in #1722, this function was removed in PR #1672.

*    Use `isspace_c()` et al in _annot-tsv.c_.
