### PR TITLE
Upgrade the default CRAM output to v3.1.

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -5263,7 +5263,7 @@ static void cram_init_tables(cram_fd *fd) {
 
 // Default version numbers for CRAM
 static int major_version = 3;
-static int minor_version = 0;
+static int minor_version = 1;
 
 /*
  * Opens a CRAM file for read (mode "rb") or write ("wb").


### PR DESCRIPTION
We are aware this may break other pipelines, but this change was announced in the last htslib release.

To force CRAM 3.0 output please use the version=3.0 option when running e.g. samtools or call the hts_set_opt function when using a library.