### PR TITLE
Prevent segfault on empty tbi index

### DIFF
--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -1396,7 +1396,7 @@ int bcf_sr_regions_next(bcf_sr_regions_t *reg)
             }
 
             // tabix index absent, reading the whole file
-            ret = hts_getline(reg->file, KS_SEP_LINE, &reg->line);
+            ret = reg->file ? hts_getline(reg->file, KS_SEP_LINE, &reg->line) : -1;
             if ( ret<0 ) { reg->iseq = -1; return -1; }
         }
         ret = _regions_parse_line(reg->line.s, ichr,ifrom,ito, &chr,&chr_end,&from,&to);


### PR DESCRIPTION
When an empty VCF file with a header but no data lines is indexed, tbx_seqnames() called via bcf_sr_add_reader() returns an empty list. Consequently, when bcf_sr_regions_next() is called and no in-memory regions are available, it attempts to read from a file which is not initialized.

This fixes https://github.com/samtools/bcftools/issues/2286