### PR TITLE
update to use htsFile in synced reader (for #1862)

### DIFF
--- a/htslib/synced_bcf_reader.h
+++ b/htslib/synced_bcf_reader.h
@@ -1,7 +1,7 @@
 /// @file htslib/synced_bcf_reader.h
 /// Stream through multiple VCF files.
 /*
-    Copyright (C) 2012-2017, 2019-2024 Genome Research Ltd.
+    Copyright (C) 2012-2017, 2019-2025 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>
 
@@ -233,9 +233,29 @@ void bcf_sr_destroy_threads(bcf_srs_t *files);
  *
  *  See also the bcf_srs_t data structure for parameters controlling
  *  the reader's logic.
+ *  Invokes bcf_sr_add_hreader with opened file
  */
 HTSLIB_EXPORT
 int bcf_sr_add_reader(bcf_srs_t *readers, const char *fname);
+
+/**
+ *  bcf_sr_add_hreader() - open new reader using htsfile
+ *  @readers: holder of the open readers
+ *  @file_ptr: htsfile already opened
+ *  @autoclose: close file along with reader or not, 1 - close, 0 - do not close
+ *  @idxname: index file name for file in @file_ptr
+ *
+ *  Returns 1 if the call succeeded, or 0 on error.
+ *
+ *  See also the bcf_srs_t data structure for parameters controlling
+ *  the reader's logic.
+ *  If idxname is NULL, uses file_ptr->fn to find index file.
+ *  With idxname as NULL, index file must be present along with the file with
+ *  default name
+ */
+HTSLIB_EXPORT
+int bcf_sr_add_hreader(bcf_srs_t *readers, htsFile *file_ptr, int autoclose,
+    const char *idxname);
 
 HTSLIB_EXPORT
 void bcf_sr_remove_reader(bcf_srs_t *files, int i);

--- a/test/test.pl
+++ b/test/test.pl
@@ -56,6 +56,7 @@ run_test('test_vcf_various',$opts);
 run_test('test_bcf_sr_sort',$opts);
 run_test('test_bcf_sr_no_index',$opts);
 run_test('test_bcf_sr_range', $opts);
+run_test('test_bcf_sr_hreader', $opts);
 run_test('test_command',$opts,cmd=>'test-bcf-translate -',out=>'test-bcf-translate.out');
 run_test('test_convert_padded_header',$opts);
 run_test('test_rebgzip',$opts);
@@ -1343,6 +1344,34 @@ sub test_bcf_sr_range {
             }
         }
     }
+}
+
+sub test_bcf_sr_hreader {
+    #uses input file from test_bcf_sr_sort / test-bcf-sr.pl
+    #invokes bcf sync reader with hread method
+    my ($opts, %args) = @_;
+    my $test = "test_bcf_sr_hreader";
+    my $fail = 0;
+    my $cmd = "$$opts{path}/test-bcf-sr -p all $$opts{tmp}/list.txt -o $$opts{tmp}/file.out";
+    my $cmd_header = "$$opts{path}/test-bcf-sr -p all $$opts{tmp}/list.txt -o $$opts{tmp}/filenew.out -u";
+    my $cmd_diff = "diff $$opts{tmp}/filenew.out $$opts{tmp}/file.out";
+
+    my ($ret, $out) = _cmd($cmd);
+    if ($ret != 0) {
+        failed($opts, $test, "Failed to create reference output\n");
+        return;
+    }
+    ($ret, $out) = _cmd($cmd_header);
+    if ($ret != 0) {
+        failed($opts, $test, "Failed to create output\n");
+        return;
+    }
+    ($ret, $out) = _cmd($cmd_diff);
+    if ($ret != 0) {
+        failed($opts, $test, "Output differs to reference output\n");
+        return;
+    }
+    passed($opts, $test);
 }
 
 sub test_command


### PR DESCRIPTION
Fixes #1862 
Added bcf_sr_add_hreader to add already opened htsfile to reader list.
  The file added can be set to close along with reader or closed explicitly by user. Aux data in synced_bcf_reader.c is updated to hold the file closure status.
  When the file name is passed along with file pointer, the index can be anywhere and mentioned using ##idx## method with file name.  As file name in htsfile does not maintain index information, the index has to be present in default location with default name (i.e. same location as file with file name.<index extension>) when no filename is passed to this method.

bcf_sr_add_reader updated to open the file and passes the file to bcf_sr_add_hreader with autoclose enabled.

Test utility and script updated to use the new interface. With -u argument, it uses the new interface where file pointer is made and used.


