### PR TITLE
Simplify kh_grow_to_fit table size check

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,7 +28,7 @@ Updates
 * Consolidate and simplify SAM header parsing.  This considerably speeds up
   parsing files with many SQ lines.
   (PR #1947. PR #1953 fixes oss-fuzz issues 444492071, 444492076, 444547724,
-   444490034)
+   444490034, PR #1977)
 
 * Switch from strtol to hts_str2uint in mod parsing for speed increase.
   (PR #1957.  Thanks to Chris Wright)

--- a/htslib/khash.h
+++ b/htslib/khash.h
@@ -311,6 +311,7 @@ static const double __ac_HASH_UPPER = 0.77;
 	SCOPE int kh_grow_to_fit_##name(kh_##name##_t *h, khint_t n_items)	\
 	{																	\
 		khint_t n_buckets;												\
+		khint_t resize_limit = (khint_t) ((double) INT_MAX * __ac_HASH_UPPER); \
 		if (n_items < h->upper_bound - h->size) {						\
 			/* Should be big enough ... */								\
 			if (n_items < h->upper_bound - h->n_occupied)				\
@@ -321,7 +322,7 @@ static const double __ac_HASH_UPPER = 0.77;
 		if (UINT_MAX - h->size < n_items)								\
 			return -2;													\
 		n_items += h->size;												\
-		if (n_items >= INT_MAX * __ac_HASH_UPPER)						\
+		if (n_items >= resize_limit)									\
 			return -2;													\
 		n_buckets = n_items > 0 ? n_items : 1;							\
 		kroundup32(n_buckets);											\


### PR DESCRIPTION
For some reason, early versions of clang incorrectly optimised a check to ensure that the number of buckets in a resized hash table will still fit in a khint_t, with the result that most of the function was replaced by "return -2".  Fix by putting the limit value in a separate variable, so the comparison part no longer needs to do any type conversion.