### PR TITLE
Fix htslib.map update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -952,7 +952,7 @@ $(srcprefix)htslib.map: libhts.so
 	    echo "Refusing to update $@ - HTSlib version not changed" 1>&2 ; \
 	    exit 1 ; \
 	fi && \
-	nm --with-symbol-versions -D -g libhts.so | awk '$$2 ~ /^[DGRT]$$/ && $$3 ~ /@@Base$$/ && $$3 !~ /^(_init|_fini|_edata)@@/ { sub(/@@Base$$/, ";", $$3); print "    " $$3 }' > $@.tmp && \
+	nm --defined-only --with-symbol-versions -D -g libhts.so | awk '$$2 ~ /^[DGRT]$$/ && ($$3 ~ /@@Base$$/ || $$3 !~ /@/) && $$3 !~ /^(_init|_fini|_edata)(@|$$)/ { sub(/@@Base$$/, "", $$3); print "    " $$3 ";" }' > $@.tmp && \
 	if [ -s $@.tmp ] ; then \
 	    cat $@ > $@.new.tmp && \
 	    printf '\n%s {\n' "HTSLIB_$$curr_vers" >> $@.new.tmp && \


### PR DESCRIPTION
At some point `nm --with-symbol-versions` stopped appending `@@Base` to unversioned symbols.  This broke the awk script that looked for symbols to add to the `htslib.map` file.  Fix by changing the match criteria to accept symbol names with no version appended as well as `@@Base`, and make minor adjustments to how the semicolon is appended to the name in the output.

Also add `--defined-only` to the `nm` command line to get rid of imported functions as they don't follow the same output format as for the symbols we want (the first column is blank). Removing them eliminates the chance that these lines could be incorrectly included.

Fixes #1971 although care will have to be taken on the next release to ensure that the missed symbols get attached to the correct version.  Possibly this could be done by pushing a commit to add them manually prior to release building activities.