### PR TITLE
Change optimisation for -fsanitize=address,undefined test build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,7 +76,7 @@ gcc_task:
     - environment:
        USE_CONFIG: yes
        # ubsan is incompatible with some -Wformat opts so we do that on clang.
-       CFLAGS: -g -O3 -fsanitize=address,undefined -DHTS_ALLOW_UNALIGNED=0 -Wno-format-truncation -Wno-format-overflow
+       CFLAGS: -g -Og -fsanitize=address,undefined -DHTS_ALLOW_UNALIGNED=0 -Wno-format-truncation -Wno-format-overflow
        LDFLAGS: -fsanitize=address,undefined
        USE_LIBDEFLATE: yes
        UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1


### PR DESCRIPTION
Combining `-O3` with `-fsanitize=address,undefined` leads to slow builds and high compiler memory consumption.  Speed up compilation by switching to `-Og`.  Even though less optimisation is done, tests still run at an acceptable speed and the total run time is faster.