### PR TITLE
Fix hts_hfile() for compressed text_format files

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -1764,7 +1764,7 @@ static hFILE *hts_hfile(htsFile *fp) {
     case bcf:          // fall through
     case bam:          return bgzf_hfile(fp->fp.bgzf);
     case cram:         return cram_hfile(fp->fp.cram);
-    case text_format:  return fp->fp.hfile;
+    case text_format:  // fall through
     case vcf:          // fall through
     case fastq_format: // fall through
     case fasta_format: // fall through


### PR DESCRIPTION
SAM and VCF files opened for write both start with `htsFile::format.format` set to `text_format`, and then update it after writing the header.  This means it's possible to open a `text_format` file with compression, so `hts_hfile()` needs to handle it in the same way as SAM and VCF.

Noticed when `hts_set_opt(fpout, HTS_OPT_BLOCK_SIZE, BAM_BLOCK_SIZE)` failed in `samtools sort` in the case where the output was a compressed SAM file.  At this point `fpout` was a `text_file`, so the wrong pointer was passed to `hfile_set_blksize()`, which luckily bailed out and returned -1 before doing any damage to the incorrectly passed-in structure.