### PR TITLE
Remove a signed overflow bug in bgzf_read_small.

### DIFF
--- a/htslib/bgzf.h
+++ b/htslib/bgzf.h
@@ -150,9 +150,14 @@ typedef struct BGZF BGZF;
  */
 static inline ssize_t bgzf_read_small(BGZF *fp, void *data, size_t length) {
     // A block length of 0 implies current block isn't loaded (see
-    // bgzf_seek_common).  That gives negative available so careful on types
-    if ((ssize_t)length < fp->block_length - fp->block_offset) {
-        // Short cut the common and easy mode
+    // bgzf_seek_common).  That means length - offset may be negative, which
+    // will be promoted to unsigned for purposes of the comparison.
+    // So we must guard against that case.
+    size_t remaining = fp->block_length - fp->block_offset > 0
+        ? fp->block_length - fp->block_offset
+        : 0;
+
+    if (length < remaining) {
         memcpy((uint8_t *)data,
                (uint8_t *)fp->uncompressed_block + fp->block_offset,
                length);


### PR DESCRIPTION
If length is passed is as > 2^63 then it became negative and passed the "length < len-offset" check, resulting in a crash.

Note this code is really susceptible to slow downs as it's in the main thread.  Benchmarking with 16 threads decoding a gzipped BAM showed a 15% slowdown by using `(ssize_t)length < fp->block_length - fp->block_offset && fp->block_length > fp->block_offset ` and several other constructions.

(This probably also means it's ripe for further improvements if the most subtle changes can have that big a performance impact.  Clearly the correct approach is to decode from bgzf to bam objects in the worker threads, but it's complex here due to the bgzf block boundaries not matching read boundaries, meaning we'd need multiple thread process-queues and piping one into the next so main just has an endless stream of bam objects to reference instead of bytes.)