### PR TITLE
Add an hts_crc32 function to use zlib or libdeflate.

### DIFF
--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -1517,6 +1517,14 @@ static inline int hts_bin_level(int bin) {
     return l;
 }
 
+/**************************************
+ * Exposing the CRC32 implementation  *
+ * Either from zlib or libdeflate.    *
+ *************************************/
+HTSLIB_EXPORT
+uint32_t hts_crc32(uint32_t crc, const void *buf, size_t len);
+
+
 //! Compute the corresponding entry into the linear index of a given bin from
 //! a binning index
 /*!


### PR DESCRIPTION
This follows on from the hts_md5* functions which wrap up either OpenSSL or our own implementation.  Libdeflate's crc32 function is considerably faster than the native zlib, so we want to use it in (for example) the new "samtools checksum" code, but we do not wish to add baggage of looking for libdeflate in the configure script.