### PR TITLE
hfile_dx : Support for the UK Biobank API (DNA Nexus "DX")

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 CC     = gcc
+CPP    = g++
 AR     = ar
 RANLIB = ranlib
 
@@ -36,7 +37,7 @@ CPPFLAGS =
 # For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
 #CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600
 CFLAGS   = -g -Wall -O2 -fvisibility=hidden
-EXTRA_CFLAGS_PIC = -fpic
+EXTRA_CFLAGS_PIC = -fpic -I../dx-toolkit/share/dnanexus/src/cpp
 TARGET_CFLAGS =
 LDFLAGS  = -fvisibility=hidden
 VERSION_SCRIPT_LDFLAGS = -Wl,-version-script,$(srcprefix)htslib.map
@@ -195,6 +196,8 @@ config_vars.h:
 
 .c.pico:
 	$(CC) $(CFLAGS) $(TARGET_CFLAGS) $(ALL_CPPFLAGS) $(EXTRA_CFLAGS_PIC) -c -o $@ $<
+.cpp.pico:
+	$(CPP) $(CFLAGS) $(TARGET_CFLAGS) $(ALL_CPPFLAGS) $(EXTRA_CFLAGS_PIC) -c -o $@ $<
 
 
 LIBHTS_OBJS = \
@@ -236,6 +239,7 @@ LIBHTS_OBJS = \
 	cram/open_trace_file.o \
 	cram/pooled_alloc.o \
 	cram/string_alloc.o \
+	hfile_dx.o \
 	$(HTSCODECS_OBJS) \
 	$(NONCONFIGURE_OBJS)
 
@@ -473,6 +477,7 @@ hfile_gcs.o hfile_gcs.pico: hfile_gcs.c config.h $(htslib_hts_h) $(htslib_kstrin
 hfile_libcurl.o hfile_libcurl.pico: hfile_libcurl.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_s3_write.o hfile_s3_write.pico: hfile_s3_write.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_h)
 hfile_s3.o hfile_s3.pico: hfile_s3.c config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(hts_time_funcs_h)
+hfile_dx.o hfile_dx.pico: hfile_dx.cpp config.h $(hfile_internal_h) $(htslib_hts_h) $(htslib_kstring_h) $(hts_time_funcs_h)
 hts.o hts.pico: hts.c config.h os/lzma_stub.h $(htslib_hts_h) $(htslib_bgzf_h) $(cram_h) $(htslib_hfile_h) $(htslib_hts_endian_h) version.h config_vars.h $(hts_internal_h) $(hfile_internal_h) $(sam_internal_h) $(htslib_hts_expr_h) $(htslib_hts_os_h) $(htslib_khash_h) $(htslib_kseq_h) $(htslib_ksort_h) $(htslib_tbx_h) $(htscodecs_htscodecs_h)
 hts_expr.o hts_expr.pico: hts_expr.c config.h $(htslib_hts_expr_h) $(htslib_hts_log_h) $(textutils_internal_h)
 hts_os.o hts_os.pico: hts_os.c config.h $(htslib_hts_defs_h) os/rand.c

--- a/configure.ac
+++ b/configure.ac
@@ -672,4 +672,18 @@ case "$srcdir" in
 esac
 AC_SUBST([HTSDIRslash_if_relsrcdir])
 
+## DNA NEXUS API
+AC_ARG_ENABLE([dx],
+    [AS_HELP_STRING([--enable-dx], [Enable DNANexus support])],
+    [if test "x$enable_dx" = "xyes"; then
+         AC_DEFINE([ENABLE_DX], [1], [Define to 1 if you want to enable DNANexus DX API])
+    fi],
+    [enable_dx=no])
+
+AC_ARG_WITH([dx-include],
+    [AS_HELP_STRING([--with-dx-include=PATH], [Specify the path DX/DNA Nexus header files])],
+    [dx_include_path="$withval"],
+    [dx_include_path=""])
+
+
 AC_OUTPUT

--- a/hfile.c
+++ b/hfile.c
@@ -1126,6 +1126,11 @@ static int load_hfile_plugins(void)
     init_add_plugin(NULL, hfile_plugin_init_s3_write, "s3w");
 #endif
 
