### PR TITLE
Add multi-region iterator support for tabix

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -4320,6 +4320,7 @@ int hts_itr_next(BGZF *fp, hts_itr_t *iter, void *r, void *data)
 int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r)
 {
     void *fp;
+    void *readrec_data;
     int ret, tid, i, cr, ci;
     hts_pos_t beg, end;
     hts_reglist_t *found_reg;
@@ -4332,6 +4333,8 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r)
         fp = fd->fp.bgzf;
     }
 
+    readrec_data = iter->readrec_data ? iter->readrec_data : fd;
+
     if (iter->read_rest) {
         if (iter->curr_off) { // seek to the start
             if (iter->seek(fp, iter->curr_off, SEEK_SET) < 0) {
@@ -4341,7 +4344,7 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r)
             iter->curr_off = 0; // only seek once
         }
 
-        ret = iter->readrec(fp, fd, r, &tid, &beg, &end);
+        ret = iter->readrec(fp, readrec_data, r, &tid, &beg, &end);
         if (ret < 0)
             iter->finished = 1;
 
@@ -4425,7 +4428,7 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r)
                     // contain a few mapped reads, so scroll
                     // forward until finding the first unmapped read.
                     do {
-                        ret = iter->readrec(fp, fd, r, &tid, &beg, &end);
+                        ret = iter->readrec(fp, readrec_data, r, &tid, &beg, &end);
                     } while (tid >= 0 && ret >=0);
 
                     if (ret < 0)
@@ -4531,7 +4534,7 @@ int hts_itr_multi_next(htsFile *fd, hts_itr_t *iter, void *r)
             }
         }
 
