### PR TITLE
change to fail on extra hts_set_threads/_pool invocation

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -1741,6 +1741,8 @@ int bgzf_thread_pool(BGZF *fp, hts_tpool *pool, int qsize) {
     // No gain from multi-threading when not compressed
     if (!fp->is_compressed)
         return 0;
+    if (fp->mt)
+        return -2;  //already exists!
 
     mtaux_t *mt;
     mt = (mtaux_t*)calloc(1, sizeof(mtaux_t));
@@ -1789,9 +1791,10 @@ int bgzf_mt(BGZF *fp, int n_threads, int n_sub_blks)
     if (!p)
         return -1;
 
-    if (bgzf_thread_pool(fp, p, 0) != 0) {
+    int ret = 0;
+    if ((ret = bgzf_thread_pool(fp, p, 0)) < 0) {
         hts_tpool_destroy(p);
-        return -1;
+        return ret;
     }
 
     fp->mt->own_pool = 1;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -5868,6 +5868,8 @@ int cram_set_voption(cram_fd *fd, enum hts_fmt_option opt, va_list args) {
 
     case CRAM_OPT_NTHREADS: {
         int nthreads =  va_arg(args, int);
+        if (fd->pool)
+            return -2;  //already exists!
         if (nthreads >= 1) {
             if (!(fd->pool = hts_tpool_init(nthreads)))
                 return -1;
@@ -5881,6 +5883,8 @@ int cram_set_voption(cram_fd *fd, enum hts_fmt_option opt, va_list args) {
 
     case CRAM_OPT_THREAD_POOL: {
         htsThreadPool *p = va_arg(args, htsThreadPool *);
+        if (fd->pool)
+            return -2;  //already exists!
         fd->pool = p ? p->pool : NULL;
         if (fd->pool) {
             fd->rqueue = hts_tpool_process_init(fd->pool,

--- a/sam.c
+++ b/sam.c
@@ -3713,7 +3713,7 @@ static void *sam_format_worker(void *arg) {
 
 int sam_set_thread_pool(htsFile *fp, htsThreadPool *p) {
     if (fp->state)
-        return 0;
+        return -2;   //already exists!
 
     if (!(fp->state = sam_state_create(fp)))
         return -1;
@@ -3747,8 +3747,11 @@ int sam_set_threads(htsFile *fp, int nthreads) {
     p.qsize = nthreads*2;
 
     int ret = sam_set_thread_pool(fp, &p);
-    if (ret < 0)
+    if (ret < 0) {
+        if (p.pool)
+            hts_tpool_destroy(p.pool);
         return ret;
+    }
 
     SAM_state *fd = (SAM_state *)fp->state;
     fd->own_pool = 1;


### PR DESCRIPTION
Hts lib enables threading through different APIs and irrespective of the API used, a thread pool is set to file handle.
If the API is invoked again, existing pool is discarded and new one set, causing leak of existing pool and threads and may cause undesired behaviours as well.

This change checks presence of an existing allocation (thread pool or data structure holding the pool) and if found returns error -2 without making any change. Incase of no existing allocation, it continues as it used to, to set new thread pool.
Updated for sam threads, bgzf thread and cram threads.

samtools view --threads 2 --input-fmt-option=nthreads=2 --output-fmt-option=nthread=2 may show the leak

this was observed while working with samtools reset reference update (PR2300)