+#ifdef ENABLE_DX
+   init_add_plugin(NULL, hfile_plugin_init_dx, "dx");
+#endif
+
+
 #endif
 
     // In the unlikely event atexit() fails, it's better to succeed here and

--- a/hfile_dx.cpp
+++ b/hfile_dx.cpp
@@ -1,8 +1,8 @@
 /*  hfile_dx.cpp -- DNA Nexus low-level file streams.
 
-    Copyright (C) 2015-2017, 2019-2020 Genome Research Ltd.
-
     Author: Pierre Lindenbaum
+            Institut-du-Thorax. U1097. Nantes. France
+            https://github.com/lindenb
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/hfile_dx.cpp
+++ b/hfile_dx.cpp
@@ -1,0 +1,181 @@
+/*  hfile_dx.cpp -- DNA Nexus low-level file streams.
+
+    Copyright (C) 2015-2017, 2019-2020 Genome Research Ltd.
+
+    Author: Pierre Lindenbaum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include "dxcpp/api.h"
+#include "config.h"
+#include "htslib/hts.h"
+#include "htslib/kstring.h"
+#include "hfile_internal.h"
+
+using namespace std;
+using namespace dx;
+
+typedef struct {
+    hFILE base;
+    DXFile *dxfile;
+    off_t file_size;
+    off_t offset;
+} hFILE_dx;
+
+
+static ssize_t dx_read(hFILE *fpv, void *bufferv, size_t nbytes)
+{
+    hFILE_dx *fp = (hFILE_dx *) fpv;
+    int64_t n = 0;
+    ssize_t n_reads = 0;
+    size_t remain = nbytes;
+    while(!fp->dxfile->eof() && remain>0) {
+      fp->dxfile-> read(&((char*)bufferv)[n_reads],nbytes);
+      n = fp->dxfile->gcount();
+      if(n==0) break;
+      fp->offset+=n;
+      remain-=n;
+      n_reads+=n;
+      }
+    return n_reads;
+
+}
+
+
+static ssize_t dx_write(hFILE *fpv, const void *bufferv, size_t nbytes)
+{
+    return -1;
+}
+
+
+static off_t dx_seek(hFILE *fpv, off_t offset, int whence)
+{
+    hFILE_dx* fp = (hFILE_dx*)fpv;
+    off_t origin, pos;
+
+
+    switch (whence) {
+    case SEEK_SET:
+        origin = 0;
+        break;
+    case SEEK_CUR:
+        errno = ENOSYS;
+        return -1;
+    case SEEK_END:
+        if (fp->file_size < 0) { errno = ESPIPE; return -1; }
+        origin = fp->file_size;
+        break;
+    default:
+        errno = EINVAL;
+        return -1;
+    }
+
+    // Check 0 <= origin+offset < fp->file_size carefully, avoiding overflow
+    if ((offset < 0)? origin + offset < 0
+                : (fp->file_size >= 0 && offset > fp->file_size - origin)) {
+        errno = EINVAL;
+        return -1;
+    }
+
+  
+    try {
+      fp->dxfile->seek(origin + offset);
+      }
+    catch(...) {
+      fprintf(stderr,"cannot seek\n");
+      return EINVAL;
+      }
+   fp->offset = origin + offset;
+   return fp->offset;
+}
+
+
+static int dx_close(hFILE *fpv)
+{
+    hFILE_dx *fp = (hFILE_dx *) fpv;
+    fp->dxfile->close();
+    delete fp->dxfile;
+    fp->dxfile=NULL;
+    else return 0;
+}
+
+static const struct hFILE_backend dx_backend =
+{
+    dx_read, dx_write, dx_seek, NULL, dx_close
+};
+
+
+static hFILE *dx_open(const char *fname, const char *mode)
+{
+if(strncmp(fname,"dx:")!=0) {
+  fprintf(stderr,"illegal, %s doesn't start with 'dx:'\n",fname);
+  goto early_error;
+  }
+hFILE_dx* fp = (hFILE_dx *) hfile_init(sizeof (hFILE_dx), mode, 0);
+if (fp == NULL) goto early_error;
+fp->offset = 0;
+fp->dxfile = new DXFile(fname);
+if(!fp->dxfile.is_open()) {
+  fprintf(stderr,"Cannot open dx file \"%s\".\n",fname);
+  goto error;
+  }
+fp->file_size =  fp->dxfile->describe()["size"].get<int64_t>();
+fp->base.backend = &libdx_backend;
+
+return fp;
+
+error:
+    if(fp->dxfile!=NULL) delete fp->dxfile;
+    hfile_destroy((hFILE *) fp);
+    return NULL;
+
+early_error:
+    return NULL;
+}
+
+
+
+int PLUGIN_GLOBAL(hfile_plugin_init,_dx)(struct hFILE_plugin *self)
+{
+    static const struct hFILE_scheme_handler handler =
+        {
+       /* Opens a stream when dispatched by hopen(); should call hfile_init()
+       to malloc a struct "derived" from hFILE and initialise it appropriately,
+       including setting base.backend to its own backend vector.  */
+        dx_open,
+       /* Returns whether the URL denotes remote storage when dispatched by
+       hisremote().  For simple cases, use one of hfile_always_*() below.  */
+        hfile_always_remote,
+        /* The name of the plugin or other code providing this handler.  */
+        "DX DNAnexus",
+        /* priority */
+        5000 + 50, 
+        /* Same as the open() method, used when extra arguments have been given to hopen().  */
+        NULL
+        };
+
+#ifdef ENABLE_PLUGINS
+    // Embed version string for examination via strings(1) or what(1)
+    static const char id[] = "@(#)hfile_dx plugin (htslib)\t" HTS_VERSION_TEXT;
+#endif
+
+    self->name = "DX DNA Nexus";
+    hfile_add_scheme_handler("dx", &handler);
+    return 0;
+}

