### PR TITLE
Add overflow check in bgzf_index_load_hfile()

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -2471,6 +2471,9 @@ int bgzf_index_load_hfile(BGZF *fp, struct hFILE *idx, const char *name)
     if (fp->idx == NULL) goto fail;
     uint64_t x;
     if (hread_uint64(&x, idx) < 0) goto fail;
+    if (x >= ((SIZE_MAX < UINT64_MAX ? SIZE_MAX : UINT64_MAX)
+              / sizeof(bgzidx1_t) / 2))
+        goto fail;
 
     fp->idx->noffs = fp->idx->moffs = x + 1;
     fp->idx->offs  = (bgzidx1_t*) malloc(fp->idx->moffs*sizeof(bgzidx1_t));


### PR DESCRIPTION
This function reads an item count from the input file and uses it to allocate an array of file offsets.  It's possible for this to overflow, resulting in an attempt to malloc(0) and, if that returns a valid pointer, an attempt to zero 16 bytes in a zero-length allocation.

Fix by checking that the allocation will not overflow.

Thanks to Harrison Green for reporting this.