### PR TITLE
Several minor samples/ fixes

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -114,6 +114,4 @@ qtask_unordered: qtask_unordered.c
 clean:
 	find . -name "*.o" | xargs rm -rf
 	find . -name "*.dSYM" | xargs rm -rf
-	rm $(PRGS)
-
-
+	-rm -f $(PRGS)

--- a/samples/write_fast.c
+++ b/samples/write_fast.c
@@ -53,7 +53,6 @@ int main(int argc, char *argv[])
     const char *outname = NULL;             //output file name
     int ret = EXIT_FAILURE;
     samFile *outfile = NULL;                //sam file
-    sam_hdr_t *out_samhdr = NULL;           //header of file
     bam1_t *bamdata = NULL;                 //to hold the read data
     char mode[4] = "a";
     const char *data = NULL, *qual = NULL;  //ref data and quality
@@ -93,22 +92,20 @@ int main(int argc, char *argv[])
     sam_open_format(outname, mode, fmt);
     */
 
-    snprintf(name, sizeof(name), "Test_%ld", time(NULL));
+    snprintf(name, sizeof(name), "Test_%ld", (long) time(NULL));
     //data
     if (bam_set1(bamdata, strlen(name), name, BAM_FUNMAP, -1, -1, 0, 0, NULL, -1, -1, 0, strlen(data), data, qual, 0) < 0) {
         printf("Failed to set data\n");
         goto end;
     }
-    if (sam_write1(outfile, out_samhdr, bamdata) < 0) {
+    //as we write only FASTA/FASTQ, we can get away without providing headers
+    if (sam_write1(outfile, NULL, bamdata) < 0) {
         printf("Failed to write data\n");
         goto end;
     }
     ret = EXIT_SUCCESS;
 end:
     //clean up
-    if (out_samhdr) {
-        sam_hdr_destroy(out_samhdr);
-    }
     if (outfile) {
         sam_close(outfile);
     }


### PR DESCRIPTION
The _samples/write_fast.c_ code confusingly never instantiated `out_samhdr`, and doesn't really have a header to supply. It got away with this because writing FASTA/Q doesn't actually need a header, so this PR makes that explicit.

Cast `time_t`, which isn't necessarily a `long` itself.

Use the usual `-rm -f` incantation so that doing `make clean` twice completes without diagnostics even when the `$(PRGS)` files already don't exist.