### PR TITLE
BUGFIX header.c sam_hdr_remove_line_pos()

### DIFF
--- a/header.c
+++ b/header.c
@@ -1450,7 +1450,7 @@ int sam_hdr_remove_line_id(sam_hdr_t *bh, const char *type, const char *ID_key, 
 
 int sam_hdr_remove_line_pos(sam_hdr_t *bh, const char *type, int position) {
     sam_hrecs_t *hrecs;
-    if (!bh || !type || position <= 0)
+    if (!bh || !type || position < 0)
         return -1;
 
     if (!(hrecs = bh->hrecs)) {


### PR DESCRIPTION
Parameter check on argument 'position' was not accounting for 0 based indices as per header description:

/* sam.h
/// Remove nth line of a given type from a header
/*!
 * @param type     Type of the searched line. Eg. "SQ"
 * @param position Index in lines of this type (zero-based). E.g. 3
 * @return         0 on success, -1 on error
 *
 * Remove a line from the header by specifying the position in the type
 * group, i.e. 3rd @SQ line.
 */
HTSLIB_EXPORT
int sam_hdr_remove_line_pos(sam_hdr_t *h, const char *type, int
position);
*/