### PR TITLE
Add undefined behaviour sanitizer into the CI checks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,6 +40,7 @@ compile_template: &COMPILE
     else
       MAKE_OPTS=-e
     fi
+    make cc-version
     if test "x$DO_MAINTAINER_CHECKS" = "xyes"; then
       make maintainer-check
     fi

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -113,7 +113,7 @@ ubuntu_task:
     - environment:
        # Cirrus-CI's clang isn't installed with ubsan, so we do that in gcc
        USE_CONFIG: yes
-       CFLAGS: -std=c99 -pedantic -Wformat -g -Wall -O3
+       CFLAGS: -std=c99 -pedantic -Wformat -Wformat=2 -g -Wall -O3
        USE_LIBDEFLATE: yes
 
   # NB: we could consider building a docker image with these

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -141,7 +141,7 @@ rocky_task:
     LC_ALL: C
     CIRRUS_CLONE_DEPTH: 1
     USE_CONFIG: yes
-    CFLAGS: -std=gnu90
+    CFLAGS: -std=gnu90 -Wformat -Wformat=2
 
   # NB: we could consider building a docker image with these
   # preinstalled and specifying that instead, to speed up testing.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,9 +73,11 @@ gcc_task:
        USE_CONFIG: no
     - environment:
        USE_CONFIG: yes
-       CFLAGS: -std=c99 -pedantic -Wformat=2 -fsanitize=address
-       LDFLAGS: -fsanitize=address
+       # ubsan is incompatible with some -Wformat opts so we do that on clang.
+       CFLAGS: -fsanitize=address,undefined -DHTS_ALLOW_UNALIGNED=0 -Wno-format-truncation -Wno-format-overflow
+       LDFLAGS: -fsanitize=address,undefined
        USE_LIBDEFLATE: yes
+       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
   install_script: |
     apt-get update
@@ -108,8 +110,9 @@ ubuntu_task:
        USE_CONFIG: yes
        DO_UNTRACKED_FILE_CHECK: yes
     - environment:
+       # Cirrus-CI's clang isn't installed with ubsan, so we do that in gcc
        USE_CONFIG: yes
-       CFLAGS: -g -Wall -O3
+       CFLAGS: -std=c99 -pedantic -Wformat -g -Wall -O3
        USE_LIBDEFLATE: yes
 
   # NB: we could consider building a docker image with these

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -30,6 +30,7 @@ jobs:
         export MSYSTEM=MINGW64
         autoreconf -i
         ./configure
+        make cc-version
         make -j6
     - name: Check Htslib
       shell: msys2 {0}

--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,14 @@ BUILT_THRASH_PROGRAMS = \
 	test/thrash_threads6 \
 	test/thrash_threads7
 
-all: lib-static lib-shared $(BUILT_PROGRAMS) plugins $(BUILT_TEST_PROGRAMS) \
-     htslib_static.mk htslib-uninstalled.pc
+all: lib-static lib-shared $(BUILT_PROGRAMS) plugins \
+	$(BUILT_TEST_PROGRAMS) htslib_static.mk htslib-uninstalled.pc
+
+# Report compiler and version
+cc-version:
+	-@$(CC) --version  2>/dev/null || true
+	-@$(CC) --qversion 2>/dev/null || true
+	-@$(CC) -V         2>/dev/null || true
 
 ALL_CPPFLAGS = -I. $(CPPFLAGS)
 
@@ -996,3 +1002,4 @@ force:
 .PHONY: clean-dylib install-dylib
 .PHONY: test_htscodecs_rans4x8 test_htscodecs_rans4x16 test_htscodecs_arith
 .PHONY: test_htscodecs_tok3 test_htscodecs_fqzcomp test_htscodecs_varint
+.PHONY: cc-version

--- a/bgzip.c
+++ b/bgzip.c
@@ -48,7 +48,7 @@
 
 static const int WINDOW_SIZE = BGZF_BLOCK_SIZE;
 
-static void error(const char *format, ...)
+static void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) error(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);
@@ -689,7 +689,7 @@ int main(int argc, char **argv)
                     if ( bgzf_index_load(fp, argv[optind], ".gzi") < 0 )
                         error("Could not load index: %s.gzi\n", argv[optind]);
                 }
-                if ( bgzf_useek(fp, start, SEEK_SET) < 0 ) error("Could not seek to %d-th (uncompressd) byte\n", start);
+                if ( bgzf_useek(fp, start, SEEK_SET) < 0 ) error("Could not seek to %ld-th (uncompressd) byte\n", start);
             }
 
             if (threads > 1)

--- a/htsfile.c
+++ b/htsfile.c
@@ -46,7 +46,7 @@ int show_headers = 1;
 int verbose = 0;
 int status = EXIT_SUCCESS;  /* Exit status from main */
 
-void error(const char *format, ...)
+void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) error(const char *format, ...)
 {
     int err = errno;
     va_list args;

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -596,7 +596,8 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     int bcf_hdr_append(bcf_hdr_t *h, const char *line);
 
     HTSLIB_EXPORT
-    int bcf_hdr_printf(bcf_hdr_t *h, const char *format, ...);
+    int bcf_hdr_printf(bcf_hdr_t *h, const char *format, ...)
+    HTS_FORMAT(HTS_PRINTF_FMT, 2, 3);
 
     /** VCF version, e.g. VCFv4.2 */
     HTSLIB_EXPORT

--- a/test/hfile.c
+++ b/test/hfile.c
@@ -35,7 +35,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include "../htslib/hts_defs.h"
 #include "../htslib/kstring.h"
 
-void HTS_NORETURN fail(const char *format, ...)
+void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) HTS_NORETURN
+fail(const char *format, ...)
 {
     int err = errno;
     va_list args;

--- a/test/test-bcf-sr.c
+++ b/test/test-bcf-sr.c
@@ -40,7 +40,7 @@
 #include "../htslib/hts.h"
 #include "../htslib/vcf.h"
 
-void error(const char *format, ...)
+void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) error(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);

--- a/test/test-bcf-translate.c
+++ b/test/test-bcf-translate.c
@@ -29,7 +29,7 @@
 
 #include "../htslib/vcf.h"
 
-void error(const char *format, ...)
+void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) error(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);

--- a/test/test-bcf_set_variant_type.c
+++ b/test/test-bcf_set_variant_type.c
@@ -29,7 +29,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "../htslib/hts.h"
 #include "../vcf.c"
 
-void error(const char *format, ...)
+void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) error(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -33,7 +33,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "../htslib/kstring.h"
 #include "../htslib/kseq.h"
 
-void error(const char *format, ...)
+void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) error(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);


### PR DESCRIPTION
Due to cirrus-ci lacking ubsan in the clang installation it needed a bit of juggling as to what checks are executed in which compiler, but this now allows us to automatically spot some undefined behaviour via the CI system.