-        ret = iter->readrec(fp, fd, r, &tid, &beg, &end);
+        ret = iter->readrec(fp, readrec_data, r, &tid, &beg, &end);
         if (ret < 0) {
             if (iter->is_cram && cram_eof(fp)) {
                 // Skip to end of range

--- a/htslib.map
+++ b/htslib.map
@@ -261,6 +261,7 @@ HTSLIB_1.0 {
     tbx_index_build;
     tbx_index_load;
     tbx_name2id;
+    tbx_itr_regions;
     tbx_readrec;
     tbx_seqnames;
     vcf_format;

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -886,6 +886,7 @@ typedef struct hts_itr_t {
     hts_readrec_func *readrec;
     hts_seek_func *seek;
     hts_tell_func *tell;
+    void *readrec_data; // If set, passed to readrec instead of fd
     struct {
         int n, m;
         int *a;

--- a/htslib/tbx.h
+++ b/htslib/tbx.h
@@ -61,9 +61,24 @@ extern const tbx_conf_t tbx_conf_gff, tbx_conf_bed, tbx_conf_psltbl, tbx_conf_sa
     #define tbx_itr_querys(tbx, s) hts_itr_querys((tbx)->idx, (s), (hts_name2id_f)(tbx_name2id), (tbx), hts_itr_query, tbx_readrec)
     #define tbx_itr_next(htsfp, tbx, itr, r) hts_itr_next(hts_get_bgzfp(htsfp), (itr), (r), (tbx))
     #define tbx_bgzf_itr_next(bgzfp, tbx, itr, r) hts_itr_next((bgzfp), (itr), (r), (tbx))
+    #define tbx_itr_multi_next(htsfp, itr, r) hts_itr_multi_next((htsfp), (itr), (r))
 
     HTSLIB_EXPORT
     int tbx_name2id(tbx_t *tbx, const char *ss);
+
+/// Create a multi-region iterator for a tabix-indexed file
+/** @param tbx      Tabix index
+    @param reglist  Region list created by hts_reglist_create()
+    @param regcount Number of regions in the list
+    @return An iterator, or NULL on failure
+
+    The multi-region iterator handles overlapping regions by deduplicating
+    records that fall in multiple regions, so each record is returned at
+    most once.  Free the iterator with tbx_itr_destroy() when done.
+    Use tbx_itr_multi_next() to advance the iterator.
+*/
+    HTSLIB_EXPORT
+    hts_itr_t *tbx_itr_regions(tbx_t *tbx, hts_reglist_t *reglist, int regcount);
 
     /* Internal helper function used by tbx_itr_next() */
     HTSLIB_EXPORT

--- a/tbx.c
+++ b/tbx.c
@@ -640,3 +640,35 @@ const char **tbx_seqnames(tbx_t *tbx, int *n)
     return names;
 }
 
+static int tbx_pseek(void *fp, int64_t offset, int whence)
+{
+    BGZF *fd = (BGZF *)fp;
+    return bgzf_seek(fd, offset, whence);
+}
+
+static int64_t tbx_ptell(void *fp)
+{
+    BGZF *fd = (BGZF *)fp;
+    if (!fd)
+        return -1L;
+    return bgzf_tell(fd);
+}
+
+hts_itr_t *tbx_itr_regions(tbx_t *tbx, hts_reglist_t *reglist, int regcount)
+{
+    hts_itr_t *itr;
+
+    if (!tbx || !reglist)
+        return NULL;
+
+    itr = hts_itr_regions(tbx->idx, reglist, regcount,
+                          (hts_name2id_f)(tbx_name2id), tbx,
+                          hts_itr_multi_bam, tbx_readrec,
+                          tbx_pseek, tbx_ptell);
+
+    if (itr)
+        itr->readrec_data = tbx;
+
+    return itr;
+}
+


### PR DESCRIPTION
## Summary

Closes #1913 (and addresses the multi-region query aspect of #1949).

This adds `tbx_itr_regions()` and `tbx_itr_multi_next()`, giving tabix-indexed files (VCF, BED, GFF, GAF, etc.) the same multi-region query capability that BAM/CRAM already have via `sam_itr_regions()`.

The key feature is **automatic deduplication**: when query regions overlap, each record is returned exactly once. This is critical for use cases like "query all known cancer genes" where gene regions may be adjacent or overlapping.

## Design

The core insight is that tabix and BAM share the same binning index format (TBI/CSI ↔ BAI/CSI), so `hts_itr_multi_bam` works directly as the query function for tabix — no new query function needed.

The one interface gap was that `hts_itr_multi_next()` hardcodes `htsFile*` as the data argument to `readrec`, but `tbx_readrec` expects `tbx_t*`. This is resolved by adding a `void *readrec_data` field to `hts_itr_t`:

- When set (by `tbx_itr_regions`), it is passed to `readrec` instead of `fd`
- When NULL (default, from `calloc`), existing BAM/CRAM behaviour is preserved
- One field addition, three line changes in `hts_itr_multi_next` — fully backwards-compatible

## Usage

```c
// Parse regions (merges overlaps automatically)
int n_reg;
hts_reglist_t *reglist = hts_reglist_create(regions, n_regions,
    &n_reg, tbx, (hts_name2id_f)(tbx_name2id));

// Create multi-region iterator
hts_itr_t *itr = tbx_itr_regions(tbx, reglist, n_reg);

// Iterate — each record returned at most once
kstring_t s = {0, 0, NULL};
while (tbx_itr_multi_next(fp, itr, &s) >= 0) {
    // process s.s
}
tbx_itr_destroy(itr);
```

## Changes

| File | Change |
|------|--------|
| `htslib/hts.h` | Add `void *readrec_data` to `hts_itr_t` |
| `hts.c` | Use `readrec_data` when set in `hts_itr_multi_next` (3 call sites) |
| `htslib/tbx.h` | Add `tbx_itr_regions()` declaration, `tbx_itr_multi_next()` macro |
| `tbx.c` | Implement `tbx_itr_regions()`, `tbx_pseek()`, `tbx_ptell()` |
| `htslib.map` | Export `tbx_itr_regions` |

## Test plan

- [x] htslib builds cleanly with no new warnings
- [x] Tested with a VCF containing 7 variants across 2 chromosomes:
  - Single-region query: correct record count
  - Non-overlapping multi-region: records from both regions returned
  - Overlapping regions (chr1:100-300 + chr1:200-400): 4 unique records, no duplicates
  - Cross-chromosome with overlap (3 regions, 2 overlapping): 7 unique records
- [x] samtools builds and passes markdup tests against updated htslib
- [x] Existing BAM/CRAM multi-region behaviour unaffected (readrec_data defaults to NULL)