### PR TITLE
ref-cache bug fixes and portablilty improvements

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,7 +28,7 @@ Updates
 * NEW. Add ref-cache, a caching proxy for reference sequences.  This is a local
   server of reference sequences, for use when encoding or decoding CRAM files
   that use reference-based compression.
-  (PR#1911)
+  (PR #1911, PR #1921)
 
 * Add support for matching VCF lines by ID.
   (PR #1844, addresses issue bcftools#1739 reported by Han Cao)

--- a/configure.ac
+++ b/configure.ac
@@ -707,6 +707,7 @@ return 0;])],
     [Define if epoll edge triggering is available])
 
   AC_CHECK_DECLS([EHOSTDOWN, ENONET], [], [], [[#include <errno.h>]])
+  AC_CHECK_DECLS([AI_V4MAPPED, AI_ADDRCONFIG], [], [], [[#include <netdb.h>]])
 
   # Test various compiler options, recommended by
   # https://github.com/ossf/wg-best-practices-os-developers/blob/main/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C%2B%2B.md

--- a/ref_cache/http_parser.c
+++ b/ref_cache/http_parser.c
@@ -234,7 +234,7 @@ static Read_result parser_read_input(Http_Parser *parser, int fd) {
         }
         return READ_BLOCKED;
     } else {
-        parser->in = (unsigned int) ((parser->in + res) & BUF_MASK);
+        parser->in = ((parser->in + (unsigned int) res) & BUF_MASK);
         parser->used += (unsigned int) res;
     }
 

--- a/ref_cache/listener.c
+++ b/ref_cache/listener.c
@@ -106,7 +106,10 @@ Listeners * get_listen_sockets(int port) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags = AI_PASSIVE|AI_NUMERICSERV|AI_ADDRCONFIG;
+    hints.ai_flags = AI_PASSIVE|AI_NUMERICSERV;
+#if defined(HAVE_DECL_AI_ADDRCONFIG) && HAVE_DECL_AI_ADDRCONFIG
+    hints.ai_flags |= AI_ADDRCONFIG;
+#endif
 
     snprintf(pnum, sizeof(pnum), "%d", port);
     res = getaddrinfo(NULL, pnum, &hints, &addr_list);

--- a/ref_cache/log_files.c
+++ b/ref_cache/log_files.c
@@ -24,6 +24,16 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <config.h>
 
+#if defined(__NetBSD__)
+// dirfd() is hidden if these are defined
+#  if defined(_XOPEN_SOURCE)
+#    undef _XOPEN_SOURCE
+#  endif
+#  if defined(_POSIX_C_SOURCE)
+#    undef _POSIX_C_SOURCE
+#  endif
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/ref_cache/log_files.c
+++ b/ref_cache/log_files.c
@@ -101,7 +101,7 @@ static int rotate_logs(Logfiles *logfiles, const Options *opts) {
     assert(opts->nlogs > 0);
     assert(logfiles->sz > opts->nlogs);
     for (i = opts->nlogs - 1U; i < logfiles->nlogs; i++) {
-        if (unlinkat(opts->log_dir_fd, logfiles->logs[i].name, 0) != 0) {
+        if (unlinkat(logfiles->log_dir_fd, logfiles->logs[i].name, 0) != 0) {
             fprintf(stderr, "Warning: Couldn't remove old log file %s/%s: %s\n",
                     opts->log_dir, logfiles->logs[i].name, strerror(errno));
         }

--- a/ref_cache/main.c
+++ b/ref_cache/main.c
@@ -354,7 +354,7 @@ static int handle_sigchld(Options *opts, Poll_wrap *pw) {
 }
 
 static Poll_wrap * init_poller(Options *opts) {
-    Poll_wrap *pw = pw_init();
+    Poll_wrap *pw = pw_init(opts->verbosity > 2);
     size_t k;
 
     if (pw == NULL) return NULL;

--- a/ref_cache/main.c
+++ b/ref_cache/main.c
@@ -190,9 +190,6 @@ static int set_up_child(Options *opts, int k, int is_upstream, Poll_wrap *pw) {
 
     if (pw != NULL) pw_close(pw);
 
-    if (opts->log_dir_fd != -1) {
-        close(opts->log_dir_fd);
-    }
     if (opts->log != stdout) {
         close(fileno(opts->log));
     }
@@ -932,7 +929,6 @@ int main(int argc, char **argv) {
     opts.max_kids = 1;
     opts.verbosity = 0;
     opts.log_dir = NULL;
-    opts.log_dir_fd = -1;
     opts.log = stdout;
     opts.match_addrs = NULL;
     opts.num_match_addrs = 0;

--- a/ref_cache/options.h
+++ b/ref_cache/options.h
@@ -62,7 +62,6 @@ struct Options {
     size_t      first_ip6;          // First ip6 range in sorted match_addrs
     off_t       max_log_sz;         // Size limit for log files in bytes
     int         cache_fd;           // File descriptor for cache_dir
-    int         log_dir_fd;         // File descriptor for log_dir
     int         listen_fds;         // Number of fds passed in by systemd
     DaemonType  daemon;             // Run as a daemon or socket service
     uint16_t    port;               // Port to listen on

--- a/ref_cache/ping.c
+++ b/ref_cache/ping.c
@@ -56,8 +56,13 @@ int check_running(int port_num) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_family   = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags    = AI_NUMERICSERV|AI_V4MAPPED|AI_ADDRCONFIG;
-
+    hints.ai_flags    = AI_NUMERICSERV;
+#if defined(HAVE_DECL_AI_V4MAPPED) && HAVE_DECL_AI_V4MAPPED
+    hints.ai_flags    |= AI_V4MAPPED;
+#endif
+#if defined(HAVE_DECL_AI_ADDRCONFIG) && HAVE_DECL_AI_ADDRCONFIG
+    hints.ai_flags    |= AI_ADDRCONFIG;
+#endif
     res = getaddrinfo(NULL, port, &hints, &addrs);
     if (res != 0) {
         fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(res));

--- a/ref_cache/poll_wrap.h
+++ b/ref_cache/poll_wrap.h
@@ -92,7 +92,7 @@ struct Pw_item {
     void *userp;
 };
 
-Poll_wrap *pw_init(void);
+Poll_wrap *pw_init(int debug);
 void pw_close(Poll_wrap *pw);
 Pw_item * pw_register(Poll_wrap *pw, int fd, Pw_fd_type fd_type,
                       uint32_t init_events, void *userp);

--- a/ref_cache/poll_wrap.h
+++ b/ref_cache/poll_wrap.h
@@ -58,9 +58,9 @@ typedef enum {
 #  define PW_HUP EPOLLHUP
 #  if defined(PW_HAVE_EDGE) && PW_HAVE_EDGE // Using configure
 #    define PW_EDGE EPOLLET
-#  elif defined(EPOLLET)
+#  elif !defined(PW_HAVE_EDGE) && defined(EPOLLET)
 #    define PW_EDGE EPOLLET
-#    define PW_HAVE_EDGE
+#    define PW_HAVE_EDGE 1
 #  else
 #    define PW_EDGE 0
 #  endif /* EPOLLET */

--- a/ref_cache/poll_wrap_epoll.c
+++ b/ref_cache/poll_wrap_epoll.c
@@ -41,11 +41,12 @@ DEALINGS IN THE SOFTWARE.  */
 #define INIT_EPOLL_SIZE 128
 
 struct Poll_wrap {
-  int epfd;
   pool_alloc_t *pool;
+  int epfd;
+  int debug;
 };
 
-Poll_wrap *pw_init(void) {
+Poll_wrap *pw_init(int debug) {
   Poll_wrap *pw = calloc(1, sizeof(Poll_wrap));
   if (pw == NULL) return NULL;
 
@@ -63,6 +64,8 @@ Poll_wrap *pw_init(void) {
     return NULL;
   }
 
+  pw->debug = debug;
+
   return pw;
 }
 
@@ -78,6 +81,11 @@ Pw_item * pw_register(Poll_wrap *pw, int fd, Pw_fd_type fd_type,
   Pw_item *item = pool_alloc(pw->pool);
   if (item == NULL)
       return NULL;
+
+  if (pw->debug) {
+      fprintf(stderr, "pw_register(%p, %d, %d, 0x%04x, %p)\n",
+              (void *) pw, fd, (int) fd_type, init_events, userp);
+  }
 
   item->fd      = fd;
   item->fd_type = fd_type;
@@ -98,6 +106,11 @@ Pw_item * pw_register(Poll_wrap *pw, int fd, Pw_fd_type fd_type,
 int pw_mod(Poll_wrap *pw, Pw_item *item, uint32_t events) {
   struct epoll_event event;
 
+  if (pw->debug) {
+      fprintf(stderr, "pw_mod(%p, %d, 0x%04x)\n",
+              (void *) pw, item->fd, events);
+  }
+
   event.events   = events;
   event.data.ptr = item;
 
@@ -113,6 +126,11 @@ int pw_wait(Poll_wrap *pw, Pw_events *events,
 int pw_remove(Poll_wrap *pw, Pw_item *item, int do_close) {
   struct epoll_event dummy;
   int res;
+
+  if (pw->debug) {
+      fprintf(stderr, "pw_remove(%p, %d%s)\n",
+              (void *) pw, item->fd, do_close ? ", close" : "");
+  }
 
   if (do_close) {
     res = close(item->fd);

--- a/ref_cache/poll_wrap_epoll.c
+++ b/ref_cache/poll_wrap_epoll.c
@@ -41,104 +41,104 @@ DEALINGS IN THE SOFTWARE.  */
 #define INIT_EPOLL_SIZE 128
 
 struct Poll_wrap {
-  pool_alloc_t *pool;
-  int epfd;
-  int debug;
+    pool_alloc_t *pool;
+    int epfd;
+    int debug;
 };
 
 Poll_wrap *pw_init(int debug) {
-  Poll_wrap *pw = calloc(1, sizeof(Poll_wrap));
-  if (pw == NULL) return NULL;
+    Poll_wrap *pw = calloc(1, sizeof(Poll_wrap));
+    if (pw == NULL) return NULL;
 
-  pw->pool = pool_create(sizeof(Pw_item));
-  if (pw->pool == NULL) {
-    free(pw);
-    return NULL;
-  }
+    pw->pool = pool_create(sizeof(Pw_item));
+    if (pw->pool == NULL) {
+        free(pw);
+        return NULL;
+    }
 
-  pw->epfd = epoll_create(INIT_EPOLL_SIZE);
-  if (pw->epfd < 0) {
-    perror("epoll_create");
-    pool_destroy(pw->pool);
-    free(pw);
-    return NULL;
-  }
+    pw->epfd = epoll_create(INIT_EPOLL_SIZE);
+    if (pw->epfd < 0) {
+        perror("epoll_create");
+        pool_destroy(pw->pool);
+        free(pw);
+        return NULL;
+    }
 
-  pw->debug = debug;
+    pw->debug = debug;
 
-  return pw;
+    return pw;
 }
 
 void pw_close(Poll_wrap *pw) {
-  close(pw->epfd);
-  pool_destroy(pw->pool);
-  free(pw);
+    close(pw->epfd);
+    pool_destroy(pw->pool);
+    free(pw);
 }
 
 Pw_item * pw_register(Poll_wrap *pw, int fd, Pw_fd_type fd_type,
                       uint32_t init_events, void *userp) {
-  struct epoll_event event;
-  Pw_item *item = pool_alloc(pw->pool);
-  if (item == NULL)
-      return NULL;
+    struct epoll_event event;
+    Pw_item *item = pool_alloc(pw->pool);
+    if (item == NULL)
+        return NULL;
 
-  if (pw->debug) {
-      fprintf(stderr, "pw_register(%p, %d, %d, 0x%04x, %p)\n",
-              (void *) pw, fd, (int) fd_type, init_events, userp);
-  }
+    if (pw->debug) {
+        fprintf(stderr, "pw_register(%p, %d, %d, 0x%04x, %p)\n",
+                (void *) pw, fd, (int) fd_type, init_events, userp);
+    }
 
-  item->fd      = fd;
-  item->fd_type = fd_type;
-  item->userp   = userp;
+    item->fd      = fd;
+    item->fd_type = fd_type;
+    item->userp   = userp;
 
-  event.events = init_events;
-  event.data.ptr = item;
+    event.events = init_events;
+    event.data.ptr = item;
 
-  if (epoll_ctl(pw->epfd, EPOLL_CTL_ADD, fd, &event) != 0) {
-    perror("epoll_ctl");
-    pool_free(pw->pool, item);
-    return NULL;
-  }
+    if (epoll_ctl(pw->epfd, EPOLL_CTL_ADD, fd, &event) != 0) {
+        perror("epoll_ctl");
+        pool_free(pw->pool, item);
+        return NULL;
+    }
 
-  return item;
+    return item;
 }
 
 int pw_mod(Poll_wrap *pw, Pw_item *item, uint32_t events) {
-  struct epoll_event event;
+    struct epoll_event event;
 
-  if (pw->debug) {
-      fprintf(stderr, "pw_mod(%p, %d, 0x%04x)\n",
-              (void *) pw, item->fd, events);
-  }
+    if (pw->debug) {
+        fprintf(stderr, "pw_mod(%p, %d, 0x%04x)\n",
+                (void *) pw, item->fd, events);
+    }
 
-  event.events   = events;
-  event.data.ptr = item;
+    event.events   = events;
+    event.data.ptr = item;
 
-  return epoll_ctl(pw->epfd, EPOLL_CTL_MOD, item->fd, &event);
+    return epoll_ctl(pw->epfd, EPOLL_CTL_MOD, item->fd, &event);
 }
 
 int pw_wait(Poll_wrap *pw, Pw_events *events,
-        int max_events, int timeout) {
-  return epoll_wait(pw->epfd, (struct epoll_event *) events,
-            max_events, timeout);
+            int max_events, int timeout) {
+    return epoll_wait(pw->epfd, (struct epoll_event *) events,
+                      max_events, timeout);
 }
 
 int pw_remove(Poll_wrap *pw, Pw_item *item, int do_close) {
-  struct epoll_event dummy;
-  int res;
+    struct epoll_event dummy;
+    int res;
 
-  if (pw->debug) {
-      fprintf(stderr, "pw_remove(%p, %d%s)\n",
-              (void *) pw, item->fd, do_close ? ", close" : "");
-  }
+    if (pw->debug) {
+        fprintf(stderr, "pw_remove(%p, %d%s)\n",
+                (void *) pw, item->fd, do_close ? ", close" : "");
+    }
 
-  if (do_close) {
-    res = close(item->fd);
-  } else {
-    res = epoll_ctl(pw->epfd, EPOLL_CTL_DEL, item->fd, &dummy);
-  }
-  pool_free(pw->pool, item);
-  return res;
+    if (do_close) {
+        res = close(item->fd);
+    } else {
+        res = epoll_ctl(pw->epfd, EPOLL_CTL_DEL, item->fd, &dummy);
+    }
+    pool_free(pw->pool, item);
+    return res;
 }
 #else
 // Prevent "empty translation unit" errors

--- a/ref_cache/poll_wrap_poll.c
+++ b/ref_cache/poll_wrap_poll.c
@@ -205,6 +205,8 @@ int pw_wait(Poll_wrap *pw, Pw_events *events,
 }
 
 int pw_remove(Poll_wrap *pw, Pw_item *item, int do_close) {
+    int fd = item->fd;
+
     if (item->fd < 0 || (unsigned int) item->fd >= pw->idx_sz
         || pw->item_index[item->fd] == NULL) {
         errno = ENOENT;
@@ -215,7 +217,7 @@ int pw_remove(Poll_wrap *pw, Pw_item *item, int do_close) {
     pw->need_compact = 1;
     pool_free(pw->pool, item);
     if (!do_close) return 0;
-    return close(item->fd);
+    return close(fd);
 }
 #else
 // Prevent "empty translation unit" errors

--- a/ref_cache/request_handler.c
+++ b/ref_cache/request_handler.c
@@ -93,7 +93,7 @@ static char * decode_uri(Http_Parser *parser) {
 
 static void handle_hello(Transaction *transact) {
     const char *resp = "Hello\r\n";
-    set_message_response(transact, text_plain, resp, sizeof(resp) - 1);
+    set_message_response(transact, text_plain, resp, strlen(resp));
 }
 
 static void handle_md5(const Options *opts, Http_Parser *parser,

--- a/ref_cache/server.c
+++ b/ref_cache/server.c
@@ -733,7 +733,7 @@ int run_poll_loop(const Options *opts, Listeners *lsocks,
         return -1;
     }
 
-    pw = pw_init();
+    pw = pw_init(opts->verbosity > 2);
     if (pw == NULL) {
         perror("Initializing poller");
         return -1;

--- a/ref_cache/transaction.c
+++ b/ref_cache/transaction.c
@@ -563,8 +563,9 @@ static inline ssize_t send_file(Transaction *transact, int out_fd, int in_fd,
                      || errno == EAGAIN || errno == EWOULDBLOCK));
         if (bytes < 0)
             return -1;
-        transact->buffer_in = (transact->buffer_in + bytes) & SEND_BUFFER_MASK;
-        buffered += bytes;
+        transact->buffer_in = ((transact->buffer_in + (unsigned int) bytes)
+                               & SEND_BUFFER_MASK);
+        buffered += (unsigned int) bytes;
         count -= bytes;
         assert(count >= 0);
 
@@ -594,7 +595,8 @@ static inline ssize_t send_file(Transaction *transact, int out_fd, int in_fd,
         if (bytes < 0)
             return -1;
         transact->fd_sent += bytes;
-        transact->buffer_out = (transact->buffer_out + bytes) & SEND_BUFFER_MASK;
+        transact->buffer_out = ((transact->buffer_out + (unsigned int) bytes)
+                                & SEND_BUFFER_MASK);
         if (bytes > 0)
             transact->flags &= ~TRANSACT_SEND_BUFFER_FULL;
 

--- a/ref_cache/upstream.c
+++ b/ref_cache/upstream.c
@@ -24,7 +24,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <config.h>
 
-#if defined(__APPLE__) && defined(__MACH__)
+#if (defined(__APPLE__) && defined(__MACH__)) || defined(__NetBSD__)
 // macOS headers hide CMSG_LEN() and CMSG_SPACE() definitions if these
 // are defined
 #  if defined(_XOPEN_SOURCE)

--- a/ref_cache/upstream.c
+++ b/ref_cache/upstream.c
@@ -130,9 +130,13 @@ static int handle_curl_socket(CURLM *multi, Multi_data *mdata,
                               int events, int fd);
 
 int upstream_send_cmd(int cmd_fd, const char hexmd5[MD5_LEN], unsigned int id) {
-    struct msghdr msg = { NULL, 0, NULL, 0, NULL, 0, 0 };
-    struct iovec   iov[2];
+    struct msghdr msg;
+    struct iovec  iov[2];
     ssize_t res;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_name = NULL;
+    msg.msg_control = NULL;
 
     /* The MD5 for the reference we want */
     iov[0].iov_base   = (void *) hexmd5;
@@ -151,8 +155,12 @@ int upstream_send_cmd(int cmd_fd, const char hexmd5[MD5_LEN], unsigned int id) {
 
 static ssize_t recv_cmd_data(int cmd_fd, char hexmd5[MD5_LEN], unsigned int *id) {
     ssize_t res;
-    struct msghdr msg = { NULL, 0, NULL, 0, NULL, 0, 0 };
-    struct iovec   iov[2];
+    struct msghdr msg;
+    struct iovec  iov[2];
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_name = NULL;
+    msg.msg_control = NULL;
 
     iov[0].iov_base   = hexmd5;
     iov[0].iov_len    = MD5_LEN;
@@ -174,10 +182,14 @@ static ssize_t recv_cmd_data(int cmd_fd, char hexmd5[MD5_LEN], unsigned int *id)
 static int upstream_send_msg(int cmd_fd, Upstream_msg *umsg, int fd) {
     ssize_t res;
     struct iovec iov[1];
-    struct msghdr msg = { NULL, 0, NULL, 0, NULL, 0, 0 };
+    struct msghdr msg;
     struct cmsghdr *cmsg;
     char   buf[CMSG_SPACE(sizeof(int))];
     int   *fdptr;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_name = NULL;
+    msg.msg_control = NULL;
 
     iov[0].iov_base = umsg;
     iov[0].iov_len  = sizeof(*umsg);
@@ -216,11 +228,15 @@ static int send_msg_all(Download *download,
 }
 
 int upstream_recv_msg(int cmd_fd, Upstream_msg *umsg, int *fd) {
-    struct msghdr msg = { NULL, 0, NULL, 0, NULL, 0, 0 };
+    struct msghdr msg;
     struct cmsghdr *cmsg = NULL;
     struct iovec   iov[1];
     ssize_t res;
     char   buf[16384];
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_name = NULL;
+    msg.msg_control = NULL;
 
     iov[0].iov_base   = umsg;
     iov[0].iov_len    = sizeof(*umsg);

--- a/ref_cache/upstream.c
+++ b/ref_cache/upstream.c
@@ -861,7 +861,7 @@ static CURLM *get_multi(Multi_data *mdata) {
 static int init_multi_data(CURLM *multi, Multi_data *mdata) {
     unsigned int i;
     mdata->multi     = multi;
-    mdata->pw        = pw_init();
+    mdata->pw        = pw_init(0);
     if (mdata->pw == NULL) {
         perror("Initalizing poller");
         return -1;


### PR DESCRIPTION
Fixes a log rotation bug, and a number of others discovered when testing on 32-bit NetBSD and alpine.

* Deal with alternate layouts for `struct msghdr`
* Unhide some symbols that disappear when `_X_OPEN_SOURCE` is set.
* Add configure checks for `AI_V4MAPPED` and `AI_ADDRCONFIG`
* Fix a use after poll_free() bug in the `poll()` based poller.
* Fix the length of the response string in `handle_hello()`
* Add poll debugging printfs
* Fix poll bugs that could cause event loop spinning, or transactions becoming deadlocked when not using edge triggered `epoll()`.
* Fix type casts to silence signed-compare warnings.

There is still one warning when compiling on alpine due to a signed compare issue in musl libc's definition of `CMSG_NXTHDR`.  As this is in the musl header files, it cannot be fixed here.