### PR TITLE
Update distdir target to include more recent source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -628,7 +628,7 @@ htscodecs/htscodecs:
 	@false
 
 # Build the htscodecs/htscodecs/version.h file if necessary
-htscodecs/htscodecs/version.h: force
+htscodecs/htscodecs/version.h: force | htscodecs/htscodecs
 	@if test -e $(srcdir)/htscodecs/.git && test -e $(srcdir)/htscodecs/configure.ac ; then \
 	  vers=`cd $(srcdir)/htscodecs && git describe --always --dirty --match 'v[0-9]\.[0-9]*'` && \
 	  case "$$vers" in \

--- a/Makefile
+++ b/Makefile
@@ -1050,11 +1050,11 @@ tags TAGS:
 # code with your program, this hook enables Automake-style "make dist"
 # for this subdirectory.  If you do bundle an htslib snapshot, please
 # add identifying information to $(PACKAGE_VERSION) as appropriate.
-# (The wildcards attempt to omit non-exported files (.git*, README.md,
+# (The wildcards attempt to omit non-exported files (.git, .gitignore,
 # etc) and other detritus that might be in the top-level directory.)
-distdir:
+distdir: htscodecs/htscodecs/version.h
 	@if [ -z "$(distdir)" ]; then echo "Please supply a distdir=DIR argument."; false; fi
-	tar -c *.[ch15] [ILMNRchtv]*[ELSbcekmnth] | (cd $(distdir) && tar -x)
+	tar -c *.[ch157] [I-R]*[ELSde] [cmors]*[bcemns4] [bhtv]*[bhknpt] htscodecs/*.md htscodecs/[ht]*/*[chp-t0-9] | (cd $(distdir) && tar -x)
 	+cd $(distdir) && $(MAKE) distclean
 
 force:


### PR DESCRIPTION
Update the wildcard to include source files and directories added since this was added in 2015 and last modified in 2017. Give up on omitting _**/README.md_ even though they are omitted from proper release tarballs, as we want to include _README.large_positions.md_.

In particular add the bundled parts of _htscodecs/**_ and ensure that _htscodecs/htscodecs/version.h_ has been built so is present in the distribution directory. (HTSlib's _version.h_ continues to be built via `version.sh` and omitted from the distribution directory.)

With this, `make distdir=../dist` produces a directory with the same files as the htslib-1.21 release tarball, modulo the addition of _README.md_ files and several expected test output files added on **develop** since the last release.

Fixes #1846.