### PR TITLE
Fix a bug in breakend detection

### DIFF
--- a/test/test-bcf_set_variant_type.c
+++ b/test/test-bcf_set_variant_type.c
@@ -91,6 +91,19 @@ static void test_bcf_set_variant_type(void)
     {
         error("[16:33625444[N was not detected as a breakend");
     }
+
+    bcf_set_variant_type("T", "]chrB:123]AGTNNNNNCAT", &var3d);
+    if ( var3d.type != VCF_BND)
+    {
+        error("]chrB:123]AGTNNNNNCAT was not detected as a breakend");
+    }
+    bcf_set_variant_type("C", "CAGTNNNNNCA[chrA:321[", &var3d);
+    if ( var3d.type != VCF_BND)
+    {
+        error("CAGTNNNNNCA[chrA:321[ was not detected as a breakend");
+    }
+
+
     // Test special reference alleles
     bcf_variant_t var4a;
     bcf_set_variant_type("A", "<NON_REF>", &var4a);

--- a/vcf.c
+++ b/vcf.c
@@ -5025,8 +5025,8 @@ static void bcf_set_variant_type(const char *ref, const char *alt, bcf_variant_t
 
     if ( *a && !*r )
     {
-        if ( *a==']' || *a=='[' ) { var->type = VCF_BND; return; } // "joined after" breakend
         while ( *a ) a++;
+        if ( *(a-1)==']' || *(a-1)=='[' ) { var->type = VCF_BND; return; } // "joined after" breakend
         var->n = (a-alt)-(r-ref); var->type = VCF_INDEL | VCF_INS; return;
     }
     else if ( *r && !*a )


### PR DESCRIPTION
it was incorrectly assumed that the ALT allele is
of equal length to REF allele, but the VCF specification allows breakend insertions, such as C > CAGTNNNNNCA[2:321682[

Resolves https://github.com/samtools/bcftools/issues/2317