### PR TITLE
Check underlying hopen() worked for preload: URLs

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -703,7 +703,7 @@ static int is_preload_url_remote(const char *url){
 
 static hFILE *hopen_preload(const char *url, const char *mode){
     hFILE* fp = hopen(url + 8, mode);
-    return hpreload(fp);
+    return fp ? hpreload(fp) : NULL;
 }
 
 hFILE *hdopen(int fd, const char *mode)


### PR DESCRIPTION
Otherwise, we might try to `hread()` a `NULL` pointer.

Credit to OSS_Fuzz
Fixes oss-fuzz id 71069