### PR TITLE
Return errors instead of EOF after all I/O errors etc in `hts_itr_multi_next`/`sam_itr_next`/`sam_read1`/`vcf_parse`/`bcf_read`

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -4291,7 +4291,7 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r)
         if (iter->curr_off) { // seek to the start
             if (iter->seek(fp, iter->curr_off, SEEK_SET) < 0) {
                 hts_log_error("Seek at offset %" PRIu64 " failed.", iter->curr_off);
-                return -1;
+                return -2;
             }
             iter->curr_off = 0; // only seek once
         }
@@ -4369,7 +4369,7 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r)
                     next_range = 0;
                     if (iter->seek(fp, iter->nocoor_off, SEEK_SET) < 0) {
                         hts_log_error("Seek at offset %" PRIu64 " failed.", iter->nocoor_off);
-                        return -1;
+                        return -2;
                     }
                     if (iter->is_cram) {
                         cram_range r = { HTS_IDX_NOCOOR };
@@ -4421,7 +4421,7 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r)
                             if (iter->seek(fp, iter->curr_off, SEEK_SET) < 0) {
                                 hts_log_error("Seek at offset %" PRIu64
                                         " failed.", iter->curr_off);
-                                return -1;
+                                return -2;
                             }
 
                             // Find the genomic range matching this interval.
@@ -4479,7 +4479,7 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r)
                         if (iter->seek(fp, iter->curr_off, SEEK_SET) < 0) {
                             hts_log_error("Seek at offset %" PRIu64 " failed.",
                                           iter->curr_off);
-                            return -1;
+                            return -2;
                         }
                     }
                 }

--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -331,7 +331,7 @@ ssize_t bgzf_write_small(BGZF *fp, const void *data, size_t length) {
     /**
      * Read one byte from a BGZF file. It is faster than bgzf_read()
      * @param fp     BGZF file handler
-     * @return       byte read; -1 on end-of-file or error
+     * @return       byte read; -1 on end-of-file; <= -2 on error
      */
     HTSLIB_EXPORT
     int bgzf_getc(BGZF *fp);

--- a/sam.c
+++ b/sam.c
@@ -4190,6 +4190,7 @@ static int fastq_parse1(htsFile *fp, bam1_t *b) {
                    -1, -1, 0,    // mate
                    x->seq.l, x->seq.s, x->qual.s,
                    0);
+    if (ret < 0) return -2;
 
     // Identify Illumina CASAVA strings.
     // <read>:<is_filtered>:<control_bits>:<barcode_sequence>
@@ -4286,7 +4287,7 @@ static inline int sam_read1_sam(htsFile *fp, sam_hdr_t *h, bam1_t *b) {
                 return -2;
             }
             if (bgzf_seek(fp->fp.bgzf, fp->fp.bgzf->seeked, SEEK_SET) < 0)
-                return -1;
+                return -2;
             fp->fp.bgzf->seeked = 0;
             goto err_recover;
         }
@@ -4308,7 +4309,7 @@ static inline int sam_read1_sam(htsFile *fp, sam_hdr_t *h, bam1_t *b) {
 
         if (fd->h != h) {
             hts_log_error("SAM multi-threaded decoding does not support changing header");
-            return -1;
+            return -2;
         }
 
         sp_bams *gb = fd->curr_bam;

--- a/vcf.c
+++ b/vcf.c
@@ -3662,7 +3662,7 @@ int vcf_parse(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v)
     // parsing.  Eg to do memcmp(key, "END", 4) in vcf_parse_info over
     // the more straight forward looking strcmp, giving a speed advantage.
     if (ks_resize(s, s->l+4) < 0)
-        return -1;
+        return -2;
 
     // Force our memory to be initialised so we avoid the technicality of
     // undefined behaviour in using a 4-byte memcmp.  (The reality is this


### PR DESCRIPTION
While investigating pysam-developers/pysam#1328, I noticed that in a number of cases `hts_itr_multi_next()` returns -1 after `iter->seek(…)` failure. -1 returned from this function (and from `sam_itr_next()`, which for multi iterators just returns this function's result) indicates a successfully reached EOF. Hence seek failure at these locations in the code results in `samtools` or other invoking code **silently omitting data** for multi-region queries.

A full audit of HTSlib functions that return ≥0 record / -1 EOF / ≤-2 error found a handful of other instances of incorrect -1 returns in `sam_read1()` and `vcf_parse()` and hence `bcf_read()`.

It also found a documentation error for `bgzf_getc()`, which does indeed distinguish between EOF and errors.

The usual reason for kstring functions to fail is memory allocation failure, which sets `errno` to ENOMEM. The audit also found cases in which these functions fail but do not set `errno`, which has been addressed. According to 6d927dfa3192492f3015b1bc9a0026f585e93acc, MinGW does not have EOVERFLOW so this works around its absence if necessary — in a somewhat involved way because this is a public header. (_hts_time_funcs.h_ has EOVERFLOW without guards, so perhaps this is out of date and EOVERFLOW is portable nowadays.)