--- a/hfile_internal.h
+++ b/hfile_internal.h
@@ -183,6 +183,7 @@ extern int hfile_plugin_init_gcs(struct hFILE_plugin *self);
 extern int hfile_plugin_init_libcurl(struct hFILE_plugin *self);
 extern int hfile_plugin_init_s3(struct hFILE_plugin *self);
 extern int hfile_plugin_init_s3_write(struct hFILE_plugin *self);
+extern int hfile_plugin_init_dx(struct hFILE_plugin *self);
 #endif
 
 // Callback to allow headers to be set in http connections.  Currently used


### PR DESCRIPTION
Hi all,

This is a preliminary PR, it is not ready for commit.

I'm using the UK biobank data https://ukbiobank.dnanexus.com . As far as I understand, all the CRAM/BAM are in the cloud (backed by amazon ?) and every time you need a CRAM/BAM, it needs to be [downloaded using their tool](https://documentation.dnanexus.com/user/objects/uploading-and-downloading-files/small-sets-of-files/downloading-using-dx) `dx download`.

Hence, even if you just want to just get the region of a BAM, the whole file must be downloaded ( ~ 3 min for 18G )

```
real    3m3.116s
user    0m45.935s
sys     1m0.066s
```

In the current PR, I used the DNA nexus C++ library : https://github.com/dnanexus/dx-toolkit to create an specialized `hfile_dx` similar to hfile_s3, hfile_gs etc... and now using the url scheme `dx:` I can use samtools with ukbb bams using `samtools view` and, of course, it's much faster.

```
time samtools view -O BAM -o out.bam -T ref/ref.fa --customized-index dx:file-G70qYb8JPKk6B36gKZK413fQ dx:file-G70qYbQJPKk7x1zQPBP94bpj "chrY:56673926-56673985"

real	0m10.317s
user	0m0.210s
sys	0m0.062s
```


What's next ?

- is it ok to include this PR in htslib ?
- is it the right way to include this dx 'plugin' in the current code ?
- I don't know enough the GNU automake, autoconf ecosystem, I tried to add some code in the configure.ac file but , for example , i don't know how to re-use `--dx-include-path`, how to prevent some .o and .pico to be included in the libraries, and at the end I modified the `Makefile`.
- It could be even faster if the callback used by htslib for reading used larger buffer, is it possible to control that size ?
- etc...
- 


