### PR TITLE
rlen calculation for vcf 4.4, 4.5

### DIFF
--- a/htslib/vcf.h
+++ b/htslib/vcf.h
@@ -950,14 +950,13 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
      *  The @p string in bcf_update_info_flag() is optional,
      *  @p n indicates whether the flag is set or removed.
      *
-     *  Note that updating an END info tag will cause line->rlen to be
-     *  updated as a side-effect (removing the tag will set it to the
-     *  string length of the REF allele). If line->pos is being changed as
+     *  Note that updating / removing END,SVLEN info tags will cause line->rlen
+     *  to be recalculated as a side-effect. If line->pos is being changed as
      *  well, it is important that this is done before calling
-     *  bcf_update_info_int32() to update the END tag, otherwise rlen will be
+     *  bcf_update_info_int32() to update the END/SVLEN tag, otherwise rlen will be
      *  set incorrectly.  If the new END value is less than or equal to
      *  line->pos, a warning will be printed and line->rlen will be set to
-     *  the length of the REF allele.
+     *  the length of the REF allele for versions upto 4.3.
      */
     #define bcf_update_info_int32(hdr,line,key,values,n)   bcf_update_info((hdr),(line),(key),(values),(n),BCF_HT_INT)
     #define bcf_update_info_float(hdr,line,key,values,n)   bcf_update_info((hdr),(line),(key),(values),(n),BCF_HT_REAL)
@@ -1002,6 +1001,8 @@ set to one of BCF_ERR* codes and must be checked before calling bcf_write().
      *  of fixed-length strings. In case of strings with variable length, shorter strings
      *  can be \0-padded. Note that the collapsed strings passed to bcf_update_format_char()
      *  are not \0-terminated.
+     *  With vcf4.5, rlen depends on format field LEN and rlen calculation uses v->pos as well.
+     *  So any change to pos be done before updating LEN that rlen calculated is correct.
      *
      *  Returns 0 on success or negative value on error.
      */

