### PR TITLE
sam_internal.h: code2base[512 -> 513] because the byte for end-of-string is missing.

### DIFF
--- a/sam_internal.h
+++ b/sam_internal.h
@@ -70,7 +70,7 @@ static inline int possibly_expand_bam_data(bam1_t *b, size_t bytes) {
  *    seq[i] = seq_nt16_str[bam_seqi(nib, i)];
  */
 static inline void nibble2base_default(uint8_t *nib, char *seq, int len) {
-    static const char code2base[512] =
+    static const char code2base[513] = /* 512 + 1 for end-of-string */
         "===A=C=M=G=R=S=V=T=W=Y=H=K=D=B=N"
         "A=AAACAMAGARASAVATAWAYAHAKADABAN"
         "C=CACCCMCGCRCSCVCTCWCYCHCKCDCBCN"


### PR DESCRIPTION
when compiling with g++ and including sam_internal.h (I need nibble2base) there is an error

```
../../htslib/sam_internal.h: In function ‘void nibble2base(uint8_t*, char*, int)’:
../../htslib/sam_internal.h:73:9: error: initializer-string for ‘const char [512]’ is too long [-fpermissive]
```

because `code2base[512]` is missing one byte for the end-of-string character.

this PR just set `code2base[513]`.