### PR TITLE
Update htscodecs and add more warnings

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -72,6 +72,7 @@ gcc_task:
        DO_MAINTAINER_CHECKS: yes
        DO_UNTRACKED_FILE_CHECK: yes
        USE_CONFIG: no
+       CFLAGS: -g -O2 -Wall -Werror -fvisibility=hidden
     - environment:
        USE_CONFIG: yes
        # ubsan is incompatible with some -Wformat opts so we do that on clang.
@@ -141,7 +142,7 @@ rocky_task:
     LC_ALL: C
     CIRRUS_CLONE_DEPTH: 1
     USE_CONFIG: yes
-    CFLAGS: -std=gnu90 -Wformat -Wformat=2
+    CFLAGS: -g -O3 -std=gnu90 -Wformat -Wformat=2 -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers -Wno-empty-body
 
   # NB: we could consider building a docker image with these
   # preinstalled and specifying that instead, to speed up testing.

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -29,7 +29,7 @@ jobs:
         export PATH="/mingw64/bin:$PATH:/c/Program Files/Git/bin"
         export MSYSTEM=MINGW64
         autoreconf -i
-        ./configure
+        ./configure --enable-werror
         make cc-version
         make -j6
     - name: Check Htslib

--- a/hts.c
+++ b/hts.c
@@ -1322,7 +1322,7 @@ int hts_parse_opt_list(htsFormat *fmt, const char *str) {
  *        -1 on failure.
  */
 int hts_parse_format(htsFormat *format, const char *str) {
-    char fmt[8];
+    char fmt[9];
     const char *cp = scan_keyword(str, ',', fmt, sizeof fmt);
 
     format->version.minor = 0; // unknown

--- a/test/test-bcf-sr.c
+++ b/test/test-bcf-sr.c
@@ -179,6 +179,7 @@ int main(int argc, char *argv[])
                 break;
             case 'h':
                 usage(EXIT_SUCCESS);
+                // fall-through
             default: usage(EXIT_FAILURE);
         }
     }


### PR DESCRIPTION
The extra warnings do spot a few buglets, such as in hts_parse_format().

Also resurrect `-Werror` which was absent from some builds.  (It's still absent from the configure-less macos builds, but the recommended configure route has it which is sufficient.)