### PR TITLE
Fix cram_encode fuzzer issue caused by negative reference lengths.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -3247,6 +3247,10 @@ cram_slice *cram_next_slice(cram_fd *fd, cram_container **cp) {
                 if (fd->ooc)
                     break;
 
+//                printf("%p %d:%ld-%ld vs %d:%ld-%ld\n", fd,
+//                       c_next->ref_seq_id, c_next->ref_seq_start, c_next->ref_seq_start+c_next->ref_seq_span-1,
+//                       fd->range.refid, fd->range.start, fd->range.end);
+
                 /* Skip containers not yet spanning our range */
                 if (fd->range.refid != -2 && c_next->ref_seq_id != -2) {
                     // ref_id beyond end of range; bail out

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -3691,7 +3691,8 @@ static int process_one_read(cram_fd *fd, cram_container *c,
             return -1;
         }
         fake_qual = spos;
-        cr->aend = no_ref ? apos : MIN(apos, c->ref_end);
+        // Protect against negative length refs (fuzz 382922241)
+        cr->aend = no_ref ? apos : MIN(apos, MAX(0, c->ref_end));
         if (cram_stats_add(c->stats[DS_FN], cr->nfeature) < 0)
             goto block_err;
 


### PR DESCRIPTION
Introduced in 24e4e31 with the cache of the LN_length field.  We now validate this as positive.  The check in cram_encode.c should now not be necessary, but it's fixed in two places incase we ever get this cropping up via another route.

Credit to OSS_Fuzz
Fixes oss-fuzz issue 382922241