### PR TITLE
update to tabix with easy validation for a few file formats

### DIFF
--- a/htslib/tbx.h
+++ b/htslib/tbx.h
@@ -1,7 +1,7 @@
 /// @file htslib/tbx.h
 /// Tabix API functions.
 /*
-    Copyright (C) 2009, 2012-2015, 2019 Genome Research Ltd.
+    Copyright (C) 2009, 2012-2015, 2019, 2025 Genome Research Ltd.
     Copyright (C) 2010, 2012 Broad Institute.
 
     Author: Heng Li <lh3@sanger.ac.uk>
@@ -53,6 +53,10 @@ typedef struct tbx_t {
     void *dict;
 } tbx_t;
 
+typedef struct settings {
+    int strict; //parsing strict (1) or not (0)
+} settings;
+
 HTSLIB_EXPORT
 extern const tbx_conf_t tbx_conf_gff, tbx_conf_bed, tbx_conf_psltbl, tbx_conf_sam, tbx_conf_vcf, tbx_conf_gaf;
 
@@ -89,6 +93,10 @@ extern const tbx_conf_t tbx_conf_gff, tbx_conf_bed, tbx_conf_psltbl, tbx_conf_sa
 
     HTSLIB_EXPORT
     int tbx_index_build3(const char *fn, const char *fnidx, int min_shift, int n_threads, const tbx_conf_t *conf);
+
+    HTSLIB_EXPORT
+    int tbx_index_build4(const char *fn, const char *fnidx, int min_shift, int n_threads, const tbx_conf_t *conf,
+    const settings *extra);
 
 
 /// Load or stream a .tbi or .csi index

--- a/tabix.1
+++ b/tabix.1
@@ -4,7 +4,7 @@
 tabix \- Generic indexer for TAB-delimited genome position files
 .\"
 .\" Copyright (C) 2009-2011 Broad Institute.
-.\" Copyright (C) 2014, 2016, 2018, 2020, 2022, 2024 Genome Research Ltd.
+.\" Copyright (C) 2014, 2016, 2018, 2020, 2022, 2024-2025 Genome Research Ltd.
 .\"
 .\" Author: Heng Li <lh3@sanger.ac.uk>
 .\"
@@ -173,6 +173,11 @@ Values higher than 3 produce additional informational and debugging messages.
 .BI "-@, --threads " INT
 Set number of threads to use for the operation.
 The default is 0, where no extra threads are in use.
+.TP
+.B -y, --easyparse
+Strict parsing is in place by default and this options avoids it.
+Data which fails in parsing will not be part of index and rest of the data are
+indexed. This is relevant only for files of type other than cram, bam and bcf.
 .PP
 .SH EXAMPLE
 (grep "^#" in.gff; grep -v "^#" in.gff | sort -t"`printf '\(rst'`" -k1,1 -k4,4n) | bgzip > sorted.gff.gz;


### PR DESCRIPTION
Update to PR #1887 to make the behaviour controlled by an option.
The error exit code return is the default behaviour as in last PR.
A command line option, '-y/--easyparse' is added to have a relaxed parsing, to create output even with non-parsable data, skipping them, as earlier tabix did. Instead of an error log, a warning will be made in such cases.
