### PR TITLE
Fix broken tests due to MSYS2 changes.

### DIFF
--- a/test/test-bcf-sr.pl
+++ b/test/test-bcf-sr.pl
@@ -71,7 +71,7 @@ sub parse_params
         error("Unknown parameter \"$arg\". Run -h for help.\n");
     }
     $$opts{tmp} = exists($$opts{keep_files}) ? $$opts{keep_files} : tempdir(CLEANUP=>1);
-    if ($^O =~ /^msys/) {
+    if ($^O =~ /^(cygwin|msys)/) {
         $$opts{tmp} = cygpath($$opts{tmp});
     }
     if ( $$opts{keep_files} ) { cmd("mkdir -p $$opts{keep_files}"); }

--- a/test/test.pl
+++ b/test/test.pl
@@ -104,7 +104,7 @@ sub cygpath {
 sub safe_tempdir
 {
     my $dir = tempdir(CLEANUP=>1);
-    if ($^O =~ /^msys/) {
+    if ($^O =~ /^(cygwin|msys)/) {
         $dir = cygpath($dir);
     }
     return $dir;
@@ -129,7 +129,7 @@ sub parse_params
     $$opts{path} = $FindBin::RealBin;
     $$opts{bin}  = $FindBin::RealBin;
     $$opts{bin}  =~ s{/test/?$}{};
-    if ($^O =~ /^msys/) {
+    if ($^O =~ /^(cygwin|msys)/) {
         $$opts{path} = cygpath($$opts{path});
         $$opts{bin}  = cygpath($$opts{bin});
     }
@@ -1085,7 +1085,7 @@ sub test_index
     # Tabix and custom index names
     _cmd("$$opts{bin}/tabix -fp vcf $$opts{tmp}/index.vcf.gz");
     my $wtmp = $$opts{tmp};
-    if ($^O =~ /^msys/) {
+    if ($^O =~ /^(cygwin|msys)/) {
         $wtmp =~ s/\//\\\\/g;
     }
     test_cmd($opts,out=>'tabix.out',cmd=>"$$opts{bin}/tabix $wtmp/index.vcf.gz##idx##$wtmp/index.vcf.gz.tbi 1:10000060-10000060");


### PR DESCRIPTION
Due to changes in how MSYS2 perl reported the identity of the OS it was built for, our tests were failing to adapt to the Windows style file locations.

Background:
https://www.msys2.org/news/#2025-02-14-moving-msys2-closer-to-cygwin

MSYS2 PR:
https://github.com/msys2/MSYS2-packages/pull/5177