### PR TITLE
Stop bgzf_index_dump_hfile() from writing invalid item counts

### DIFF
--- a/bgzf.c
+++ b/bgzf.c
@@ -2399,10 +2399,11 @@ int bgzf_index_dump_hfile(BGZF *fp, struct hFILE *idx, const char *name)
     if (bgzf_flush(fp) != 0) return -1;
 
     // discard the entry marking the end of the file
-    if (fp->mt && fp->idx)
+    if (fp->mt && fp->idx && fp->idx->noffs > 0)
         fp->idx->noffs--;
 
-    if (hwrite_uint64(fp->idx->noffs - 1, idx) < 0) goto fail;
+    if (hwrite_uint64(fp->idx->noffs > 0 ? fp->idx->noffs - 1 : 0, idx) < 0)
+        goto fail;
     for (i=1; i<fp->idx->noffs; i++)
     {
         if (hwrite_uint64(fp->idx->offs[i].caddr, idx) < 0) goto fail;


### PR DESCRIPTION
Adds `fp->idx->noffs > 0` checks before decrementing the item count written to GZI indexes.  Fixes a bug where the wrong value was written when compressing and GZI indexing an empty file.  Note that since 6dd0d7d, files exhibiting this bug will be rejected by `bgzf_index_load_hfile()`.

Thanks to Matthieu Muffato for reporting this bug.