### PR TITLE
Accumulated minor build fixes for uncommon circumstances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -811,7 +811,7 @@ test/test_faidx.o: test/test_faidx.c config.h $(htslib_faidx_h)
 test/test_index.o: test/test_index.c config.h $(htslib_sam_h) $(htslib_vcf_h)
 test/test-vcf-api.o: test/test-vcf-api.c config.h $(htslib_hts_h) $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_kseq_h)
 test/test-vcf-sweep.o: test/test-vcf-sweep.c config.h $(htslib_vcf_sweep_h)
-test/test-bcf-sr.o: test/test-bcf-sr.c config.h $(htslib_synced_bcf_reader_h) $(htslib_hts_h) $(htslib_vcf_h)
+test/test-bcf-sr.o: test/test-bcf-sr.c config.h $(htslib_hts_defs_h) $(htslib_synced_bcf_reader_h) $(htslib_hts_h) $(htslib_vcf_h)
 test/test-bcf-translate.o: test/test-bcf-translate.c config.h $(htslib_vcf_h)
 test/test_introspection.o: test/test_introspection.c config.h $(htslib_hts_h) $(htslib_hfile_h)
 test/test-bcf_set_variant_type.o: test/test-bcf_set_variant_type.c config.h $(htslib_hts_h) vcf.c

--- a/Makefile
+++ b/Makefile
@@ -940,7 +940,7 @@ install-pkgconfig: htslib.pc.tmp installdirs
 # A pkg-config file (suitable for copying to $PKG_CONFIG_PATH) that provides
 # flags for building against the uninstalled library in this build directory.
 htslib-uninstalled.pc: htslib.pc.tmp
-	sed -e 's#@-includedir@#'`pwd`'#g;s#@-libdir@#'`pwd`'#g' htslib.pc.tmp > $@
+	sed -e "s#@-includedir@#`pwd`#g;s#@-libdir@#`pwd`#g" htslib.pc.tmp > $@
 
 
 testclean:

--- a/test/test_khash.c
+++ b/test/test_khash.c
@@ -40,8 +40,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <htslib/khash.h>
-#include <htslib/kroundup.h>
+#include "../htslib/khash.h"
+#include "../htslib/kroundup.h"
 
 #define MAX_ENTRIES 99999999
 


### PR DESCRIPTION
Some small fixes for build failures in relatively unusual circumstances:

* Fix some quoting if the build directory path contains spaces; fixes #1904;
* Fix configuring in a separate build directory by adjusting `#include` style in _test/test_khash.c_;
* While we're changing _Makefile_, a trivial dependency addition to shut my script up.