### PR TITLE
Improved error handling in cram_compress_block2.

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -3575,6 +3575,8 @@ static int cram_byte_array_stop_decode_char(cram_slice *slice, cram_codec *c,
 
     cp = (char *)b->data + b->idx;
     if (out) {
+        // FIXME: Add check for out overflow.  Maybe using *out_size
+        // as a maximum size?  Similarly for other variable sized decodes
         while ((ch = *cp) != (char)c->u.byte_array_stop.stop) {
             if (cp - (char *)b->data >= b->uncomp_size)
                 return -1;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -2249,8 +2249,20 @@ int cram_compress_block2(cram_fd *fd, cram_slice *s,
                                            b->content_id, &comp_size, method,
                                            method == GZIP_1 ? 1 : level,
                                            strat);
-            if (!comp)
+            if (!comp) {
+                // Our cached best method failed, but maybe another works?
+                // Rerun with trial mode engaged again.
+                if (metrics && metrics->trial == 0) {
+                    hts_log_info("Compressed block ID %d method %s failed, "
+                                 "redoing trial",
+                                 b->content_id, cram_block_method2str(method));
+                    metrics->trial = NTRIALS;
+                    metrics->next_trial = TRIAL_SPAN;
+                    return cram_compress_block2(fd, s, b, metrics, method,
+                                                level);
+                }
                 return -1;
+            }
 
             if (comp_size < b->uncomp_size) {
                 free(b->data);


### PR DESCRIPTION
If we learn a method is good to use but that method subsequently fails to encode, we don't just fail in cram_compress_block2 any more. Instead we restart the trial / adaption technique again to learn what works instead.

This fixes an issue in CRAM encoding when we attempted to SIMD rANS encode a block of Ns, but after RLE is applied the resultant buffer was too small for SIMD to work.  (Also fixed in htscodecs)

Seen with long data which starts off with sequences, tuning soft-clip SC series to rans.  This then switches to long-read data with seq `*`, but still having soft-clips.  Due to an oddity of CRAM feature codes we still need to encode a sequence for the S CIGAR op, so this is all "N"s for seq `*` .  Ufortunately this caused rANS SIMD to fail.  (See https://github.com/samtools/htscodecs/pull/137)