### PR TITLE
Make HAVE_ATTRIBUTE_TARGET check also check that SSSE3 intrinsics work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ config.h:
 	echo '#define HAVE_ATTRIBUTE_CONSTRUCTOR 1' >> $@
 	echo '#endif' >> $@
 	echo '#if (defined(__x86_64__) || defined(_M_X64))' >> $@
-	echo '#define HAVE_ATTRIBUTE_TARGET 1' >> $@
+	echo '#define HAVE_ATTRIBUTE_TARGET_SSSE3 1' >> $@
 	echo '#define HAVE_BUILTIN_CPU_SUPPORT_SSSE3 1' >> $@
 	echo '#endif' >> $@
 	echo '#if defined __linux__' >> $@

--- a/configure.ac
+++ b/configure.ac
@@ -174,16 +174,25 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([],[
 ])
 
 dnl Check for function attribute used in conjunction with __builtin_cpu_supports
-AC_MSG_CHECKING([for __attribute__((target))])
+dnl and that it does enable the corresponding intrinsics (which is broken on ancient GCCs)
+AC_MSG_CHECKING([for working __attribute__((target("ssse3")))])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+  #ifdef __x86_64__
+  #include "x86intrin.h"
+
   __attribute__((target("ssse3")))
-  int zero(void) {
-    return 0;
+  void shuffle(char *aptr, char *bptr) {
+    __m128i a = _mm_lddqu_si128((__m128i *)aptr);
+    __m128i b = _mm_shuffle_epi8(a, a);
+    _mm_storeu_si128((__m128i *)bptr, b);
   }
-]], [[zero();]])], [
+  #else
+  void shuffle(char *aptr, char *bptr) { }
+  #endif
+]], [[shuffle(0, 0);]])], [
   AC_MSG_RESULT([yes])
-  AC_DEFINE([HAVE_ATTRIBUTE_TARGET], 1,
-            [Define if __attribute__((target(...))) is available.])
+  AC_DEFINE([HAVE_ATTRIBUTE_TARGET_SSSE3], 1,
+            [Define if __attribute__((target("ssse3"))) works.])
 ], [
   AC_MSG_RESULT([no])
 ])

--- a/sam_internal.h
+++ b/sam_internal.h
@@ -100,7 +100,7 @@ static inline void nibble2base_default(uint8_t *nib, char *seq, int len) {
 }
 
 #if defined HAVE_ATTRIBUTE_CONSTRUCTOR && \
-    ((defined __x86_64__ && defined HAVE_ATTRIBUTE_TARGET && defined HAVE_BUILTIN_CPU_SUPPORT_SSSE3) || \
+    ((defined __x86_64__ && defined HAVE_ATTRIBUTE_TARGET_SSSE3 && defined HAVE_BUILTIN_CPU_SUPPORT_SSSE3) || \
      (defined __ARM_NEON))
 #define BUILDING_SIMD_NIBBLE2BASE
 #endif


### PR DESCRIPTION
We released a new pysam based on HTSlib et al 1.21 last week, and now #1838 has been re-reported as pysam-developers/pysam#1327. So that nobody gets more support requests, it would be good to fix it so that the _simd.c_ code is disabled for these ancient compilers.

Playing with the [Compiler Explorer](https://godbolt.org/), I confirmed that GCC ≤ 4.8.5 cannot compile _simd.c_, while GCC ≥ 4.9.0 can. I considered `HTS_GCC_AT_LEAST(4,9)` but realised that the existing `HAVE_SSSE3` appears to be exactly what is needed.

However further Compiler Exploration showed that GCC ≤ 4.8.5 can compile these intrinsics with `-mssse3` but not with merely `__attribute__((target("ssse3")))`, which fails to enable the intrinsics. Hence the right approach is to actually use some intrinsics in the configure test as @daviesrob suggested in https://github.com/samtools/htslib/issues/1838#issuecomment-2356380704. This PR does that.