### PR TITLE
Fix compilation against older glibc / macOS SDK

### DIFF
--- a/ref_cache/main.c
+++ b/ref_cache/main.c
@@ -24,6 +24,12 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <config.h>
 
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+// Work around older MacOS SDKs which hid O_DIRECTORY if _POSIX_C_SOURCE
+// or _XOPEN_SOURCE are defined.
+#define _DARWIN_C_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/ref_cache/server.c
+++ b/ref_cache/server.c
@@ -233,8 +233,11 @@ static int check_addr_allowed(const Options *opts, sa_family_t family,
         start = 0;
         end = opts->first_ip6;
     } else if (family == AF_INET6 && addrlen == sizeof(struct sockaddr_in6)) {
+        const uint8_t v4mapped_prefix[12] = {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff
+        };
         addrp = (const uint8_t *) &addr->in6.sin6_addr;
-        if (IN6_IS_ADDR_V4MAPPED(&addr->in6.sin6_addr)) {
+        if (memcmp(addrp, v4mapped_prefix, sizeof(v4mapped_prefix)) == 0) {
             // V4MAPPED addresses are really IPv4, with the mapped address
             // in the last four bytes
             family = AF_INET;


### PR DESCRIPTION
Work around problems caused by symbols being hidden when defining `_POSIX_C_SOURCE` or `_XOPEN_SOURCE`:

* The `IN6_IS_ADDR_V4MAPPED` macro fails to compile on glibc before 2.25.  Fix by avoiding it and using `memcmp()` to match the prefix it detects instead.
* macOS SDKs before 12.0 hid `O_DIRECTORY`.  Fix by defining `_DARWIN_C_SOURCE` to get it back.

Thanks to @jmarshall for spotting these problems, which affected Conda builds even on modern systems.

Replaces and closes #1927