### PR TITLE
Oss fuzz 499447432

### DIFF
--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1504,7 +1504,7 @@ int next_cigar_op(uint32_t *cigar, uint32_t ncigar, int *skip, int *spos,
 static inline int extend_ref(char **ref, uint32_t (**hist)[5], hts_pos_t pos,
                              hts_pos_t ref_start, hts_pos_t *ref_end,
                              hts_pos_t *ref_end_alloc) {
-    if (*ref_end < pos)
+    if (*ref_end < pos && pos < *ref_end_alloc)
         *ref_end = pos;
     if (pos < ref_start)
         return -1;
@@ -1541,6 +1541,9 @@ static inline int extend_ref(char **ref, uint32_t (**hist)[5], hts_pos_t pos,
     new_end -= ref_start;
     memset(&(*ref)[old_end],  0,  new_end-old_end);
     memset(&(*hist)[old_end], 0, (new_end-old_end)*sizeof(**hist));
+
+    if (*ref_end < pos)
+        *ref_end = pos;
 
     return 0;
 }

--- a/header.c
+++ b/header.c
@@ -174,8 +174,8 @@ static int sam_hrecs_update_hashes(sam_hrecs_t *hrecs,
             return -1; // SN should be present, according to spec.
         }
 
-        if (len == -1) {
-            hts_log_error("Header includes @SQ line \"%s\" with no LN: tag",
+        if (len <= 0) {
+            hts_log_error("Header includes @SQ line \"%s\" with invalid or no LN: tag",
                           name);
             return -1; // LN should be present, according to spec.
         }


### PR DESCRIPTION
- Fix extend_ref to not change ref_end on error, fixing a read buffer overflow.
- Improve SQ LN field checking, failing on LN:-2 and also LN:0 or "LN:"

Note this isn't CVE worthy as the code it fixes appeared since the last release.


