### PR TITLE
Make --write-index work for concat with vcf

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -516,6 +516,9 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     */
     HTSLIB_EXPORT
     int vcf_write_line(htsFile *fp, kstring_t *line);
+    
+    HTSLIB_EXPORT
+    int vcf_write_line_with_index(htsFile *fp, const bcf_hdr_t *h, kstring_t *line, int tid, hts_pos_t pos, hts_pos_t len);
 
     /**************************************************************************
      *  Header querying and manipulation routines

--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -516,9 +516,25 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
     */
     HTSLIB_EXPORT
     int vcf_write_line(htsFile *fp, kstring_t *line);
-    
+
+
+
+    /// Write a line to a VCF file for indexing
+    /** @param line   Line to write
+        @param fp     File to write it to
+        @param h      The header for the vcf file
+        @param chr_id Chromosome id
+        @param name   Chromosome name
+        @param beg    Beginning position
+        @param end    End position
+        @return 0 on success; -1 on failure
+
+        @note Similar to vcf_write_line.  No checks are done on the line being added, apart from
+              ensuring that it ends with a newline.  This function
+              should therefore be used with care.
+    */
     HTSLIB_EXPORT
-    int vcf_write_line_with_index(htsFile *fp, const bcf_hdr_t *h, kstring_t *line, int tid, hts_pos_t pos, hts_pos_t len);
+    int vcf_write_line_with_index(htsFile *fp, const bcf_hdr_t *h, kstring_t *line, int chr_id, char *name, hts_pos_t pos, hts_pos_t len);
 
     /**************************************************************************
      *  Header querying and manipulation routines

--- a/vcf.c
+++ b/vcf.c
@@ -4257,6 +4257,30 @@ int vcf_write(htsFile *fp, const bcf_hdr_t *h, bcf1_t *v)
     return ret==fp->line.l ? 0 : -1;
 }
 
+
+int vcf_write_line_with_index(htsFile *fp,  const bcf_hdr_t *h, kstring_t *line, int tid,
+            hts_pos_t pos, hts_pos_t len)
+{
+    ssize_t ret;
+    
+    fprintf(stderr, "vcf_write_line_with_index start\n");
+
+    if (fp->format.compression == no_compression || !fp->idx) { // compressed reads only for indexing
+        return -1;
+    }
+    
+    ret = bgzf_write(fp->fp.bgzf, line->s, line->l); // error handling?
+    
+    if (bgzf_idx_push(fp->fp.bgzf, fp->idx, tid, pos, pos + len, bgzf_tell(fp->fp.bgzf), 1) < 0) {
+        return -1;
+    }
+    
+    fprintf(stderr, "vcf_write_line_with_index end\n");
+    
+    return 0; // again, more error handling needed
+}
+  
+
 /************************
  * Data access routines *
  ************************/


### PR DESCRIPTION
Add a new function to work like _vcf_write_line_ but with index handling code.

To make _vcf_write_line_ work to produce an index I would of had to change its arguments as more information was needed.  Instead I added a new function.

In conjunction with the BCFtools change (samtools/bcftools#2283) this should fix samtools/bcftools#2246.