### PR TITLE
Suppress a curl_easy_setopt() warning in ref_cache code

### DIFF
--- a/ref_cache/upstream.c
+++ b/ref_cache/upstream.c
@@ -866,7 +866,7 @@ static int init_multi_data(CURLM *multi, Multi_data *mdata) {
                     curl_easy_strerror(cc));
             goto fail;
         }
-        cc = curl_easy_setopt(mdata->curls[i], CURLOPT_NOPROGRESS, 0);
+        cc = curl_easy_setopt(mdata->curls[i], CURLOPT_NOPROGRESS, 0L);
 #if LIBCURL_VERSION_NUM >= 0x072000 // 7.32.0
         cc = curl_easy_setopt(mdata->curls[i],
                               CURLOPT_XFERINFOFUNCTION, progress_callback);


### PR DESCRIPTION
Avoids a warning with a recent enough libcurl that uses GCC extensions to type-check `curl_easy_setopt()` usage:

```
In file included from ref_cache/upstream.c:30:
In function 'init_multi_data',
    inlined from 'run_multi_upstream_handler' at ref_cache/upstream.c:1140:9,
    inlined from 'run_upstream_handler' at ref_cache/upstream.c:1184:11:
ref_cache/upstream.c:869:14: warning: call to '_curl_easy_setopt_err_long' declared with
    attribute warning: curl_easy_setopt expects a long argument [-Wattribute-warning]
  869 |         cc = curl_easy_setopt(mdata->curls[i], CURLOPT_NOPROGRESS, 0);
      |              ^~~~~~~~~~~~~~~~
```

----

In case others report similar difficulties, you may also be interested in the workarounds that bioconda had to apply to get the new ref_cache code to compile with their elderly OS SDKs: (cf bioconda/bioconda-recipes#56518):

* glibc 2.17 (which conda still uses) needs help to define `struct in6_addr` correctly ([BZ16421](https://sourceware.org/bugzilla/show_bug.cgi?id=16421))
* the macOS SDK shipped with Xcode 15.4 needs help to define `O_DIRECTORY` correctly

You could perhaps work around the latter by putting

```c
#ifndef O_DIRECTORY
#define O_DIRECTORY  0
#endif
```

near the top of _ref_cache/main.c_, but this seems a fairly niche problem so that may not be worthwhile.