### PR TITLE
Reset variant types after updating alleles

### DIFF
--- a/vcf.c
+++ b/vcf.c
@@ -5495,6 +5495,7 @@ int bcf_has_filter(const bcf_hdr_t *hdr, bcf1_t *line, char *filter)
 static inline int _bcf1_sync_alleles(const bcf_hdr_t *hdr, bcf1_t *line, int nals)
 {
     line->d.shared_dirty |= BCF1_DIRTY_ALS;
+    line->d.var_type = -1;
 
     line->n_allele = nals;
     hts_expand(char*, line->n_allele, line->d.m_allele, line->d.allele);


### PR DESCRIPTION
Variant type calls produced by `bcf_set_variant_types()` may be stale after updating alleles via `bcf_update_alleles()` or `bcf_update_alleles_str()`, so set `d.var_type` to -1 to force a recalculation.

Fixes an out of bounds access in bcftools consensus that occurred when it added a new allele to a record.