### PR TITLE
Remove `-lhts` from `Libs.private` in the pkg-config file.

### DIFF
--- a/htslib.pc.in
+++ b/htslib.pc.in
@@ -11,5 +11,5 @@ Description: C library for high-throughput sequencing data formats
 Version: @-PACKAGE_VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lhts
-Libs.private: -L${libdir} @private_LIBS@ -lhts -lm -lpthread
+Libs.private: -L${libdir} @private_LIBS@ -lm -lpthread
 Requires.private: zlib @pc_requires@


### PR DESCRIPTION
I noticed that `htslib.pc.in` specifies `-lhts` in both the `Libs` and the `Libs.private` fields. This causes problems when using HTSlib from vcpkg, because vcpkg [merges](https://learn.microsoft.com/en-us/vcpkg/maintainers/functions/vcpkg_fixup_pkgconfig) the latter field with the former, resulting in `Libs: "-L${libdir}" -lhts "-L${libdir}" -lhts -lhtscodecs "-L${prefix}/lib" -lm -lpthread`. This causes CMake to remove the first `-lhts`, which causes link errors because of undefined symbols from htscodecs.

This PR fixes this by removing `-lhts` from `Libs.private`. According to [my understanding of pkg-config](https://people.freedesktop.org/~dbn/pkg-config-guide.html#:~:text=Libs%3A%20The%20link%20flags%20specific,but%20not%20exposed%20to%20applications.) the duplication in both `Libs` and `Libs.private` is redundant either way.

Validated locally.