--- a/tbx.c
+++ b/tbx.c
@@ -96,8 +96,11 @@ int tbx_name2id(tbx_t *tbx, const char *ss)
 int tbx_parse1(const tbx_conf_t *conf, size_t len, char *line, tbx_intv_t *intv)
 {
     size_t i, b = 0;
-    int id = 1;
-    char *s;
+    int id = 1, getlen = 0, alcnt = 0, haveins = 0, lenpos = -1;
+    char *s, *t;
+    uint8_t insals[8192];
+    int64_t reflen = 0, svlen = 0, fmtlen = 0, tmp = 0;
+
     intv->ss = intv->se = 0; intv->beg = intv->end = -1;
     for (i = 0; i <= len; ++i) {
         if (line[i] == '\t' || line[i] == 0) {
@@ -165,10 +168,42 @@ int tbx_parse1(const tbx_conf_t *conf, size_t len, char *line, tbx_intv_t *intv)
                         intv->end = intv->beg + l;
                     }
                 } else if ((conf->preset&0xffff) == TBX_VCF) {
-                    if (id == 4) {
+                    if (id == 4) { //ref allele
                         if (b < i) intv->end = intv->beg + (i - b);
-                    } else if (id == 8) { // look for "END="
-                        int c = line[i];
+                        ++alcnt;
+                        reflen = i - b;
+                    } if (id == 5) {    //alt allele
+                        int lastbyte = 0, c = line[i];
+                        insals[lastbyte] = 0;
+                        line[i] = 0;
+                        s = line + b;
+                        do {
+                            t = strchr(s, ',');
+                            if (alcnt >> 3 != lastbyte) {   //initialize insals
+                                lastbyte = alcnt >> 3;
+                                insals[lastbyte] = 0;
+                            }
+                            ++alcnt;
+                            if (t) {
+                                *t = 0;
+                            }
+                            if (s[0] == '<') {
+                                if (!strcmp("<INS>", s)) {  //note inserts
+                                    insals[lastbyte] |= 1 << ((alcnt - 1) & 7);
+                                    haveins = 1;
+                                } else if (!strcmp("<*>", s) ||
+                                    !strcmp("<NON_REF>", s)) {  //note gvcf
+                                    getlen = 1;
+                                }
+                            }
+                            if (t) {
+                                *t = ',';
+                                s = t + 1;
+                            }
+                        } while (t && alcnt < 65536);   //max allcnt is 65535
+                        line[i] = c;
+                    } else if (id == 8) { //INFO, look for "END=" / "SVLEN"
+                        int c = line[i], d = 1;
                         line[i] = 0;
                         s = strstr(line + b, "END=");
                         if (s == line + b) s += 4;
@@ -194,13 +229,84 @@ int tbx_parse1(const tbx_conf_t *conf, size_t len, char *line, tbx_intv_t *intv)
                                 intv->end = end;
                             }
                         }
+                        s = strstr(line + b, "SVLEN=");
+                        if (s == line + b) s += 6;  //at start of info
+                        else if (s) {               //not at the start
+                            s = strstr(line + b, ";SVLEN=");
+                            if (s) s += 7;
+                        }
+                        while (s && d < alcnt) {
+                            t = strchr(s, ',');
+                            if ((haveins) && (insals[d >> 3] & (1 << (d & 7)))) {
+                                tmp = 1;    //<INS>
+                            } else {
+                                tmp = atoll(s);
+                                tmp = tmp < 0 ? llabs(tmp) : tmp;
+                            }
+                            svlen = svlen < tmp ? tmp : svlen;
+                            s = t ? t + 1 : NULL;
+                            ++d;
+                        }
+                        line[i] = c;
+                    } else if (getlen && id == 9 ) {    //FORMAT
+                        int c = line[i], pos = -1;
+                        line[i] = 0;
+                        s = line + b;
+                        while (s) {
+                            ++pos;
+                            if (!(t = strchr(s, ':'))) {    //no further fields
+                                if (!strcmp(s, "LEN")) {
+                                    lenpos = pos;
+                                }
+                                break;  //not present at all!
+                            } else {
+                                *t = '\0';
+                                if (!strcmp(s, "LEN")) {
+                                    lenpos = pos;
+                                    *t = ':';
+                                    break;
+                                }
+                                *t = ':';
+                                s = t + 1;  //check next one
+                            }
+                        }
+                        line[i] = c;
+                        if (lenpos == -1) { //not present
+                            break;
+                        }
+                    } else if (id > 9 && getlen && lenpos != -1) {
+                        //get LEN from sample
+                        int c = line[i], d = 0;
+                        line[i] = 0; tmp = 0;
+                        s = line + b;
+                        for (d = 0; d <= lenpos; ++d) {
+                            if (d == lenpos) {
+                                tmp = atoll(s);
+                                break;
+                            }
+                            if ((t = strchr(s, ':'))) {
+                                s = t + 1;
+                            } else {
+                                break;    //not in sycn with fmt def!
+                            }
+                        }
+                        fmtlen = fmtlen < tmp ? tmp : fmtlen;
                         line[i] = c;
                     }
                 }
             }
-            b = i + 1;
+            b = i + 1;  //beginning if current field
             ++id;
         }
+    }
+    if ((conf->preset&0xffff) == TBX_VCF) {
+        tmp = reflen < svlen ?
+                svlen < fmtlen ? fmtlen : svlen :
+                reflen < fmtlen ? fmtlen : reflen ;
+        tmp += intv->beg;
+        intv->end = intv->end < tmp ? tmp : intv->end;
+
+        //NOTE: 'end' calculation be in sync with end/rlen in vcf.c:get_rlen
     }
     if (intv->ss == 0 || intv->se == 0 || intv->beg < 0 || intv->end < 0) return -1;
     return 0;

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -687,25 +687,29 @@ void test_rlen_values(void)
     "1\t4338\t.\tG\t<*>\t213.73\t.\tEND=4342;SVLEN=.;SVCLAIM=.\tGT:LEN\t0/1:7\t0|0:8\n" \
     "1\t4353\t.\tG\t<*>\t213.73\t.\tEND=4357;SVLEN=.;SVCLAIM=.\tGT:LEN\t0/1:7\t0|0:.\n" \
     "1\t4363\t.\tG\t<*>\t213.73\t.\tEND=4367;SVLEN=.;SVCLAIM=.\tGT:LEN\t0/1:7\t0|0:.\n" \
