### PR TITLE
update for filters which refer header data

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -2415,6 +2415,29 @@ int bam_mods_queryi(hts_base_mod_state *state, int i,
 HTSLIB_EXPORT
 int *bam_mods_recorded(hts_base_mod_state *state, int *ntype);
 
+// Sets the header to the file
+/**
+ * @param fp         File to which header to be set
+ * @param h          Header to be set
+ * @param dup        Whether to use duplicated header (1) or not (0)
+ *
+ * @return -1 on error and 0 on success
+ * Existing header will be destroyed, thr' sam_hdr_destroy, and new one is set.
+ * When header is set directly (dup=0), the reference count is incremented.
+ */
+HTSLIB_EXPORT
+int sam_hdr_set(samFile *fp, sam_hdr_t *h, int dup);
+
+// Get the header from the file pointer
+/**
+ * @param fp         File pointer from which header to be retrieved
+ * @return pointer to header or NULL
+ * For a valid file pointer, the returned header could be NULL when the header
+ * is not read yet. sam_hdr_incr_ref has to be invoked where ever apropriate.
+ */
+HTSLIB_EXPORT
+sam_hdr_t* sam_hdr_get(samFile* fp);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sam.c
+++ b/sam.c
@@ -1909,6 +1909,8 @@ static sam_hdr_t *sam_hdr_create(htsFile* fp) {
         return NULL;
     }
 
+    if (fp->bam_header)
+        sam_hdr_destroy(fp->bam_header);
     fp->bam_header = sam_hdr_sanitise(h);
     fp->bam_header->ref_count = 1;
 
@@ -2061,9 +2063,11 @@ int sam_hdr_write(htsFile *fp, const sam_hdr_t *h)
     }
     //only sam,bam and cram reaches here
     if (h) {    //the new header
-        if (fp->bam_header)
-            sam_hdr_destroy(fp->bam_header);
+        sam_hdr_t *tmp = fp->bam_header;
         fp->bam_header = sam_hdr_dup(h);
+        sam_hdr_destroy(tmp);
+        if (!fp->bam_header && h)
+            return -1;  //failed to duplicate
     }
     return 0;
 }
@@ -2161,6 +2165,39 @@ int sam_hdr_change_HD(sam_hdr_t *h, const char *key, const char *val)
     }
     return sam_hdr_rebuild(h);
 }
+
+/* releases existing header and sets new one; increments ref count if not
+duplicating */
+int sam_hdr_set(samFile *fp, sam_hdr_t *h, int duplicate)
+{
+    if (!fp)
+        return -1;
+
+    if (duplicate) {
+        sam_hdr_t *tmp = fp->bam_header;
+        fp->bam_header = sam_hdr_dup(h);
+        sam_hdr_destroy(tmp);
+        if (!fp->bam_header && h)
+            return -1;  //duplicate failed
+    } else {
+        if (fp->bam_header != h) {  //if not the same
+            sam_hdr_destroy(fp->bam_header);
+            fp->bam_header = h;
+            sam_hdr_incr_ref(fp->bam_header);
+        }
+    }
+
+    return 0;
+}
+
+//return the bam_header, user has to use sam_hdr_incr_ref where ever required
+sam_hdr_t* sam_hdr_get(samFile* fp)
+{
+    if (!fp)
+        return NULL;
+    return fp->bam_header;
+}
+
 /**********************
  *** SAM record I/O ***
  **********************/


### PR DESCRIPTION
Filter expressions which needs header information, like rname, mrname, rnext and  library, will not work well when used along with iterators. Filter processing uses fp->bam_header but it will be empty except for sam files and causes this.
This PR sets htsFile's bam_header with header that is read on sam_hdr_read api. This ensures that the bam_header field is not empty and available for filter evaluation.
To keep the bam_header in sync with data, the same is released and reset on header write. 

Added get/set methods that header can be set and retrieved from file pointer. 