### PR TITLE
Add error check to bgzf_seek_common()

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -2210,6 +2210,7 @@ static inline int64_t bgzf_seek_common(BGZF* fp,
 
         if (fp->mt->errcode) {
             fp->errcode |= BGZF_ERR_IO;
+            errno = fp->mt->errcode;
             pthread_mutex_unlock(&fp->mt->command_m);
             return -1;
         }

--- a/bgzf.c
+++ b/bgzf.c
@@ -2205,6 +2205,10 @@ static inline int64_t bgzf_seek_common(BGZF* fp,
                 abort();  // Should not get to any other state
             }
         } while (fp->mt->command != SEEK_DONE);
+
+        if (fp->mt->errcode)
+            return -1;
+
         fp->mt->command = NONE;
 
         fp->block_length = 0;  // indicates current block has not been loaded


### PR DESCRIPTION
As per issue #1889, multithreaded seeking was not checking the error status on return.