### PR TITLE
Minor one-line rewrite to avoid undefined behaviour

### DIFF
--- a/synced_bcf_reader.c
+++ b/synced_bcf_reader.c
@@ -264,7 +264,7 @@ int bcf_sr_add_reader(bcf_srs_t *files, const char *fname)
     }
     //get idx name and pass to add_hreader
     idxname = strstr(fname, HTS_IDX_DELIM);
-    idxname += idxname ? sizeof(HTS_IDX_DELIM) - 1 : 0;
+    if (idxname) idxname += strlen(HTS_IDX_DELIM);
     if (!(ret = bcf_sr_add_hreader(files, file_ptr, 1, idxname))) {
         hts_close(file_ptr);    //failed, close the file
     }

--- a/test/test-bcf-sr.c
+++ b/test/test-bcf-sr.c
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
               w/o name it has to be along with file with default naming*/
 
             const char *idxname = strstr(vcfs[i], HTS_IDX_DELIM);
-            idxname += idxname ? sizeof(HTS_IDX_DELIM) - 1 : 0;
+            if (idxname) idxname += strlen(HTS_IDX_DELIM);
             if ( !bcf_sr_add_hreader(sr, htsfp[i], 1, idxname) ) {
                 error("Failed to add reader %s: %s\n", vcfs[i],
                     bcf_sr_strerror(sr->errnum));


### PR DESCRIPTION
Even adding zero to a null pointer is not kosher, and produces diagnostics at runtime with `‑fsanitize=undefined`:

```
synced_bcf_reader.c:267:13: runtime error: applying zero offset to null pointer
```

Also use `strlen(HTS_IDX_DELIM)` for clarity — it will be optimised to the same constant as the `sizeof` version anyway, and is already used elsewhere.