### PR TITLE
hfile_s3: fix s3_seek returning wrong offset on cache-hit

### DIFF
--- a/hfile_s3.c
+++ b/hfile_s3.c
@@ -2063,7 +2063,7 @@ static off_t s3_seek(hFILE *fpv, off_t offset, int whence) {
         ks_clear(&fp->buffer); // resetting fp->buffer triggers a new remote read
     }
 
-    return fp->last_read;
+    return (off_t) pos;
 }
 
 


### PR DESCRIPTION
s3_read fetches data in 1 MB chunks (READ_PART_SIZE) and tracks position with two fields: fp->last_read (the remote offset at the end of the fetched chunk) and fp->last_read_buffer (the read cursor within the local buffer).
s3_seek checks whether the target pos falls within the buffered window and repositions accordingly, but has always returned fp->last_read regardless of which branch was taken:

```c
if (pos <= fp->last_read && pos > (fp->last_read - fp->buffer.l)) {
    fp->last_read_buffer = pos - (fp->last_read - fp->buffer.l);
} else {
    fp->last_read = pos;
    ks_clear(&fp->buffer);
}
return fp->last_read;  // returns chunk end on cache-hit
```

On a cache-miss this is fine - fp->last_read was just set to pos. On a cache-hit, fp->last_read still holds the chunk end, so hseek() in hfile.c sets fp->offset to the chunk end rather than the seek target. The next BGZF read then pulls bytes from the wrong file offset

```
[E::bgzf_read_block] Invalid BGZF header at offset N
Error: BCF read error
```

The bug surfaces when consecutive seek targets fall within the same 1 MB fetch window. This occurs naturally with bcftools annotate/query -R against a regions file containing genomically clustered positions - nearby positions map to nearby BGZF virtual offsets whose underlying raw file offsets can fall within the same chunk.

A public S3 URL hosting the files used to observe this issue will be added once an internal access exemption has been processed. Alternatively, a GRCh38 dbSNP VCF from NCBI (https://ftp.ncbi.nlm.nih.gov/snp/organisms/human_9606/VCF/00-All.vcf.gz) uploaded to any S3-compatible bucket can be queried using the attached regions file with:

`bcftools view -R regions.tsv s3://<bucket>/00-All.vcf.gz`

[regions.tsv](https://github.com/user-attachments/files/27942089/regions.tsv)

Assisted-by: GitHub-Copilot:claude-sonnet-4.6