### PR TITLE
Fix issue created in PR#1848

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -4954,6 +4954,8 @@ int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr) {
                         hts_log_warning("NOTE: the CRAM file will be bigger "
                                         "than using an external reference");
                         pthread_mutex_lock(&fd->ref_lock);
+                        // Best guess.  It may be unmapped data with broken
+                        // headers, in which case this will get ignored.
                         fd->embed_ref = 2;
                         pthread_mutex_unlock(&fd->ref_lock);
                         break;


### PR DESCRIPTION
We shouldn't be attempting to create embedded reference sequences for CRAM containers with reads mapped to chr -1 (ie unmapped).  We don't permit embed_ref in multi-ref mode and it's nonsensical for entirely unmapped data.

The only real fix needed here is `&& c->ref_id >= 0` just before calling cram_generate_reference(), but checking elsewhere can sidestep other potential issues and we have safety in checking in more than one place.

Credit to OSS_Fuzz
Fixes oss-fuzz issue 372547397

Note the following test triggered it, but it's only for that most recent commit and 1.21 was fine so this is a brief regression.

```
@SQ	SN:foo	LN:999
x	4	*	1	0	*	*	0	0	ACGT	PQRS
```
