### PR TITLE
Fix out-of-bounds read in cram_codec_iter_next()

### DIFF
--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -291,7 +291,7 @@ static cram_codec *cram_codec_iter_next(cram_codec_iter *iter,
             iter->curr_map = iter->curr_map->next;
             return cc;
         }
-    } while (iter->idx <= CRAM_MAP_HASH);
+    } while (iter->idx < CRAM_MAP_HASH);
 
     // End of codecs
     return NULL;


### PR DESCRIPTION
`cram_block_compression_hdr::tag_encoding_map[]` has `CRAM_MAP_HASH` elements, so the iterator should not go beyond that.