### PR TITLE
removed direct header access through file, uses user read header

### DIFF
--- a/samples/mpileup.c
+++ b/samples/mpileup.c
@@ -73,7 +73,7 @@ int readdata(void *data, bam1_t *b)
     }
 
     //read alignment and send
-    return sam_read1(conf->infile, conf->infile->bam_header, b);
+    return sam_read1(conf->infile, conf->in_samhdr, b);
 }
 
 /// main_demo - start of the demo

--- a/samples/pileup.c
+++ b/samples/pileup.c
@@ -81,7 +81,7 @@ int readdata(void *data, bam1_t *b)
     }
 
     //read alignment and send
-    return sam_read1(conf->infile, conf->infile->bam_header, b);
+    return sam_read1(conf->infile, conf->in_samhdr, b);
 }
 
 /// main_demo - start of the demo

--- a/samples/pileup_mod.c
+++ b/samples/pileup_mod.c
@@ -87,7 +87,7 @@ int readdata(void *data, bam1_t *b)
     }
 
     //read alignment and send
-    return sam_read1(conf->infile, conf->infile->bam_header, b);
+    return sam_read1(conf->infile, conf->in_samhdr, b);
 }
 
 /// main_demo - start of the demo


### PR DESCRIPTION
Fixes #1961
The samples used header in samFile which is improper; modified to use the header explicitly read.