### PR TITLE
Add hts_tpool_worker_id() API

### DIFF
--- a/htslib/thread_pool.h
+++ b/htslib/thread_pool.h
@@ -115,6 +115,14 @@ HTSLIB_EXPORT
 int hts_tpool_size(hts_tpool *p);
 
 
+/// Return the worker ID index, from 0 to nthreads-1.
+/**
+ * @param p         Thread pool
+ * @return          The worker index (0..ntheads-1) or -1 if not found
+ */
+HTSLIB_EXPORT
+int hts_tpool_worker_id(hts_tpool *pool);
+
 /// Add an item to the work pool.
 /**
  * @param p     Thread pool


### PR DESCRIPTION
This returns a numeric value from 0 to nthreads-1 corresponding to the current running thread, or -1 if unthreaded or the thread does not correspond to one allocated to this pool.

It may be used to associate data to a thread rather than to a job. For example maintaining one open file handle per thread spawned.