### PR TITLE
Fix compilation failure on MacOS X 10.9 (and likely other very old platforms)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -666,6 +666,33 @@ Linux, FreeBSD, MacOS, and other BSD derivatives])
     ])
   ])
 
+# Check for a working fstatat interface
+AS_IF([test "$ref_cache" = enabled],[
+  AC_MSG_CHECKING([for fstatat])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([
+      #include <fcntl.h>
+      #include <sys/stat.h>
+    ],[
+      struct stat statbuf;
+      return fstatat(AT_FDCWD, "/", &statbuf, AT_SYMLINK_NOFOLLOW);
+    ])
+  ], [
+    AC_MSG_RESULT([yes])
+  ], [
+    AC_MSG_RESULT([no])
+    ref_cache="disabled"
+    AS_IF([test "x$enable_ref_cache" = xcheck], [
+      AC_MSG_WARN([ref-cache not enabled: missing fstatat()])
+    ],[
+      MSG_ERROR([ref-cache not enabled
+
+ref-cache is not supported on this configuration, as the fstatat() interface
+cannot be found.])
+    ])
+  ])
+])
+
 # Check how to get a working cmsg interface
 AS_IF([test "$ref_cache" = enabled],[
   AC_MSG_CHECKING([for CMSG_LEN])

--- a/simd.c
+++ b/simd.c
@@ -34,6 +34,8 @@ DEALINGS IN THE SOFTWARE.  */
 #include "htslib/sam.h"
 #include "sam_internal.h"
 
+#ifdef BUILDING_SIMD_NIBBLE2BASE
+
 #if defined __x86_64__
 #include <immintrin.h>
 #elif defined __ARM_NEON
@@ -113,8 +115,6 @@ static inline int cpu_supports_neon(void) {
 }
 
 #endif
-
-#ifdef BUILDING_SIMD_NIBBLE2BASE
 
 void (*htslib_nibble2base)(uint8_t *nib, char *seq, int len) = nibble2base_default;
 


### PR DESCRIPTION
Adds a configure check for `fstatat( , , , AT_SYMLINK_NOFOLLOW)` so that the `ref-cache` can be disabled automatically on platforms that lack this interface.  Also adjusts the position of the `BUILDING_SIMD_NIBBLE2BASE` guard in `simd.c` so that it doesn't try to include `immintrin.h` when the code that uses it is not going to be built.

Fixes #1941