### PR TITLE
Fix typo in ref-cache configure check for libcurl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -645,7 +645,7 @@ AS_IF([test "x$enable_ref_cache" != xno],
   [AS_CASE([$PLATFORM],
      [Darwin | default],[
         AS_IF([test "x$libcurl" = xenabled], [ref_cache="enabled"], [
-          AS_IF([test "x$enable_ref_cache" = check], [
+          AS_IF([test "x$enable_ref_cache" = xcheck], [
             AC_MSG_WARN([ref-cache not enabled: requires libcurl])
           ],[
             MSG_ERROR([ref-cache not enabled


### PR DESCRIPTION
Fix typo that incorrectly made configure report an error about not being able to build ref-cache if libcurl was not available. If ref-cache is not explicitly requested, it should just print a warning.

Fixes #1926 