### PR TITLE
For the VCF rlen calculation, only use SVLEN for DEL, DUP and CNV symbolic alleles

### DIFF
--- a/tbx.c
+++ b/tbx.c
@@ -187,17 +187,13 @@ int tbx_parse1(const tbx_conf_t *conf, size_t len, char *line, tbx_intv_t *intv)
                             if (t) {
                                 *t = 0;
                             }
-                            if (s[0] == '<') {
-                                if (!strcmp("<DEL>", s)  // note deletions
-                                    || !strcmp("<DUP>", s) // and DUPs
-                                    || !strcmp("<CNV>", s)
-                                    || !strncmp("<CNV:", s, 5)) { // and CNVs
-                                    svlenals[lastbyte] |= 1 << ((alcnt - 1) & 7);
-                                    use_svlen = 1;
-                                } else if (!strcmp("<*>", s) ||
-                                    !strcmp("<NON_REF>", s)) {  //note gvcf
-                                    getlen = 1;
-                                }
+                            if (svlen_on_ref_for_vcf_alt(s, -1)) {
+                                // Need to check SVLEN for this ALT
+                                svlenals[lastbyte] |= 1 << ((alcnt - 1) & 7);
+                                use_svlen = 1;
+                            } else if (!strcmp("<*>", s) ||
+                                       !strcmp("<NON_REF>", s)) {  //note gvcf
+                                getlen = 1;
                             }
                             if (t) {
                                 *t = ',';

--- a/tbx.c
+++ b/tbx.c
@@ -96,9 +96,9 @@ int tbx_name2id(tbx_t *tbx, const char *ss)
 int tbx_parse1(const tbx_conf_t *conf, size_t len, char *line, tbx_intv_t *intv)
 {
     size_t i, b = 0;
-    int id = 1, getlen = 0, alcnt = 0, havedel = 0, lenpos = -1;
+    int id = 1, getlen = 0, alcnt = 0, use_svlen = 0, lenpos = -1;
     char *s, *t;
-    uint8_t delals[8192];
+    uint8_t svlenals[8192];
     int64_t reflen = 0, svlen = 0, fmtlen = 0, tmp = 0;
 
     intv->ss = intv->se = 0; intv->beg = intv->end = -1;
@@ -174,23 +174,26 @@ int tbx_parse1(const tbx_conf_t *conf, size_t len, char *line, tbx_intv_t *intv)
                         reflen = i - b;
                     } if (id == 5) {    //alt allele
                         int lastbyte = 0, c = line[i];
-                        delals[lastbyte] = 0;
+                        svlenals[lastbyte] = 0;
                         line[i] = 0;
                         s = line + b;
                         do {
                             t = strchr(s, ',');
                             if (alcnt >> 3 != lastbyte) {   //initialize insals
                                 lastbyte = alcnt >> 3;
-                                delals[lastbyte] = 0;
+                                svlenals[lastbyte] = 0;
                             }
                             ++alcnt;
                             if (t) {
                                 *t = 0;
                             }
                             if (s[0] == '<') {
-                                if (!strcmp("<DEL>", s)) {  //note deletions
-                                    delals[lastbyte] |= 1 << ((alcnt - 1) & 7);
-                                    havedel = 1;
+                                if (!strcmp("<DEL>", s)  // note deletions
+                                    || !strcmp("<DUP>", s) // and DUPs
+                                    || !strcmp("<CNV>", s)
+                                    || !strncmp("<CNV:", s, 5)) { // and CNVs
+                                    svlenals[lastbyte] |= 1 << ((alcnt - 1) & 7);
+                                    use_svlen = 1;
                                 } else if (!strcmp("<*>", s) ||
                                     !strcmp("<NON_REF>", s)) {  //note gvcf
                                     getlen = 1;
@@ -237,7 +240,7 @@ int tbx_parse1(const tbx_conf_t *conf, size_t len, char *line, tbx_intv_t *intv)
                         }
                         while (s && d < alcnt) {
                             t = strchr(s, ',');
-                            if ((havedel) && (delals[d >> 3] & (1 << (d & 7)))) {
+                            if ((use_svlen) && (svlenals[d >> 3] & (1 << (d & 7)))) {
                                 // <DEL> symbolic allele
                                 tmp = atoll(s);
                                 tmp = tmp < 0 ? llabs(tmp) : tmp;

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -671,6 +671,7 @@ void test_rlen_values(void)
     "##INFO=<ID=END,Number=1,Type=Integer,Description=\"end\">\n" \
     "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"gt\">\n" \
     "##INFO=<ID=SVLEN,Number=A,Type=Integer,Description=\"svlen\">\n" \
+    "##INFO=<ID=CN,Number=A,Type=Float,Description=\"Copy number\">\n" \
     "##INFO=<ID=SVCLAIM,Number=A,Type=String,Description=\"svclaim\">\n" \
     "##FORMAT=<ID=LEN,Number=1,Type=Integer,Description=\"fmt len\">\n" \
     "##contig=<ID=1,Length=40>\n" \
@@ -690,9 +691,12 @@ void test_rlen_values(void)
     "1\t4370\t.\tG\t<INS>,<*>\t213.73\t.\tEND=4371;SVLEN=.;SVCLAIM=.\tGT:LEN\t0/1:7\t0|0:.\n" \
     "1\t4378\t.\tG\t<DEL>,<INS>,<*>\t213.73\t.\tEND=4379;SVLEN=3,5,.;SVCLAIM=D,J,.\tGT:LEN\t0/1:7\t0|0:.\n" \
     "1\t4385\t.\tG\tT,<DEL>\t213.73\t.\tEND=4387;SVLEN=.,180\tGT\t0/1\t0|0\n" \
-    "1\t4585\t.\tG\tT,<*>\t213.73\t.\tEND=4587\tGT:LEN\t0/1:190\t0|0:.\n" \
-    "1\t4785\t.\tG\tT\t213.73\t.\tEND=4787;SVLEN=8;SVCLAIM=.\tGT:LEN\t0/1:.\t0|0:10\n"
-    // For the last line, SVLEN should be ignored as the allele is not <DEL>
+    "1\t4585\t.\tG\t<DUP>,<DUP>\t213.73\t.\tEND=4587;SVLEN=10,10\tGT\t0/1\t0|0\n" \
+    "1\t4605\t.\tG\t<CNV>\t213.73\t.\tEND=4607;SVLEN=11;CN=2\tGT\t0/1\t0|0\n" \
+    "1\t4625\t.\tG\t<CNV:TR>\t213.73\t.\tEND=4627;SVLEN=12;CN=1.5\tGT\t0/1\t0|0\n" \
+    "1\t4785\t.\tG\tT,<*>\t213.73\t.\tEND=4787\tGT:LEN\t0/1:190\t0|0:.\n" \
+    "1\t5785\t.\tG\tT\t213.73\t.\tEND=5787;SVLEN=8;SVCLAIM=.\tGT:LEN\t0/1:.\t0|0:10\n"
+    // For the last line, SVLEN should be ignored as the allele is not symbolic
     // and LEN should be ignored as there is no <*> allele.  The END tag will
     // be used as it's higher than POS + length of REF.
 
@@ -705,11 +709,11 @@ void test_rlen_values(void)
     static char d45[] = "data:,"
     "##fileformat=VCFv4.5\n" data;
     /* ideal expected rlen for tests
-    int rlen43[] = {1, 1, 2, 1, 1, 1, 11, 5, 5, 5, 2, 2, 3, 3, 3};
-    int rlen44[] = {1, 1, 2, 1, 11, 1, 11, 5, 5, 5, 2, 4, 181, 190, 3};
-    int rlen45[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 190, 3};*/
+    int rlen43[] = {1, 1, 2, 1, 1, 1, 11, 5, 5, 5, 2, 2, 3, 3, 3, 3, 3, 3};
+    int rlen44[] = {1, 1, 2, 1, 11, 1, 11, 5, 5, 5, 2, 4, 181, 11, 12, 13, 3, 3};
+    int rlen45[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 11, 12, 13, 190, 3};*/
     // but we dont check version and hence resulting rlen should be
-    int rlen[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 190, 3};
+    int rlen[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 11, 12, 13, 190, 3};
 
     const int vcfsz = sizeof(rlen)/sizeof(rlen[0]);
 

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -689,12 +689,15 @@ void test_rlen_values(void)
     "1\t4363\t.\tG\t<*>\t213.73\t.\tEND=4367;SVLEN=.;SVCLAIM=.\tGT:LEN\t0/1:7\t0|0:.\n" \
     "1\t4370\t.\tG\t<INS>,<*>\t213.73\t.\tEND=4371;SVLEN=.;SVCLAIM=.\tGT:LEN\t0/1:7\t0|0:.\n" \
     "1\t4378\t.\tG\t<DEL>,<INS>,<*>\t213.73\t.\tEND=4379;SVLEN=3,5,.;SVCLAIM=D,J,.\tGT:LEN\t0/1:7\t0|0:.\n" \
-    "1\t4385\t.\tG\tT\t213.73\t.\tEND=4387;SVLEN=8;SVCLAIM=.\tGT:LEN\t0/1:.\t0|0:10\n"
-    //this last one is invalid one, to showcase how SVLEN is considered even when ALT is no SV
-    //this is because data are not cross checked with allele types, to make it simple
+    "1\t4385\t.\tG\tT,<DEL>\t213.73\t.\tEND=4387;SVLEN=.,180\tGT\t0/1\t0|0\n" \
+    "1\t4585\t.\tG\tT,<*>\t213.73\t.\tEND=4587\tGT:LEN\t0/1:190\t0|0:.\n" \
+    "1\t4785\t.\tG\tT\t213.73\t.\tEND=4787;SVLEN=8;SVCLAIM=.\tGT:LEN\t0/1:.\t0|0:10\n"
+    // For the last line, SVLEN should be ignored as the allele is not <DEL>
+    // and LEN should be ignored as there is no <*> allele.  The END tag will
+    // be used as it's higher than POS + length of REF.
 
     //test vcf with different versions
-    const int vcfsz = 13, testsz = 3;
+    const int testsz = 3;
     static char d43[] = "data:,"
     "##fileformat=VCFv4.3\n" data;
     static char d44[] = "data:,"
@@ -702,11 +705,13 @@ void test_rlen_values(void)
     static char d45[] = "data:,"
     "##fileformat=VCFv4.5\n" data;
     /* ideal expected rlen for tests
-    int rlen43[] = {1, 1, 2, 1, 1, 1, 11, 5, 5, 5, 2, 2, 3};
-    int rlen44[] = {1, 1, 2, 1, 11, 1, 11, 5, 5, 5, 2, 4, 9};
-    int rlen45[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 9};*/
+    int rlen43[] = {1, 1, 2, 1, 1, 1, 11, 5, 5, 5, 2, 2, 3, 3, 3};
+    int rlen44[] = {1, 1, 2, 1, 11, 1, 11, 5, 5, 5, 2, 4, 181, 190, 3};
+    int rlen45[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 190, 3};*/
     // but we dont check version and hence resulting rlen should be
-    int rlen[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 9};
+    int rlen[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 190, 3};
+
+    const int vcfsz = sizeof(rlen)/sizeof(rlen[0]);
 
     char *darr[] = {&d43[0], &d44[0], &d45[0]};     //data array
     int *rarr[] = {&rlen[0], &rlen[0], &rlen[0]};   //result array

--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -691,11 +691,13 @@ void test_rlen_values(void)
     "1\t4370\t.\tG\t<INS>,<*>\t213.73\t.\tEND=4371;SVLEN=.;SVCLAIM=.\tGT:LEN\t0/1:7\t0|0:.\n" \
     "1\t4378\t.\tG\t<DEL>,<INS>,<*>\t213.73\t.\tEND=4379;SVLEN=3,5,.;SVCLAIM=D,J,.\tGT:LEN\t0/1:7\t0|0:.\n" \
     "1\t4385\t.\tG\tT,<DEL>\t213.73\t.\tEND=4387;SVLEN=.,180\tGT\t0/1\t0|0\n" \
-    "1\t4585\t.\tG\t<DUP>,<DUP>\t213.73\t.\tEND=4587;SVLEN=10,10\tGT\t0/1\t0|0\n" \
-    "1\t4605\t.\tG\t<CNV>\t213.73\t.\tEND=4607;SVLEN=11;CN=2\tGT\t0/1\t0|0\n" \
-    "1\t4625\t.\tG\t<CNV:TR>\t213.73\t.\tEND=4627;SVLEN=12;CN=1.5\tGT\t0/1\t0|0\n" \
-    "1\t4785\t.\tG\tT,<*>\t213.73\t.\tEND=4787\tGT:LEN\t0/1:190\t0|0:.\n" \
-    "1\t5785\t.\tG\tT\t213.73\t.\tEND=5787;SVLEN=8;SVCLAIM=.\tGT:LEN\t0/1:.\t0|0:10\n"
+    "1\t4585\t.\tG\tT,<DEL:ME>\t213.73\t.\tEND=4587;SVLEN=.,180\tGT\t0/1\t0|0\n" \
+    "1\t4685\t.\tG\t<DUP>,<DUP>\t213.73\t.\tEND=4687;SVLEN=10,10\tGT\t0/1\t0|0\n" \
+    "1\t4705\t.\tG\t<CNV>\t213.73\t.\tEND=4707;SVLEN=11;CN=2\tGT\t0/1\t0|0\n" \
+    "1\t4725\t.\tG\t<CNV:TR>\t213.73\t.\tEND=4727;SVLEN=12;CN=1.5\tGT\t0/1\t0|0\n" \
+    "1\t4745\t.\tG\t<INV>\t213.73\t.\tEND=4747;SVLEN=10\tGT\t0/1\t0|0\n" \
+    "1\t4885\t.\tG\tT,<*>\t213.73\t.\tEND=4887\tGT:LEN\t0/1:190\t0|0:.\n" \
+    "1\t5885\t.\tG\tT\t213.73\t.\tEND=5887;SVLEN=8;SVCLAIM=.\tGT:LEN\t0/1:.\t0|0:10\n"
     // For the last line, SVLEN should be ignored as the allele is not symbolic
     // and LEN should be ignored as there is no <*> allele.  The END tag will
     // be used as it's higher than POS + length of REF.
@@ -709,11 +711,11 @@ void test_rlen_values(void)
     static char d45[] = "data:,"
     "##fileformat=VCFv4.5\n" data;
     /* ideal expected rlen for tests
-    int rlen43[] = {1, 1, 2, 1, 1, 1, 11, 5, 5, 5, 2, 2, 3, 3, 3, 3, 3, 3};
-    int rlen44[] = {1, 1, 2, 1, 11, 1, 11, 5, 5, 5, 2, 4, 181, 11, 12, 13, 3, 3};
-    int rlen45[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 11, 12, 13, 190, 3};*/
+    int rlen43[] = {1, 1, 2, 1, 1, 1, 11, 5, 5, 5, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3};
+    int rlen44[] = {1, 1, 2, 1, 11, 1, 11, 5, 5, 5, 2, 4, 181, 181, 11, 12, 13, 11, 3, 3};
+    int rlen45[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 181, 11, 12, 13, 11, 190, 3};*/
     // but we dont check version and hence resulting rlen should be
-    int rlen[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 11, 12, 13, 190, 3};
+    int rlen[] = {1, 1, 2, 1, 11, 1, 11, 8, 7, 7, 7, 7, 181, 181, 11, 12, 13, 11, 190, 3};
 
     const int vcfsz = sizeof(rlen)/sizeof(rlen[0]);
 

--- a/vcf.c
+++ b/vcf.c
@@ -6169,12 +6169,12 @@ static int64_t get_rlen(const bcf_hdr_t *h, bcf1_t *v)
 {
     uint8_t *f = (uint8_t*)v->shared.s, *t = NULL,
         *e = (uint8_t*)v->shared.s + v->shared.l;
-    int size, type, id, lenid, endid, svlenid, i, bad, gvcf = 0, haveins = 0;
+    int size, type, id, lenid, endid, svlenid, i, bad, gvcf = 0, havedel = 0;
     bcf_info_t *endinfo = NULL, *svleninfo = NULL, end_lcl, svlen_lcl;
     bcf_fmt_t *lenfmt = NULL, len_lcl;
 
-    //holds <ins> allele status for the max no of alleles
-    uint8_t insals[8192];
+    //holds <DEL> allele status for the max no of alleles
+    uint8_t delals[8192];
     //pos from info END, fmt LEN, info SVLEN
     hts_pos_t end = 0, end_fmtlen = 0, end_svlen = 0, hpos;
     int64_t len_ref = 0, len = 0, tmp;
@@ -6183,16 +6183,16 @@ static int64_t get_rlen(const bcf_hdr_t *h, bcf1_t *v)
     endid = bcf_hdr_id2int(h, BCF_DT_ID, "END");
 
     //initialise bytes which are to be used
-    memset(insals, 0, 1 + v->n_allele / 8);
+    memset(delals, 0, 1 + v->n_allele / 8);
 
     //use decoded data where ever available and where not, get from stream
     if (v->unpacked & BCF_UN_STR || v->d.shared_dirty & BCF1_DIRTY_ALS) {
         for (i = 1; i < v->n_allele; ++i) {
             //checks only alt alleles, with NUL
-            if (!strcmp(v->d.allele[i], "<INS>")) {
-                //ins allele, note to skip corresponding svlen val
-                insals[i >> 3] |= 1 << (i & 7);
-                haveins = 1;
+            if (!strcmp(v->d.allele[i], "<DEL>")) {
+                //del allele, note to check corresponding svlen val
+                delals[i >> 3] |= 1 << (i & 7);
+                havedel = 1;
             } else if (!strcmp(v->d.allele[i], "<*>") ||
                          !strcmp(v->d.allele[i], "<NON_REF>")) {
                 gvcf = 1;   //gvcf present, have to check for LEN field
@@ -6211,10 +6211,10 @@ static int64_t get_rlen(const bcf_hdr_t *h, bcf1_t *v)
             if (!i) {   //REF length
                 len_ref = size;
             } else {
-                if (size == 5 && !strncmp((char*)f, "<INS>", size)) {
-                    //ins allele, note to skip corresponding svlen val
-                    insals[i >> 3] |= 1 << (i & 7);
-                    haveins = 1;
+                if (size == 5 && !strncmp((char*)f, "<DEL>", size)) {
+                    //del allele, note to check corresponding svlen val
+                    delals[i >> 3] |= 1 << (i & 7);
+                    havedel = 1;
                 } else if ((size == 3 && !strncmp((char*)f, "<*>", size)) ||
                     (size == 9 && !strncmp((char*)f, "<NON_REF>", size))) {
                     gvcf = 1;   //gvcf present, have to check for LEN field
@@ -6230,6 +6230,11 @@ static int64_t get_rlen(const bcf_hdr_t *h, bcf1_t *v)
         size = bcf_dec_size(f, &f, &type);
         f += size << bcf_type_shift[type];
     }
+
+    // Can skip SVLEN lookup if there are no <DEL> symbolic alleles
+    if (!havedel)
+        svlenid = -1;
+
     // INFO
     if (svlenid >= 0 || endid >= 0 ) {  //only if end/svlen present
         if (v->unpacked & BCF_UN_INFO || v->d.shared_dirty & BCF1_DIRTY_INF) {
@@ -6297,23 +6302,26 @@ static int64_t get_rlen(const bcf_hdr_t *h, bcf1_t *v)
     if (svleninfo && svleninfo->vptr) {
         //svlen info exists, not being deleted
         bad = 0;
-        //get largest svlen, except <ins>; expects to be . for non SV alleles
+        //get largest svlen corresponding to a <DEL> symbolic allele
         for (i = 0; i < svleninfo->len && i + 1 < v->n_allele; ++i) {
+            if (!(delals[i >> 3] & (1 << ((i + 1) & 7))))
+                continue;
+
             switch(svleninfo->type) {
                 case BCF_BT_INT8:
-                    tmp = ((int8_t*)svleninfo->vptr)[i];
+                    tmp = le_to_i8(&svleninfo->vptr[i]);
                     tmp = tmp == bcf_int8_missing ? 0 : tmp;
                 break;
                 case BCF_BT_INT16:
-                    tmp = ((int16_t*)svleninfo->vptr)[i];
+                    tmp = le_to_i16(&svleninfo->vptr[i * 2]);
                     tmp = tmp == bcf_int16_missing ? 0 : tmp;
                 break;
                 case BCF_BT_INT32:
-                    tmp = ((int32_t*)svleninfo->vptr)[i];
+                    tmp = le_to_i32(&svleninfo->vptr[i * 4]);
                     tmp = tmp == bcf_int32_missing ? 0 : tmp;
                 break;
                 case BCF_BT_INT64:
-                    tmp = ((int64_t*)svleninfo->vptr)[i];
+                    tmp = le_to_i64(&svleninfo->vptr[i * 8]);
                     tmp = tmp == bcf_int64_missing ? 0 : tmp;
                 break;
                 default: //invalid
@@ -6325,10 +6333,7 @@ static int64_t get_rlen(const bcf_hdr_t *h, bcf1_t *v)
                 len = 0;
                 break;
             }
-            //expects only SV will have valid svlen and rest have '.'
-            if ((haveins) && (insals[i >> 3] & (1 << ((i + 1) & 7)))) {
-                continue;   //skip svlen for <ins>
-            }
+
             tmp = tmp < 0 ? llabs(tmp) : tmp;
             if (len < tmp) len = tmp;
         }
@@ -6348,19 +6353,19 @@ static int64_t get_rlen(const bcf_hdr_t *h, bcf1_t *v)
             for (j = 0; j < lenfmt->n; ++j) {
                 switch(lenfmt->type) {
                 case BCF_BT_INT8:
-                    tmp = (((int8_t*)lenfmt->p + offset))[j];
+                    tmp = le_to_i8(lenfmt->p + offset + j);
                     tmp = tmp == bcf_int8_missing ? 0 : tmp;
                 break;
                 case BCF_BT_INT16:
-                    tmp = ((int16_t*)(lenfmt->p + offset))[j];
+                    tmp = le_to_i16(lenfmt->p + offset + j * 2);
                     tmp = tmp == bcf_int16_missing ? 0 : tmp;
                 break;
                 case BCF_BT_INT32:
-                    tmp = ((int32_t*)(lenfmt->p + offset))[j];
+                    tmp = le_to_i32(lenfmt->p + offset + j * 4);
                     tmp = tmp == bcf_int32_missing ? 0 : tmp;
                 break;
                 case BCF_BT_INT64:
-                    tmp = ((int64_t*)(lenfmt->p + offset))[j];
+                    tmp = le_to_i64(lenfmt->p + offset + j * 8);
                     tmp = tmp == bcf_int64_missing ? 0 : tmp;
                 break;
                 default: //invalid


### PR DESCRIPTION
PR #1897 updated the VCF rlen calculation in line with VCF 4.4, including taking account of INFO `SVLEN` for non-INS alleles.  This was not correct though as it included non-symbolic alleles if they (incorrectly) had a non-missing `SVLEN`; and other types of symbolic allele that do not affect the length with respect to the reference. In fact, only deletions can have an affect on rlen, so this changes the calculation to only use `SVLEN` for `<DEL>` alleles.

A bug is also fixed on big-endian platforms where INFO and FORMAT values were being accessed incorrectly.  These are always stored in little-endian order, so need to be converted to native ordering when read.  The tests are updated to include values greater than 128 to ensure that this works correctly.

Fixes #1940