### PR TITLE
Protect the failed reference error message.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2391,7 +2391,10 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
     if ((fd->required_fields & SAM_SEQ) &&
         s->ref == NULL && s->hdr->ref_seq_id >= 0 && !c->comp_hdr->no_ref) {
         hts_log_error("Unable to fetch reference %s:%"PRId64"-%"PRId64,
-                      fd->refs->ref_id[ref_id]->name, s->hdr->ref_seq_start,
+                      fd->refs->ref_id && ref_id >= 0 && ref_id < fd->refs->nref
+                      ? fd->refs->ref_id[ref_id]->name
+                      : "unknown",
+                      s->hdr->ref_seq_start,
                       s->hdr->ref_seq_start + s->hdr->ref_seq_span-1);
         return -1;
     }


### PR DESCRIPTION
With mismatching ref_id and SQ headers this turned into a null pointer dereference.

Credit to OSS_Fuzz
Fixes oss-fuzz issue 418125747