### PR TITLE
Fixes for S3 uploading bugs.

### DIFF
--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -538,6 +538,8 @@ static int redirect_endpoint(hFILE_s3 *fp, kstring_t *header) {
         }
     }
 
+    if (hts_verbose >= HTS_LOG_INFO) fprintf(stderr, "hfile_s3: redirect_endpoint: return %d\n", ret);
+
     return ret;
 }
 
@@ -1122,7 +1124,6 @@ static int set_region(s3_auth_data *ad, kstring_t *region) {
 #define S3_MOVED_PERMANENTLY 301
 #define S3_BAD_REQUEST 400
 
-
 static struct {
     kstring_t useragent;
     CURLSH *share;
@@ -1319,6 +1320,13 @@ static struct curl_slist *set_html_headers(hFILE_s3 *fp, kstring_t *auth, kstrin
     struct curl_slist *headers = NULL;
     int err = 0;
 
+    /* The next two lines have the effect of preventing curl from
+       adding these headers.  If they exist it can lead to conflicts
+       in the signature calculations (not present in all S3 systems).
+    */
+    add_header(&headers, "Content-Type:");
+    add_header(&headers, "Expect:");
+
     if (auth->l)
         if ((err = add_header(&headers, auth->s)))
             goto error;
@@ -1407,10 +1415,12 @@ uploads and abandon the upload process.
 static int abort_upload(hFILE_s3 *fp) {
     kstring_t url = KS_INITIALIZE;
     kstring_t canonical_query_string = KS_INITIALIZE;
-    int ret = -1;
+    int ret = -1, save_errno;
     struct curl_slist *headers = NULL;
     char http_request[] = "DELETE";
     CURLcode err;
+
+    save_errno = errno; // keep the errno that caused the need to abort
 
     clear_authorisation_values(fp);
 
@@ -1459,6 +1469,7 @@ static int abort_upload(hFILE_s3 *fp) {
     fp->aborted = 1;
     cleanup(fp);
 
+    errno = save_errno;
     return ret;
 }
 
@@ -1497,6 +1508,7 @@ static int complete_upload(hFILE_s3 *fp, kstring_t *resp) {
     curl_easy_reset(fp->curl);
 
     err = curl_easy_setopt(fp->curl, CURLOPT_POST, 1L);
+
     err |= curl_easy_setopt(fp->curl, CURLOPT_POSTFIELDS, fp->completion_message.s);
     err |= curl_easy_setopt(fp->curl, CURLOPT_POSTFIELDSIZE, (long) fp->completion_message.l);
     err |= curl_easy_setopt(fp->curl, CURLOPT_WRITEFUNCTION, response_callback);
@@ -1670,6 +1682,7 @@ static int s3_write_close(hFILE *fpv) {
     kstring_t response = {0, 0, NULL};
     int ret = 0;
     CURLcode cret;
+    long response_code;
 
     if (!fp->aborted) {
 
@@ -1679,7 +1692,6 @@ static int s3_write_close(hFILE *fpv) {
             ret = upload_part(fp, &response);
 
             if (!ret) {
-                long response_code;
                 kstring_t etag = {0, 0, NULL};
 
                 cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
@@ -1715,6 +1727,19 @@ static int s3_write_close(hFILE *fpv) {
             if (!ret) {
                 if (strstr(response.s, "CompleteMultipartUploadResult") == NULL) {
                     ret = -1;
+                    cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
+
+                    fprintf(stderr, "*** GOT HERE %ld***\n", response_code);
+
+                    if (cret == CURLE_OK) {
+                        if (hts_verbose >= HTS_LOG_INFO) {
+                            if (report_s3_error(&response, response_code)) {
+                                fprintf(stderr, "hfile_s3: warning, unable to report full S3 error status.\n");
+                            }
+                        }
+
+                        errno = http_status_errno(response_code);
+                    }
                 }
             }
         } else {
@@ -1745,6 +1770,8 @@ static int handle_bad_request(hFILE_s3 *fp, kstring_t *resp) {
     ret = set_region(fp->au, &region);
 
     ks_free(&region);
+
+    if (hts_verbose >= HTS_LOG_INFO) fprintf(stderr, "hfile_s3: handle_bad_request: return %d\n", ret);
 
     return ret;
 }
@@ -2145,6 +2172,9 @@ static hFILE *s3_write_open(const char *url, s3_auth_data *auth) {
                     ret = initialise_upload(fp, &header, &response, has_user_query);
                 }
             }
+
+            // reget the response code (may not have changed)
+            cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
         } else {
             // unable to get a response code from curl
             ret = -1;

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -1122,6 +1122,7 @@ static int set_region(s3_auth_data *ad, kstring_t *region) {
 // Some common code
 
 #define S3_MOVED_PERMANENTLY 301
+#define S3_TEMPORARY_REDIRECT 307
 #define S3_BAD_REQUEST 400
 
 static struct {
@@ -1179,7 +1180,7 @@ static char *stristr(char *haystack, char *needle) {
         char *h = haystack;
         char *n = needle;
 
-        while (toupper(*h) == toupper(*n)) {
+        while (toupper_c(*h) == toupper_c(*n)) {
             h++, n++;
             if (!*h || !*n) break;
         }
@@ -1324,8 +1325,10 @@ static struct curl_slist *set_html_headers(hFILE_s3 *fp, kstring_t *auth, kstrin
        adding these headers.  If they exist it can lead to conflicts
        in the signature calculations (not present in all S3 systems).
     */
-    add_header(&headers, "Content-Type:");
-    add_header(&headers, "Expect:");
+    err = add_header(&headers, "Content-Type:");
+    err |= add_header(&headers, "Expect:");
+
+    if (err) goto error;
 
     if (auth->l)
         if ((err = add_header(&headers, auth->s)))
@@ -1877,14 +1880,13 @@ static int get_part(hFILE_s3 *fp, kstring_t *resp) {
     struct curl_slist *headers = NULL;
     int ret = -1;
     char http_request[] = "GET";
-    char canonical_query_string = 0;
     CURLcode err;
 
     ks_clear(&fp->buffer); // reset storage buffer
     clear_authorisation_values(fp);
 
     if (fp->au->is_v4) {
-        if (v4_authorisation(fp, http_request, NULL, &canonical_query_string, 0) != 0) {
+        if (v4_authorisation(fp, http_request, NULL, "", 0) != 0) {
             goto out;
         }
 
@@ -2102,7 +2104,7 @@ static hFILE *s3_write_open(const char *url, s3_auth_data *auth) {
     hFILE_s3 *fp;
     kstring_t response = {0, 0, NULL};
     kstring_t header   = {0, 0, NULL};
-    int ret, has_user_query = 0;
+    int has_user_query = 0;
     char *query_start;
     const char *env;
     CURLcode cret;
@@ -2150,33 +2152,35 @@ static hFILE *s3_write_open(const char *url, s3_auth_data *auth) {
         has_user_query = 1;;
     }
 
-    ret = initialise_upload(fp, &header, &response, has_user_query);
+    if (initialise_upload(fp, &header, &response, has_user_query))
+        goto error;
+
     cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
 
-    if (ret == 0) {
-        if (cret == CURLE_OK) {
-            if (response_code == S3_MOVED_PERMANENTLY) {
-                if (redirect_endpoint(fp, &header) == 0) {
-                    ks_clear(&response);
-                    ks_clear(&header);
+    if (cret == CURLE_OK) {
+        if (response_code == S3_MOVED_PERMANENTLY || response_code == S3_TEMPORARY_REDIRECT) {
+            if (redirect_endpoint(fp, &header) == 0) {
+                ks_clear(&response);
+                ks_clear(&header);
 
-                    ret = initialise_upload(fp, &header, &response, has_user_query);
-                }
-            } else if (response_code == S3_BAD_REQUEST) {
-                if (handle_bad_request(fp, &response) == 0) {
-                    ks_clear(&response);
-                    ks_clear(&header);
-
-                    ret = initialise_upload(fp, &header, &response, has_user_query);
-                }
+                if (initialise_upload(fp, &header, &response, has_user_query))
+                    goto error;
             }
+        } else if (response_code == S3_BAD_REQUEST) {
+            if (handle_bad_request(fp, &response) == 0) {
+                ks_clear(&response);
+                ks_clear(&header);
 
-            // reget the response code (may not have changed)
-            cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
-        } else {
-            // unable to get a response code from curl
-            ret = -1;
+                if (initialise_upload(fp, &header, &response, has_user_query))
+                    goto error;
+            }
         }
+
+        // reget the response code (may not have changed)
+        cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
+    } else {
+        // unable to get a response code from curl
+        goto error;
     }
 
     if (response_code >= 300) {
@@ -2192,10 +2196,8 @@ static hFILE *s3_write_open(const char *url, s3_auth_data *auth) {
             errno = http_status_errno(response_code);
         }
 
-        ret = -1;
+        goto error;
     }
-
-    if (ret) goto error;
 
     if (get_upload_id(fp, &response)) goto error;
 
@@ -2231,7 +2233,6 @@ static hFILE *s3_read_open(const char *url, s3_auth_data *auth) {
     const char *env;
     kstring_t response   = {0, 0, NULL};
     kstring_t file_range = {0, 0, NULL};
-    int ret;
     CURLcode cret;
     long response_code = 0;
 
@@ -2268,31 +2269,33 @@ static hFILE *s3_read_open(const char *url, s3_auth_data *auth) {
 
     kputs(url, &fp->url);
 
-    ret = initialise_download(fp, &response);
+    if (initialise_download(fp, &response))
+        goto error;
+
     cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
 
-    if (ret == 0) {
-        if (cret == CURLE_OK) {
-            if (response_code == S3_MOVED_PERMANENTLY) {
-                ks_clear(&response);
+    if (cret == CURLE_OK) {
+        if (response_code == S3_MOVED_PERMANENTLY || response_code == S3_TEMPORARY_REDIRECT) {
+            ks_clear(&response);
 
-                if (redirect_endpoint(fp, &response) == 0) {
-                    ret = initialise_download(fp, &response);
-                }
-            } else if (response_code == S3_BAD_REQUEST) {
-                ks_clear(&response);
-
-                if (handle_bad_request(fp, &fp->buffer) == 0) {
-                    ret = initialise_download(fp, &response);
-                }
+            if (redirect_endpoint(fp, &response) == 0) {
+                if (initialise_download(fp, &response))
+                    goto error;
             }
+        } else if (response_code == S3_BAD_REQUEST) {
+            ks_clear(&response);
 
-            // reget the response code (may not have changed)
-            cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
-        } else {
-            // unable to get a response code from curl
-            ret = -1;
+            if (handle_bad_request(fp, &fp->buffer) == 0) {
+                if (initialise_download(fp, &response))
+                    goto error;
+            }
         }
+
+        // reget the response code (may not have changed)
+        cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
+    } else {
+        // unable to get a response code from curl
+        goto error;
     }
 
     if (response_code >= 300) {
@@ -2308,10 +2311,8 @@ static hFILE *s3_read_open(const char *url, s3_auth_data *auth) {
             errno = http_status_errno(response_code);
         }
 
-        ret = -1;
+        goto error;
     }
-
-    if (ret) goto error;
 
     if (get_entry(response.s, "content-range: bytes ", "\n", &file_range) == EOF) {
         fprintf(stderr, "hfile_s3: warning: failed to read file size.\n");
@@ -2401,7 +2402,7 @@ static hFILE *hopen_s3(const char *url, const char *mode)
 {
     hFILE *fp;
 
-    if (getenv("HTS_S3_V2") == NULL) { // Force the v2 signature code
+    if (getenv("HTS_S3_V2") == NULL) {
         fp = s3_open_v4(url, mode, NULL);
     } else {
         fp = s3_open_v2(url, mode, NULL);

--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -1729,8 +1729,6 @@ static int s3_write_close(hFILE *fpv) {
                     ret = -1;
                     cret = curl_easy_getinfo(fp->curl, CURLINFO_RESPONSE_CODE, &response_code);
 
-                    fprintf(stderr, "*** GOT HERE %ld***\n", response_code);
-
                     if (cret == CURLE_OK) {
                         if (hts_verbose >= HTS_LOG_INFO) {
                             if (report_s3_error(&response, response_code)) {


### PR DESCRIPTION
First bug prevented the finalisation of the upload in AWS.  This was caused by not removing two header entries which caused the signature to be miscalculated.

Second was caused by failure to re-check the error state after a redirection.

Hopefully this should fix #1979.