### PR TITLE
Adjust GitHub actions windows build package list

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -15,18 +15,18 @@ jobs:
         msystem: mingw64
         update: false
         install: >-
-          git
-          zlib-devel
-          libbz2-devel
-          liblzma-devel
-          mingw-w64-x86_64-toolchain
           mingw-w64-x86_64-autotools
-          mingw-w64-x86_64-tools-git
+          mingw-w64-x86_64-bzip2
+          mingw-w64-x86_64-curl
           mingw-w64-x86_64-libdeflate
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-tools-git
+          mingw-w64-x86_64-xz
+          mingw-w64-x86_64-zlib
     - name: Compile htslib
       shell: msys2 {0}
       run: |
-        export PATH=/mingw64/bin:$PATH
+        export PATH="/mingw64/bin:$PATH:/c/Program Files/Git/bin"
         export MSYSTEM=MINGW64
         autoreconf -i
         ./configure
@@ -34,7 +34,7 @@ jobs:
     - name: Check Htslib
       shell: msys2 {0}
       run: |
-        export PATH=/mingw64/bin:$PATH
+        export PATH="/mingw64/bin:$PATH:/c/Program Files/Git/bin"
         export MSYSTEM=MINGW64
         make test-shlib-exports && make check
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://api.cirrus-ci.com/github/samtools/htslib.svg?branch=develop)](https://api.cirrus-ci.com/github/samtools/htslib)
-[![Build status](https://ci.appveyor.com/api/projects/status/v46hkwyfjp3l8nd3/branch/develop?svg=true)](https://ci.appveyor.com/project/samtools/htslib/branch/develop)
+[![Build status](https://github.com/samtools/htslib/actions/workflows/windows-build.yml/badge.svg)](https://github.com/samtools/htslib/actions/workflows/windows-build.yml?query=branch%3Adevelop)
 [![Github All Releases](https://img.shields.io/github/downloads/samtools/htslib/total.svg)](https://github.com/samtools/htslib)
 
 HTSlib is an implementation of a unified C library for accessing common file


### PR DESCRIPTION
Use the mingw-w64-x86_64 flavour of all packages.  Add curl, so hfile_libcurl etc. build.  Remove the mingw git package as git for windows is already present.  Add the location of git for windows to `$PATH` (note this must be at the end, else the wrong shell gets picked up when running tests leading to backslash conversion issues).

Switch badge on README.md from AppVeyor to GitHub.