### PR TITLE
Fix symbol version file building script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -946,9 +946,8 @@ $(srcprefix)htslib.map: libhts.so
 	    printf '\n%s {\n' "HTSLIB_$$curr_vers" >> $@.new.tmp && \
 	    cat $@.tmp >> $@.new.tmp && \
 	    printf '} %s;\n' "$$last_vers" >> $@.new.tmp && \
-	        rm -f $@.tmp && \
-	        mv $@.new.tmp $@ ; \
-	    fi ; \
+	    rm -f $@.tmp && \
+	    mv $@.new.tmp $@ ; \
 	else \
 	    rm -f $@.tmp ; \
 	fi

--- a/NEWS
+++ b/NEWS
@@ -113,6 +113,9 @@ Build Changes
 * Updated htscodecs submodule to version 1.6.3
   (PR #1917)
 
+* Fix the script used to build the symbol version file.
+  (PR #1918)
+
 Bug fixes
 ---------
 


### PR DESCRIPTION
Remove a stray `fi` and the misleading indentation that made it difficult to spot.

It's odd that this has gone unnoticed for so long, as the script has run successfully in the past (most recently adding symbols for `HTSLIB_1.21`).

To test, it's necessary to do something like:
```
make htslib.map PACKAGE_VERSION=1.22
```
so it thinks it needs to add new versioned symbols.