-    "1\t4373\t.\tG\tT\t213.73\t.\tEND=4375;SVLEN=8;SVCLAIM=.\tGT:LEN\t0/1:.\t0|0:10\n"
-    //this last one is invalid one, to showcase how SVLEN/LEN are considered even when ALT is no SV/gvcf
+    "1\t4370\t.\tG\t<INS>,<*>\t213.73\t.\tEND=4371;SVLEN=.;SVCLAIM=.\tGT:LEN\t0/1:7\t0|0:.\n" \
+    "1\t4378\t.\tG\t<DEL>,<INS>,<*>\t213.73\t.\tEND=4379;SVLEN=3,5,.;SVCLAIM=D,J,.\tGT:LEN\t0/1:7\t0|0:.\n" \
+    "1\t4385\t.\tG\tT\t213.73\t.\tEND=4387;SVLEN=8;SVCLAIM=.\tGT:LEN\t0/1:.\t0|0:10\n"
+    //this last one is invalid one, to showcase how SVLEN is considered even when ALT is no SV
     //this is because data are not cross checked with allele types, to make it simple
 
     //test vcf with different versions
-    const int vcfsz = 11, testsz = 3;
+    const int vcfsz = 13, testsz = 3;
     static char d43[] = "data:,"
     "##fileformat=VCFv4.3\n" data;
     static char d44[] = "data:,"
     "##fileformat=VCFv4.4\n" data;
     static char d45[] = "data:,"
     "##fileformat=VCFv4.5\n" data;
-    //expected rlen for tests
-    int rlen43[] = {1, 1, 2, 1, 1, 1, 11, 5, 5, 5, 3};
-    int rlen44[] = {1, 1, 2, 1, 11, 1, 11, 5, 5, 5, 9};
-    int rlen45[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 10};
+    /* ideal expected rlen for tests
+    int rlen43[] = {1, 1, 2, 1, 1, 1, 11, 5, 5, 5, 2, 2, 3};
+    int rlen44[] = {1, 1, 2, 1, 11, 1, 11, 5, 5, 5, 2, 4, 9};
+    int rlen45[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 9};*/
+    // but we dont check version and hence resulting rlen should be
+    int rlen[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 9};
 
-    char *darr[] = {&d43[0], &d44[0], &d45[0]};           //data array
-    int *rarr[] = {&rlen43[0], &rlen44[0], &rlen45[0]};   //result array
+    char *darr[] = {&d43[0], &d44[0], &d45[0]};     //data array
+    int *rarr[] = {&rlen[0], &rlen[0], &rlen[0]};   //result array
 
     enum htsLogLevel logging = hts_get_log_level();
 


### PR DESCRIPTION
rlen set based on version, position, end, svlen and format len.
depends on PR #1861 (rebased).

recalculates rlen on END and SVLEN info field update, LEN format field update and allele updates.
test updated for validation of rlen calculation.
4.3 uses END and reference length
4.4 uses END, SVLEN and reference length
4.5 uses SVLEN, LEN, reference length
When SVLEN/LEN is not present, it is inferred from END. It is made irrespective of version and no. of alleles, to make it simple and it seems OK.
Cross check of SVLEN with allele is made only for INS, as it is expected to be '.', resulting in 0, for non - SV alleles.

Note: 
Version change may necessitate rlen recalculation and needs to trigger it. It is not handled in this PR.
Until it is made, we may have to save as vcf and reload to have rlen calculated appropriately.

Fixes #1820 
