### PR TITLE
Parallel cram2bam

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2380,7 +2380,7 @@ static int bam_size(sam_hrecs_t *bfd, cram_fd *fd, cram_record *cr) {
  *
  * Note memory for these is in a single malloc.  Hence compute upfront the
  * memory size of each record prior to conversion.
- * 
+ *
  * Returns 0 on success,
  *        -1 on failure
  */
@@ -2405,6 +2405,9 @@ static int bulk_cram_to_bam(sam_hrecs_t *bfd, cram_fd *fd, cram_slice *s) {
                 return -1;
             memset(&bl->bams[bl->nbams], 0,
                    (s->hdr->num_records - bl->nbams) * sizeof(*bl->bams));
+            int i;
+            for (i = bl->nbams; i < s->hdr->num_records; i++)
+                bam_set_mempolicy(&bl->bams[i], BAM_USER_OWNS_STRUCT);
             bl->nbams = s->hdr->num_records;
         }
     } else {
@@ -2414,20 +2417,20 @@ static int bulk_cram_to_bam(sam_hrecs_t *bfd, cram_fd *fd, cram_slice *s) {
             return -1;
         bl->nbams = s->hdr->num_records;
         bl->next = NULL;
-        bl->bams = calloc(s->hdr->num_records, sizeof(bam_seq_t *));
+        bl->bams = calloc(s->hdr->num_records, sizeof(*bl->bams));
         if (!bl->bams) {
             free(bl);
             return -1;
         }
+        int i;
+        for (i = 0; i < s->hdr->num_records; i++)
+            bam_set_mempolicy(&bl->bams[i], BAM_USER_OWNS_STRUCT);
     }
     s->bl = bl;
 
     for (i = 0; i < s->hdr->num_records; i++) {
         int sz = bam_size(bfd, fd, &s->crecs[i]);
-        if (!s->bl->bams[i])
-            if (!(s->bl->bams[i] = bam_init1()))
-                return -1;
-        realloc_bam_data(s->bl->bams[i], sz);
+        realloc_bam_data(&s->bl->bams[i], sz);
     }
 
     for (i = 0; i < s->hdr->num_records; i++) {
@@ -3210,7 +3213,7 @@ int cram_decode_slice_mt(cram_fd *fd, cram_container *c, cram_slice *s,
  *         -1 on failure.
  */
 int cram_to_bam(sam_hdr_t *sh, cram_fd *fd, cram_slice *s,
-                cram_record *cr, int rec, bam_seq_t **bam) {
+                cram_record *cr, int rec, bam_seq_t *bam) {
     int ret, rg_len;
     char name_a[1024], *name;
     int name_len;
@@ -3277,7 +3280,7 @@ int cram_to_bam(sam_hdr_t *sh, cram_fd *fd, cram_slice *s,
         qual = NULL;
     }
 
-    ret = bam_set1(*bam,
+    ret = bam_set1(bam,
                    name_len, name,
                    cr->flags, cr->ref_id, cr->apos - 1, cr->mqual,
                    cr->ncigar, &s->cigar[cr->cigar],
@@ -3288,13 +3291,13 @@ int cram_to_bam(sam_hdr_t *sh, cram_fd *fd, cram_slice *s,
         return ret;
     }
 
-    aux = (char *)bam_aux(*bam);
+    aux = (char *)bam_aux(bam);
 
     /* Auxiliary strings */
     if (cr->aux_size != 0) {
         memcpy(aux, BLOCK_DATA(s->aux_blk) + cr->aux, cr->aux_size);
         aux += cr->aux_size;
-        (*bam)->l_data += cr->aux_size;
+        bam->l_data += cr->aux_size;
     }
 
     /* RG:Z: */
@@ -3304,10 +3307,10 @@ int cram_to_bam(sam_hdr_t *sh, cram_fd *fd, cram_slice *s,
         memcpy(aux, bfd->rg[cr->rg].name, len);
         aux += len;
         *aux++ = 0;
-        (*bam)->l_data += rg_len;
+        bam->l_data += rg_len;
     }
 
-    return (*bam)->l_data;
+    return bam->l_data;
 }
 
 /*
@@ -3743,23 +3746,25 @@ int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam, int *has_CG_tag) {
     c = fd->ctr;
     s = c->slice;
 
+    int policy = bam_get_mempolicy(*bam);
     if (s->bl) {
         // If the user owns the data then we just have to do a slow copy
-        if (bam_get_mempolicy(*bam) & BAM_USER_OWNS_DATA) {
-            return bam_copy1(*bam, s->bl->bams[s->curr_rec-1]) ? 0 : -1;
+        if (policy & BAM_USER_OWNS_DATA) {
+            return bam_copy1(*bam, &s->bl->bams[s->curr_rec-1]) ? 0 : -1;
         }
 
         // Otherwise we'll copy the struct but swap the data pointers over
         uint8_t *data = (*bam)->data;
         uint32_t m_data = (*bam)->m_data;
-        **bam = *s->bl->bams[s->curr_rec-1];
-        s->bl->bams[s->curr_rec-1]->data = data;
-        s->bl->bams[s->curr_rec-1]->m_data = m_data;
+        **bam = s->bl->bams[s->curr_rec-1];
+        bam_set_mempolicy(*bam, policy);
+        s->bl->bams[s->curr_rec-1].data = data;
+        s->bl->bams[s->curr_rec-1].m_data = m_data;
         return 0;
     }
 
     *has_CG_tag = cr->has_CG;
-    return cram_to_bam(fd->header, fd, s, cr, s->curr_rec-1, bam);
+    return cram_to_bam(fd->header, fd, s, cr, s->curr_rec-1, *bam);
 }
 
 /*

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -3272,6 +3272,10 @@ int cram_to_bam(sam_hdr_t *sh, cram_fd *fd, cram_slice *s,
         bam->l_data += rg_len;
     }
 
+    if (cr->has_CG)
+        if (bam_tag2cigar(bam, 1, 1) < 0)
+            return -1;
+
     return bam->l_data;
 }
 
@@ -3697,7 +3701,7 @@ cram_record *cram_get_seq(cram_fd *fd) {
  * Returns >= 0 success (number of bytes written to *bam)
  *        -1 on EOF or failure (check fd->err)
  */
-int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam, int *has_CG_tag) {
+int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam) {
     cram_record *cr;
     cram_container *c;
     cram_slice *s;
@@ -3725,7 +3729,6 @@ int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam, int *has_CG_tag) {
         return 0;
     }
 
-    *has_CG_tag = cr->has_CG;
     return cram_to_bam(fd->header, fd, s, cr, s->curr_rec-1, *bam);
 }
 

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2014,6 +2014,7 @@ static int cram_decode_aux(cram_fd *fd,
     int32_t TL = 0;
     unsigned char *TN;
     uint32_t ds = s->data_series;
+    cr->has_CG = 0;
 
     if (!(ds & (CRAM_TL|CRAM_aux))) {
         cr->aux = 0;
@@ -2046,6 +2047,8 @@ static int cram_decode_aux(cram_fd *fd,
             *has_MD = (BLOCK_SIZE(s->aux_blk)+3) * (TN[2] == '*' ? -1 : 1);
         if (TN[0] == 'N' && TN[1] == 'M' && has_NM)
             *has_NM = (BLOCK_SIZE(s->aux_blk)+3) * (TN[2] == '*' ? -1 : 1);;
+        if (TN[0] == 'C' && TN[1] == 'G')
+            cr->has_CG = 1;
 
         //printf("Tag %d/%d\n", i+1, cr->ntags);
         tag_data[0] = TN[0];
@@ -2957,6 +2960,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
 
         /* Auxiliary tags */
         has_MD = has_NM = 0;
+        cr->has_CG = -1; // unknown
         if (CRAM_MAJOR_VERS(fd->version) == 1)
             r |= cram_decode_aux_1_0(c, s, blk, cr);
         else
@@ -3699,7 +3703,7 @@ cram_record *cram_get_seq(cram_fd *fd) {
  * Returns >= 0 success (number of bytes written to *bam)
  *        -1 on EOF or failure (check fd->err)
  */
-int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam) {
+int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam, int *has_CG_tag) {
     cram_record *cr;
     cram_container *c;
     cram_slice *s;
@@ -3721,9 +3725,28 @@ int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam) {
         // We could also handle the inbetween case were the user doesn't
         // own the data so we can just switch pointers over.
         // For now we take the easy bam_copy approach.
-        return bam_copy1(*bam, s->bl[s->curr_rec-1]) ? 0 : -1;
+        //fprintf(stderr, "mem=%d\n", (*bam)->mempolicy);
+        if ((*bam)->mempolicy != 0) {
+            fprintf(stderr, "mem=%d\n", (*bam)->mempolicy);
+            return bam_copy1(*bam, s->bl[s->curr_rec-1]) ? 0 : -1;
+        }
+
+        // Otherwise we can swap pointers
+        bam1_t *b = *bam;
+        *bam = s->bl[s->curr_rec-1];
+        s->bl[s->curr_rec-1] = b;
+        return 0;
+
+#if 0
+        // Swap bam1_t->data around, but copy struct
+        uint8_t *data_tmp = (*bam)->data;
+        **bam = *s->bl[s->curr_rec-1];
+        s->bl[s->curr_rec-1]->data = data_tmp;
+        return 0;
+#endif
     }
 
+    *has_CG_tag = cr->has_CG;
     return cram_to_bam(fd->header, fd, s, cr, s->curr_rec-1, bam);
 }
 

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../htslib/hts.h"
 #include "../htslib/hts_alloc.h"
 #include "../htslib/hfile.h"
+#include "../sam_internal.h" // realloc_bam_data()
 
 //Whether CIGAR has just M or uses = and X to indicate match and mismatch
 //#define USE_X
@@ -2386,32 +2387,52 @@ static int bam_size(sam_hrecs_t *bfd, cram_fd *fd, cram_record *cr) {
 static int bulk_cram_to_bam(sam_hrecs_t *bfd, cram_fd *fd, cram_slice *s) {
     int i;
     int r = 0;
-    int sizes[10000]; // FIXME: why cache in two passes?
 
-    size_t len = 0;
+    bam_list *bl = NULL;
+    pthread_mutex_lock(&fd->bam_list_lock);
+    if (fd->bl) {
+        bl = fd->bl;
+        fd->bl = fd->bl->next;
+    }
+    pthread_mutex_unlock(&fd->bam_list_lock);
+
+    if (bl) {
+        // Reuse an old bam list, possibly growing it
+        if (s->hdr->num_records > bl->nbams) {
+            bl->bams = realloc(bl->bams, s->hdr->num_records *
+                               sizeof(*bl->bams));
+            if (!bl->bams)
+                return -1;
+            memset(&bl->bams[bl->nbams], 0,
+                   (s->hdr->num_records - bl->nbams) * sizeof(*bl->bams));
+            bl->nbams = s->hdr->num_records;
+        }
+    } else {
+        // Create a new bam list
+        bl = calloc(1, sizeof(*bl));
+        if (!bl)
+            return -1;
+        bl->nbams = s->hdr->num_records;
+        bl->next = NULL;
+        bl->bams = calloc(s->hdr->num_records, sizeof(bam_seq_t *));
+        if (!bl->bams) {
+            free(bl);
+            return -1;
+        }
+    }
+    s->bl = bl;
+
     for (i = 0; i < s->hdr->num_records; i++) {
         int sz = bam_size(bfd, fd, &s->crecs[i]);
-        if (i < 10000)
-            sizes[i] = sz;
-        len += round8(sz);
+        if (!s->bl->bams[i])
+            if (!(s->bl->bams[i] = bam_init1()))
+                return -1;
+        realloc_bam_data(s->bl->bams[i], sz);
     }
 
-    s->bl = (bam_seq_t **)malloc(s->hdr->num_records * sizeof(*s->bl) + len + 8);
-    if (!s->bl)
-        return -1;
-
-    // Round up to next multiple of 8, to ensure bam structs are 8-byte aligned.
-    char *x = ((char *)s->bl) + round8(s->hdr->num_records * sizeof(*s->bl));
     for (i = 0; i < s->hdr->num_records; i++) {
-        bam_seq_t *b = (bam_seq_t *)x, *o = b;
-        int bsize = i < 10000 ? sizes[i] : bam_size(bfd, fd, &s->crecs[i]);
-        b->m_data = bsize;
-        b->data = (uint8_t *)b + sizeof(*b);
-        r |= (cram_to_bam(fd->header, fd, s, &s->crecs[i], i, &b) < 0);
-        // if we allocated enough, the above won't have resized b
-        assert(o == b && o->m_data == bsize);
-        x += round8(bsize);
-        s->bl[i] = b;
+        r |= (cram_to_bam(fd->header, fd, s, &s->crecs[i], i,
+                          &s->bl->bams[i]) < 0);
     }
 
     return r?-1:0;
@@ -3646,6 +3667,14 @@ cram_record *cram_get_seq(cram_fd *fd) {
         if (c && c->slice && c->slice->curr_rec < c->slice->max_rec) {
             s = c->slice;
         } else {
+            // Save old spare bams list if needed
+            if (c && (s = c->slice) && s->bl) {
+                pthread_mutex_lock(&fd->bam_list_lock);
+                s->bl->next = fd->bl;
+                fd->bl = s->bl;
+                pthread_mutex_unlock(&fd->bam_list_lock);
+                s->bl = NULL;
+            }
             if (!(s = cram_next_slice(fd, &c)))
                 return NULL;
             continue; /* In case slice contains no records */
@@ -3715,35 +3744,18 @@ int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam, int *has_CG_tag) {
     s = c->slice;
 
     if (s->bl) {
-        //*bam = s->bl[s->curr_rec-1]; return 0;
-
-        // TODO:
-        // Ideally we'd check bam->mempolicy and if not BAM_USER_OWNS_STRUCT
-        // and not BAM_USER_OWNS_DATA then we can just do
-        // *bam = s->bl[s->curr_rec-1];
-        //
-        // We could also handle the inbetween case were the user doesn't
-        // own the data so we can just switch pointers over.
-        // For now we take the easy bam_copy approach.
-        //fprintf(stderr, "mem=%d\n", (*bam)->mempolicy);
-        if ((*bam)->mempolicy != 0) {
-            fprintf(stderr, "mem=%d\n", (*bam)->mempolicy);
-            return bam_copy1(*bam, s->bl[s->curr_rec-1]) ? 0 : -1;
+        // If the user owns the data then we just have to do a slow copy
+        if (bam_get_mempolicy(*bam) & BAM_USER_OWNS_DATA) {
+            return bam_copy1(*bam, s->bl->bams[s->curr_rec-1]) ? 0 : -1;
         }
 
-        // Otherwise we can swap pointers
-        bam1_t *b = *bam;
-        *bam = s->bl[s->curr_rec-1];
-        s->bl[s->curr_rec-1] = b;
+        // Otherwise we'll copy the struct but swap the data pointers over
+        uint8_t *data = (*bam)->data;
+        uint32_t m_data = (*bam)->m_data;
+        **bam = *s->bl->bams[s->curr_rec-1];
+        s->bl->bams[s->curr_rec-1]->data = data;
+        s->bl->bams[s->curr_rec-1]->m_data = m_data;
         return 0;
-
-#if 0
-        // Swap bam1_t->data around, but copy struct
-        uint8_t *data_tmp = (*bam)->data;
-        **bam = *s->bl[s->curr_rec-1];
-        s->bl[s->curr_rec-1]->data = data_tmp;
-        return 0;
-#endif
     }
 
     *has_CG_tag = cr->has_CG;

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2343,39 +2343,6 @@ static int cram_decode_tlen(cram_fd *fd, cram_container *c, cram_slice *s,
     return r;
 }
 
-/*
- * Bulk conversion of an entire cram slice to an array of bam objects.
- * (Assumption that fd->required_fields will not change from one
- * cram_get_bam_seq() call to the  next.)
- *
- * Returns 0 on success
- *        -1 on failure
- */
-#define round4(v) (((v-1)&~3)+4)
-#define round8(v) (((v-1)&~7)+8)
-static int bam_size(sam_hrecs_t *bfd, cram_fd *fd, cram_record *cr) {
-    int name_len, rg_len;
-
-    // See cram_to_bam function for these sizes
-    if (fd->required_fields & SAM_QNAME) {
-        if (cr->name_len)
-            name_len = cr->name_len;
-        else
-            name_len = strlen(fd->prefix) + 20; // overestimate; uint64
-    } else {
-        name_len = 1;
-    }
-
-    rg_len = (cr->rg != -1) ? bfd->rg[cr->rg].name_len + 4 : 0;
-
-    return sizeof(bam_seq_t)
-        + round4(name_len + 1) // nul padding
-        + 4 * cr->ncigar
-        + (cr->len+1)/2        // seq
-        + cr->len              // qual
-        + cr->aux_size + rg_len + 1;
-}
-
 /* Converts an entire slice worth of CRAM objects to BAM objects.
  *
  * Note memory for these is in a single malloc.  Hence compute upfront the
@@ -2427,11 +2394,6 @@ static int bulk_cram_to_bam(sam_hrecs_t *bfd, cram_fd *fd, cram_slice *s) {
             bam_set_mempolicy(&bl->bams[i], BAM_USER_OWNS_STRUCT);
     }
     s->bl = bl;
-
-    for (i = 0; i < s->hdr->num_records; i++) {
-        int sz = bam_size(bfd, fd, &s->crecs[i]);
-        realloc_bam_data(&s->bl->bams[i], sz);
-    }
 
     for (i = 0; i < s->hdr->num_records; i++) {
         r |= (cram_to_bam(fd->header, fd, s, &s->crecs[i], i,

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2340,6 +2340,81 @@ static int cram_decode_tlen(cram_fd *fd, cram_container *c, cram_slice *s,
 }
 
 /*
+ * Bulk conversion of an entire cram slice to an array of bam objects.
+ * (Assumption that fd->required_fields will not change from one
+ * cram_get_bam_seq() call to the  next.)
+ *
+ * Returns 0 on success
+ *        -1 on failure
+ */
+#define round4(v) (((v-1)&~3)+4)
+#define round8(v) (((v-1)&~7)+8)
+static int bam_size(sam_hrecs_t *bfd, cram_fd *fd, cram_record *cr) {
+    int name_len, rg_len;
+
+    // See cram_to_bam function for these sizes
+    if (fd->required_fields & SAM_QNAME) {
+        if (cr->name_len)
+            name_len = cr->name_len;
+        else
+            name_len = strlen(fd->prefix) + 20; // overestimate; uint64
+    } else {
+        name_len = 1;
+    }
+
+    rg_len = (cr->rg != -1) ? bfd->rg[cr->rg].name_len + 4 : 0;
+
+    return sizeof(bam_seq_t)
+        + round4(name_len + 1) // nul padding
+        + 4 * cr->ncigar
+        + (cr->len+1)/2        // seq
+        + cr->len              // qual
+        + cr->aux_size + rg_len + 1;
+}
+
+/* Converts an entire slice worth of CRAM objects to BAM objects.
+ *
+ * Note memory for these is in a single malloc.  Hence compute upfront the
+ * memory size of each record prior to conversion.
+ * 
+ * Returns 0 on success,
+ *        -1 on failure
+ */
+static int bulk_cram_to_bam(sam_hrecs_t *bfd, cram_fd *fd, cram_slice *s) {
+    int i;
+    int r = 0;
+    int sizes[10000]; // FIXME: why cache in two passes?
+
+    size_t len = 0;
+    for (i = 0; i < s->hdr->num_records; i++) {
+        int sz = bam_size(bfd, fd, &s->crecs[i]);
+        if (i < 10000)
+            sizes[i] = sz;
+        len += round8(sz);
+    }
+
+    s->bl = (bam_seq_t **)malloc(s->hdr->num_records * sizeof(*s->bl) + len + 8);
+    if (!s->bl)
+        return -1;
+
+    // Round up to next multiple of 8, to ensure bam structs are 8-byte aligned.
+    char *x = ((char *)s->bl) + round8(s->hdr->num_records * sizeof(*s->bl));
+    for (i = 0; i < s->hdr->num_records; i++) {
+        bam_seq_t *b = (bam_seq_t *)x, *o = b;
+        int bsize = i < 10000 ? sizes[i] : bam_size(bfd, fd, &s->crecs[i]);
+        b->m_data = bsize;
+        b->data = (uint8_t *)b + sizeof(*b);
+        r |= (cram_to_bam(fd->header, fd, s, &s->crecs[i], i, &b) < 0);
+        // if we allocated enough, the above won't have resized b
+        assert(o == b && o->m_data == bsize);
+        x += round8(bsize);
+        s->bl[i] = b;
+    }
+
+    return r?-1:0;
+}
+
+/*
  * Decode an entire slice from container blocks. Fills out s->crecs[] array.
  * Returns 0 on success
  *        -1 on failure
@@ -3009,6 +3084,17 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
     BLOCK_RESIZE_EXACT(s->name_blk, BLOCK_SIZE(s->name_blk)+1);
     BLOCK_RESIZE_EXACT(s->aux_blk,  BLOCK_SIZE(s->aux_blk)+1);
 
+    // If we're wanting BAM records, convert these up-front too.
+    // This is useful when we're streaming lots of data in a
+    // multi-threaded environment as the cram to bam conversion is
+    // then threaded too.
+    //
+    // Possible future optimisation - check range query and don't
+    // convert all reads to BAM.
+
+    if (fd->pool)
+        r |= bulk_cram_to_bam(bfd, fd, s);
+
     return r;
 
  block_err:
@@ -3623,6 +3709,20 @@ int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam) {
 
     c = fd->ctr;
     s = c->slice;
+
+    if (s->bl) {
+        //*bam = s->bl[s->curr_rec-1]; return 0;
+
+        // TODO:
+        // Ideally we'd check bam->mempolicy and if not BAM_USER_OWNS_STRUCT
+        // and not BAM_USER_OWNS_DATA then we can just do
+        // *bam = s->bl[s->curr_rec-1];
+        //
+        // We could also handle the inbetween case were the user doesn't
+        // own the data so we can just switch pointers over.
+        // For now we take the easy bam_copy approach.
+        return bam_copy1(*bam, s->bl[s->curr_rec-1]) ? 0 : -1;
+    }
 
     return cram_to_bam(fd->header, fd, s, cr, s->curr_rec-1, bam);
 }

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../htslib/hts.h"
 #include "../htslib/hts_alloc.h"
 #include "../htslib/hfile.h"
-#include "../sam_internal.h" // realloc_bam_data()
+#include "../sam_internal.h" // bam_tag2cigar()
 
 //Whether CIGAR has just M or uses = and X to indicate match and mismatch
 //#define USE_X
@@ -2366,10 +2366,12 @@ static int bulk_cram_to_bam(sam_hrecs_t *bfd, cram_fd *fd, cram_slice *s) {
     if (bl) {
         // Reuse an old bam list, possibly growing it
         if (s->hdr->num_records > bl->nbams) {
-            bl->bams = hts_realloc_p(bl->bams, s->hdr->num_records,
-                                     sizeof(*bl->bams));
-            if (!bl->bams)
+            bam_seq_t *bams;
+            bams = hts_realloc_p(bl->bams, s->hdr->num_records,
+                                 sizeof(*bl->bams));
+            if (!bams)
                 return -1;
+            bl->bams = bams;
             memset(&bl->bams[bl->nbams], 0,
                    (s->hdr->num_records - bl->nbams) * sizeof(*bl->bams));
             int i;

--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -2366,8 +2366,8 @@ static int bulk_cram_to_bam(sam_hrecs_t *bfd, cram_fd *fd, cram_slice *s) {
     if (bl) {
         // Reuse an old bam list, possibly growing it
         if (s->hdr->num_records > bl->nbams) {
-            bl->bams = realloc(bl->bams, s->hdr->num_records *
-                               sizeof(*bl->bams));
+            bl->bams = hts_realloc_p(bl->bams, s->hdr->num_records,
+                                     sizeof(*bl->bams));
             if (!bl->bams)
                 return -1;
             memset(&bl->bams[bl->nbams], 0,

--- a/cram/cram_decode.h
+++ b/cram/cram_decode.h
@@ -120,7 +120,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
  * the allocated size. These can initially be pointers to NULL and zero.
  *
  * This function will reallocate the bam buffer as required and update
- * (*bam)->alloc accordingly, allowing it to be used within a loop
+ * bam->alloc accordingly, allowing it to be used within a loop
  * efficiently without needing to allocate new bam objects over and
  * over again.
  *
@@ -128,7 +128,7 @@ int cram_decode_slice(cram_fd *fd, cram_container *c, cram_slice *s,
  *         -1 on failure.
  */
 int cram_to_bam(sam_hdr_t *sh, cram_fd *fd, cram_slice *s,
-                cram_record *cr, int rec, bam_seq_t **bam);
+                cram_record *cr, int rec, bam_seq_t *bam);
 
 /*
  * Drains and frees the decode read-queue for a multi-threaded reader.

--- a/cram/cram_decode.h
+++ b/cram/cram_decode.h
@@ -67,7 +67,7 @@ cram_record *cram_get_seq(cram_fd *fd);
  * Returns 0 on success;
  *        -1 on EOF or failure (check fd->err)
  */
-int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam, int *has_CG_tag);
+int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam);
 
 
 /* ----------------------------------------------------------------------

--- a/cram/cram_decode.h
+++ b/cram/cram_decode.h
@@ -67,7 +67,7 @@ cram_record *cram_get_seq(cram_fd *fd);
  * Returns 0 on success;
  *        -1 on EOF or failure (check fd->err)
  */
-int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam);
+int cram_get_bam_seq(cram_fd *fd, bam_seq_t **bam, int *has_CG_tag);
 
 
 /* ----------------------------------------------------------------------

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1853,7 +1853,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
     cram_block *c_hdr;
     int multi_ref = 0;
     int r1, r2, sn, nref, embed_ref, no_ref;
-    spare_bams *spares;
+    bam_list *spares;
 
     if (!c->bams)
         goto err;
@@ -2139,8 +2139,9 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
     /* Link our bams[] array onto the spare bam list for reuse */
     spares = malloc(sizeof(*spares));
     if (!spares) goto_err;
-    pthread_mutex_lock(&fd->bam_list_lock);
     spares->bams = c->bams;
+    spares->nbams = c->nbams;
+    pthread_mutex_lock(&fd->bam_list_lock);
     spares->next = fd->bl;
     fd->bl = spares;
     pthread_mutex_unlock(&fd->bam_list_lock);
@@ -4186,12 +4187,23 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
         /* First time through, allocate a set of bam pointers */
         pthread_mutex_lock(&fd->bam_list_lock);
         if (fd->bl) {
-            spare_bams *spare = fd->bl;
+            bam_list *spare = fd->bl;
+            if (c->max_c_rec > spare->nbams) {
+                if (!(spare->bams =
+                      realloc(spare->bams,
+                              c->max_c_rec * sizeof(bam_seq_t*)))) {
+                    pthread_mutex_unlock(&fd->bam_list_lock);
+                    return -1;
+                }
+                spare->nbams = c->max_c_rec;
+            }
             c->bams = spare->bams;
+            c->nbams = spare->nbams;
             fd->bl = spare->next;
             free(spare);
         } else {
             c->bams = calloc(c->max_c_rec, sizeof(bam_seq_t *));
+            c->nbams = c->max_c_rec;
             if (!c->bams) {
                 pthread_mutex_unlock(&fd->bam_list_lock);
                 return -1;
@@ -4202,6 +4214,10 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
 
     /* Copy or alloc+copy the bam record, for later encoding */
     if (c->bams[c->curr_c_rec]) {
+        // IDEA: We could have a cram_put_bam_seq_fast which does pointer
+        // swapping for bam1_t->data.  The caller would need to accept
+        // that the bam object it passes in is modified, but this is often
+        // fine if we're doing a read-write loop.
         if (bam_copy1(c->bams[c->curr_c_rec], b) == NULL)
             return -1;
     } else {

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1216,11 +1216,12 @@ static int cram_encode_slice(cram_fd *fd, cram_container *c,
     {
         int i, j;
 
-        s->hdr->block_content_ids = hts_realloc_p(s->hdr->block_content_ids,
-                                                  sizeof(*s->hdr->block_content_ids),
-                                                  s->hdr->num_blocks);
-        if (!s->hdr->block_content_ids)
+        int32_t *bids = hts_realloc_p(s->hdr->block_content_ids,
+                                      sizeof(*s->hdr->block_content_ids),
+                                      s->hdr->num_blocks);
+        if (!bids)
             return -1;
+        s->hdr->block_content_ids = bids;
 
         for (i = j = 1; i < s->hdr->num_blocks; i++) {
             if (!s->block[i] || s->block[i] == s->block[0])
@@ -2580,9 +2581,11 @@ static int cram_add_feature(cram_container *c, cram_slice *s,
                             cram_record *r, cram_feature *f) {
     if (s->nfeatures >= s->afeatures) {
         s->afeatures = s->afeatures ? s->afeatures*2 : 1024;
-        s->features = hts_realloc_p(s->features, sizeof(*s->features), s->afeatures);
-        if (!s->features)
+        cram_feature *features
+            = hts_realloc_p(s->features, sizeof(*s->features), s->afeatures);
+        if (!features)
             return -1;
+        s->features = features;
     }
 
     if (!r->nfeature++) {
@@ -3489,9 +3492,11 @@ static int process_one_read(cram_fd *fd, cram_container *c,
         cr->ncigar      = bam_cigar_len(b);
         while (cr->cigar + cr->ncigar >= s->cigar_alloc) {
             s->cigar_alloc = s->cigar_alloc ? s->cigar_alloc*2 : 1024;
-            s->cigar = hts_realloc_p(s->cigar, sizeof(*s->cigar), s->cigar_alloc);
-            if (!s->cigar)
+            uint32_t *cigar
+                = hts_realloc_p(s->cigar, sizeof(*s->cigar), s->cigar_alloc);
+            if (!cigar)
                 return -1;
+            s->cigar = cigar;
         }
 
         cig_to = (uint32_t *)s->cigar;
@@ -4189,12 +4194,14 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
         if (fd->bl) {
             bam_list *spare = fd->bl;
             if (c->max_c_rec > spare->nbams) {
-                if (!(spare->bams =
-                      hts_realloc_p(spare->bams, c->max_c_rec,
-                                    sizeof(*spare->bams)))) {
+                bam_seq_t *bams
+                    = hts_realloc_p(spare->bams, c->max_c_rec,
+                                    sizeof(*spare->bams));
+                if (!bams) {
                     pthread_mutex_unlock(&fd->bam_list_lock);
                     return -1;
                 }
+                spare->bams = bams;
                 int i;
                 for (i = spare->nbams; i < c->max_c_rec; i++)
                     bam_set_mempolicy(&spare->bams[i], BAM_USER_OWNS_STRUCT);

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -1359,7 +1359,7 @@ static int lossy_read_names(cram_fd *fd, cram_container *c, cram_slice *s,
     // 1: Iterate through names to count frequency
     for (r1 = bam_start, r2 = 0; r2 < s->hdr->num_records; r1++, r2++) {
         //cram_record *cr = &s->crecs[r2];
-        bam_seq_t *b = c->bams[r1];
+        bam_seq_t *b = &c->bams[r1];
         khint_t k;
         int n;
         uint64_t e;
@@ -1402,7 +1402,7 @@ static int lossy_read_names(cram_fd *fd, cram_container *c, cram_slice *s,
     // 2: Remove names if all present (hd.i == -1)
     for (r1 = bam_start, r2 = 0; r2 < s->hdr->num_records; r1++, r2++) {
         cram_record *cr = &s->crecs[r2];
-        bam_seq_t *b = c->bams[r1];
+        bam_seq_t *b = &c->bams[r1];
         khint_t k;
 
         k = kh_get(m_s2u64, names, bam_name(b));
@@ -1443,7 +1443,7 @@ static int add_read_names(cram_fd *fd, cram_container *c, cram_slice *s,
          r1 < c->curr_c_rec && r2 < s->hdr->num_records;
          r1++, r2++) {
         cram_record *cr = &s->crecs[r2];
-        bam_seq_t *b = c->bams[r1];
+        bam_seq_t *b = &c->bams[r1];
 
         cr->name        = BLOCK_SIZE(s->name_blk);
         if ((cr->cram_flags & CRAM_FLAG_DETACHED) || keep_names) {
@@ -1739,15 +1739,15 @@ static int cram_generate_reference(cram_container *c, cram_slice *s, int r1) {
     // user told us to do embed_ref=2.
     char *ref = NULL;
     uint32_t (*hist)[5] = NULL;
-    hts_pos_t ref_start = c->bams[r1]->core.pos, ref_end = 0,
+    hts_pos_t ref_start = c->bams[r1].core.pos, ref_end = 0,
         ref_end_alloc = 0;
     if (ref_start < 0)
         return -1; // cannot build consensus from unmapped data
 
     // initial allocation
     if (extend_ref(&ref, &hist,
-                   c->bams[r1 + s->hdr->num_records-1]->core.pos +
-                   c->bams[r1 + s->hdr->num_records-1]->core.l_qseq,
+                   c->bams[r1 + s->hdr->num_records-1].core.pos +
+                   c->bams[r1 + s->hdr->num_records-1].core.l_qseq,
                    ref_start, &ref_end, &ref_end_alloc) < 0)
         return -1;
 
@@ -1755,12 +1755,12 @@ static int cram_generate_reference(cram_container *c, cram_slice *s, int r1) {
     int r2;
     hts_pos_t last_pos = -1;
     for (r2 = 0; r1 < c->curr_c_rec && r2 < s->hdr->num_records; r1++, r2++) {
-        if (c->bams[r1]->core.pos < last_pos) {
+        if (c->bams[r1].core.pos < last_pos) {
             hts_log_error("Cannot build reference with unsorted data");
             goto err;
         }
-        last_pos = c->bams[r1]->core.pos;
-        if (cram_add_to_ref(c->bams[r1], &ref, &hist, ref_start, &ref_end,
+        last_pos = c->bams[r1].core.pos;
+        if (cram_add_to_ref(&c->bams[r1], &ref, &hist, ref_start, &ref_end,
                             &ref_end_alloc) < 0)
             goto err;
     }
@@ -1889,9 +1889,9 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
     /* To create M5 strings */
     /* Fetch reference sequence */
     if (!no_ref) {
-        if (!c->bams || !c->curr_c_rec || !c->bams[0])
+        if (!c->bams || !c->curr_c_rec || !c->nbams)
             goto_err;
-        bam_seq_t *b = c->bams[0];
+        bam_seq_t *b = &c->bams[0];
 
         if (embed_ref <= 1) {
             char *ref = cram_get_ref(fd, bam_ref(b), 1, 0);
@@ -1956,7 +1956,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
         }
         c->ref_seq_id = c->ref_id;
     } else {
-        c->ref_id = bam_ref(c->bams[0]);
+        c->ref_id = bam_ref(&c->bams[0]);
         cram_ref_incr(fd->refs, c->ref_id);
         c->ref_seq_id = c->ref_id;
     }
@@ -2038,7 +2038,7 @@ int cram_encode_container(cram_fd *fd, cram_container *c) {
         // fields and just gathering stats for others.
         for (r2 = 0; r1 < c->curr_c_rec && r2 < s->hdr->num_records; r1++, r2++) {
             cram_record *cr = &s->crecs[r2];
-            bam_seq_t *b = c->bams[r1];
+            bam_seq_t *b = &c->bams[r1];
 
             /* If multi-ref we need to cope with changing reference per seq */
             if (c->multi_seq && !no_ref) {
@@ -4191,10 +4191,13 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
             if (c->max_c_rec > spare->nbams) {
                 if (!(spare->bams =
                       realloc(spare->bams,
-                              c->max_c_rec * sizeof(bam_seq_t*)))) {
+                              c->max_c_rec * sizeof(*spare->bams)))) {
                     pthread_mutex_unlock(&fd->bam_list_lock);
                     return -1;
                 }
+                int i;
+                for (i = spare->nbams; i < c->max_c_rec; i++)
+                    bam_set_mempolicy(&spare->bams[i], BAM_USER_OWNS_STRUCT);
                 spare->nbams = c->max_c_rec;
             }
             c->bams = spare->bams;
@@ -4202,29 +4205,25 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
             fd->bl = spare->next;
             free(spare);
         } else {
-            c->bams = calloc(c->max_c_rec, sizeof(bam_seq_t *));
+            c->bams = calloc(c->max_c_rec, sizeof(*c->bams));
             c->nbams = c->max_c_rec;
             if (!c->bams) {
                 pthread_mutex_unlock(&fd->bam_list_lock);
                 return -1;
             }
+            int i;
+            for (i = 0; i < c->max_c_rec; i++)
+                bam_set_mempolicy(&c->bams[i], BAM_USER_OWNS_STRUCT);
         }
         pthread_mutex_unlock(&fd->bam_list_lock);
     }
 
-    /* Copy or alloc+copy the bam record, for later encoding */
-    if (c->bams[c->curr_c_rec]) {
-        // IDEA: We could have a cram_put_bam_seq_fast which does pointer
-        // swapping for bam1_t->data.  The caller would need to accept
-        // that the bam object it passes in is modified, but this is often
-        // fine if we're doing a read-write loop.
-        if (bam_copy1(c->bams[c->curr_c_rec], b) == NULL)
-            return -1;
-    } else {
-        c->bams[c->curr_c_rec] = bam_dup1(b);
-        if (c->bams[c->curr_c_rec] == NULL)
-            return -1;
-    }
+    // IDEA: We could have a cram_put_bam_seq_fast which does pointer
+    // swapping for bam1_t->data.  The caller would need to accept
+    // that the bam object it passes in is modified, but this is often
+    // fine if we're doing a read-write loop.
+    if (bam_copy1(&c->bams[c->curr_c_rec], b) == NULL)
+        return -1;
     if (bam_seq_len(b)) {
         c->s_num_bases += bam_seq_len(b);
     } else {

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -4190,8 +4190,8 @@ int cram_put_bam_seq(cram_fd *fd, bam_seq_t *b) {
             bam_list *spare = fd->bl;
             if (c->max_c_rec > spare->nbams) {
                 if (!(spare->bams =
-                      realloc(spare->bams,
-                              c->max_c_rec * sizeof(*spare->bams)))) {
+                      hts_realloc_p(spare->bams, c->max_c_rec,
+                                    sizeof(*spare->bams)))) {
                     pthread_mutex_unlock(&fd->bam_list_lock);
                     return -1;
                 }

--- a/cram/cram_external.c
+++ b/cram/cram_external.c
@@ -876,7 +876,7 @@ int cram_filter_container(cram_fd *in, cram_fd *out, cram_container *c,
             break;
 
         // Broadly rquivalent to cram_get_bam_seq, but starting from 'cr'
-        err |= cram_to_bam(in->header, in, s, cr, s->curr_rec++, &b) < 0;
+        err |= cram_to_bam(in->header, in, s, cr, s->curr_rec++, b) < 0;
 
         if (cram_put_bam_seq(out, b) < 0) {
             err |= 1;

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3694,10 +3694,10 @@ cram_container *cram_new_container(int nrec, int nslice) {
     return NULL;
 }
 
-static void free_bam_list(bam_seq_t **bams, int max_rec) {
+static void free_bam_list(bam_seq_t *bams, int max_rec) {
     int i;
     for (i = 0; i < max_rec; i++)
-        bam_free(bams[i]);
+        bam_free(&bams[i]);
 
     free(bams);
 }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -4422,8 +4422,10 @@ void cram_free_slice(cram_slice *s) {
     if (!s)
         return;
 
-    if (s->bl)
+    if (s->bl) {
+        free_bam_list(s->bl->bams, s->bl->nbams);
         free(s->bl);
+    }
 
     if (s->hdr_block)
         cram_free_block(s->hdr_block);
@@ -5559,7 +5561,7 @@ int cram_write_eof_block(cram_fd *fd) {
  *        -1 on failure
  */
 int cram_close(cram_fd *fd) {
-    spare_bams *bl, *next;
+    bam_list *bl, *next;
     int i, ret = 0;
 
     if (!fd)
@@ -5602,10 +5604,8 @@ int cram_close(cram_fd *fd) {
     }
 
     for (bl = fd->bl; bl; bl = next) {
-        int max_rec = fd->seqs_per_slice * fd->slices_per_container;
-
         next = bl->next;
-        free_bam_list(bl->bams, max_rec);
+        free_bam_list(bl->bams, bl->nbams);
         free(bl);
     }
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -4422,6 +4422,9 @@ void cram_free_slice(cram_slice *s) {
     if (!s)
         return;
 
+    if (s->bl)
+        free(s->bl);
+
     if (s->hdr_block)
         cram_free_block(s->hdr_block);
 

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -464,6 +464,7 @@ struct cram_container {
 
     /* For multi-threading */
     bam_seq_t **bams;
+    int nbams;            // size of associated bams array
 
     /* Statistics for encoding */
     cram_stats *stats[DS_END];
@@ -602,6 +603,12 @@ typedef union cram_feature {
     } H;
 } cram_feature;
 
+typedef struct bam_list {
+    bam_seq_t **bams;
+    struct bam_list *next;
+    int nbams;
+} bam_list;
+
 /*
  * A slice is really just a set of blocks, but it
  * is the logical unit for decoding a number of
@@ -666,7 +673,7 @@ struct cram_slice {
     int slice_num;               // To be copied into c->curr_slice in decode
 
     // Cache of converted BAM structs
-    bam_seq_t **bl;
+    bam_list *bl;
 };
 
 /*-----------------------------------------------------------------------------
@@ -748,11 +755,6 @@ typedef struct {
 /*-----------------------------------------------------------------------------
  */
 /* CRAM File handle */
-
-typedef struct spare_bams {
-    bam_seq_t **bams;
-    struct spare_bams *next;
-} spare_bams;
 
 struct cram_fd;
 typedef struct varint_vec {
@@ -869,7 +871,7 @@ struct cram_fd {
     pthread_mutex_t metrics_lock;
     pthread_mutex_t ref_lock;
     pthread_mutex_t range_lock;
-    spare_bams *bl;
+    bam_list *bl; // linked list of arrays of spare bam records
     pthread_mutex_t bam_list_lock;
     void *job_pending;
     int ooc;                            // out of containers.

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -463,7 +463,7 @@ struct cram_container {
     //struct ref_entry *ref;
 
     /* For multi-threading */
-    bam_seq_t **bams;
+    bam_seq_t *bams;
     int nbams;            // size of associated bams array
 
     /* Statistics for encoding */
@@ -604,7 +604,7 @@ typedef union cram_feature {
 } cram_feature;
 
 typedef struct bam_list {
-    bam_seq_t **bams;
+    bam_seq_t *bams;
     struct bam_list *next;
     int nbams;
 } bam_list;

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -662,6 +662,9 @@ struct cram_slice {
 
     int max_rec, curr_rec;       // current and max recs per slice
     int slice_num;               // To be copied into c->curr_slice in decode
+
+    // Cache of converted BAM structs
+    bam_seq_t **bl;
 };
 
 /*-----------------------------------------------------------------------------

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -521,6 +521,8 @@ typedef struct cram_record {
     uint32_t feature;     // idx to s->feature
     uint32_t nfeature;    // number of features
     int32_t mate_flags;   // MF
+
+    int has_CG;           // used to avoid bam_tag2cigar call
 } cram_record;
 
 // Accessor macros as an analogue of the bam ones

--- a/sam.c
+++ b/sam.c
@@ -1556,11 +1556,12 @@ static int cram_readrec(BGZF *ignored, void *fpv, void *bv, int *tid, hts_pos_t 
     int pass_filter, ret;
 
     do {
-        ret = cram_get_bam_seq(fp->fp.cram, &b);
+        int has_CG_tag = 0;
+        ret = cram_get_bam_seq(fp->fp.cram, &b, &has_CG_tag);
         if (ret < 0)
             return cram_eof(fp->fp.cram) ? -1 : -2;
 
-        if (bam_tag2cigar(b, 1, 1) < 0)
+        if (has_CG_tag && bam_tag2cigar(b, 1, 1) < 0)
             return -2;
 
         *tid = b->core.tid;
@@ -4145,11 +4146,12 @@ static inline int sam_read1_bam(htsFile *fp, sam_hdr_t *h, bam1_t *b) {
 
 // Internal component of sam_read1 below
 static inline int sam_read1_cram(htsFile *fp, sam_hdr_t *h, bam1_t **b) {
-    int ret = cram_get_bam_seq(fp->fp.cram, b);
+    int has_CG_tag = 0;
+    int ret = cram_get_bam_seq(fp->fp.cram, b, &has_CG_tag);
     if (ret < 0)
         return cram_eof(fp->fp.cram) ? -1 : -2;
 
-    if (bam_tag2cigar(*b, 1, 1) < 0)
+    if (has_CG_tag && bam_tag2cigar(*b, 1, 1) < 0)
         return -2;
 
     return ret;

--- a/sam.c
+++ b/sam.c
@@ -678,7 +678,8 @@ hts_pos_t bam_endpos(const bam1_t *b)
     return b->core.pos + rlen;
 }
 
-static int bam_tag2cigar(bam1_t *b, int recal_bin, int give_warning) // return 0 if CIGAR is untouched; 1 if CIGAR is updated with CG
+// return 0 if CIGAR is untouched; 1 if CIGAR is updated with CG
+int bam_tag2cigar(bam1_t *b, int recal_bin, int give_warning)
 {
     bam1_core_t *c = &b->core;
 
@@ -1556,13 +1557,9 @@ static int cram_readrec(BGZF *ignored, void *fpv, void *bv, int *tid, hts_pos_t 
     int pass_filter, ret;
 
     do {
-        int has_CG_tag = 0;
-        ret = cram_get_bam_seq(fp->fp.cram, &b, &has_CG_tag);
+        ret = cram_get_bam_seq(fp->fp.cram, &b);
         if (ret < 0)
             return cram_eof(fp->fp.cram) ? -1 : -2;
-
-        if (has_CG_tag && bam_tag2cigar(b, 1, 1) < 0)
-            return -2;
 
         *tid = b->core.tid;
         *beg = b->core.pos;
@@ -4146,13 +4143,9 @@ static inline int sam_read1_bam(htsFile *fp, sam_hdr_t *h, bam1_t *b) {
 
 // Internal component of sam_read1 below
 static inline int sam_read1_cram(htsFile *fp, sam_hdr_t *h, bam1_t **b) {
-    int has_CG_tag = 0;
-    int ret = cram_get_bam_seq(fp->fp.cram, b, &has_CG_tag);
+    int ret = cram_get_bam_seq(fp->fp.cram, b);
     if (ret < 0)
         return cram_eof(fp->fp.cram) ? -1 : -2;
-
-    if (has_CG_tag && bam_tag2cigar(*b, 1, 1) < 0)
-        return -2;
 
     return ret;
 }

--- a/sam_internal.h
+++ b/sam_internal.h
@@ -117,6 +117,8 @@ static inline void nibble2base(uint8_t *nib, char *seq, int len) {
 #endif
 }
 
+int bam_tag2cigar(bam1_t *b, int recal_bin, int give_warning);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The main thread does a lot of work in `cram_to_bam` and `bam_set1`.  Io_lib's model for this was to put this code into the worker threads.  I thought I'd done that here too (I have for the writer already), but apparently not.  This PR fixes that.

A profile of the main thread:

```
$ ./test/test_view.dev -B -@32  ~/scratch/data/novaseq.10m.cram & perf record -t $! 2>/dev/null;perf report -n 2>/dev/null| head -20 | egrep -v '^#'
[1] 3634487
[1]+  Done                    ./test/test_view.dev -B -@32 ~/scratch/data/novaseq.10m.cram
    49.75%          2100  test_view.dev  test_view.dev      [.] bam_set1
     9.51%           407  test_view.dev  test_view.dev      [.] cram_to_bam
     5.93%           266  test_view.dev  libc.so.6          [.] __memmove_avx512_unaligned_erms
     3.13%           129  test_view.dev  libc.so.6          [.] __strncpy_evex
     2.50%            92  test_view.dev  [unknown]          [k] 0xffffffff82cb9b7e
     2.37%            97  test_view.dev  test_view.dev      [.] cram_get_seq
     2.25%            92  test_view.dev  test_view.dev      [.] sam_read1
     2.11%            92  test_view.dev  test_view.dev      [.] bam_cigar2rqlens
     1.65%            64  test_view.dev  test_view.dev      [.] cram_get_bam_seq
```


With this PR:

```
@ qpg-gpu-01[samtools.../htslib]; ./test/test_view.cram2bam -B -@32  ~/scratch/data/novaseq.10m.cram & perf record -t $! 2>/dev/null;perf report -n 2>/dev/null| head -20 | egrep -v '^#'
[1] 3634842
[1]+  Done                    ./test/test_view.cram2bam -B -@32 ~/scratch/data/novaseq.10m.cram
    15.65%           101  test_view.cram2  test_view.cram2bam  [.] cram_get_bam_seq
    11.31%            65  test_view.cram2  libc.so.6           [.] _int_free
     6.69%            38  test_view.cram2  [unknown]           [k] 0xffffffff829076fb
     5.17%            34  test_view.cram2  test_view.cram2bam  [.] cram_get_seq
     5.12%            29  test_view.cram2  [unknown]           [k] 0xffffffff8291f048
     4.73%            32  test_view.cram2  test_view.cram2bam  [.] sam_read1
     4.24%            24  test_view.cram2  [unknown]           [k] 0xffffffff828d0d41
     4.23%            24  test_view.cram2  [unknown]           [k] 0xffffffff8292a32a
     3.35%            19  test_view.cram2  [unknown]           [k] 0xffffffff82929c09
```

Wall clock benchmarks with 32 cores show a doubling in throughput (making it slightly faster than BAM, but that's due to the same main-thread excessive work problem there too):

```
$ for i in `seq 1 10`;do /usr/bin/time -f '%e %U %S'  ./test/test_view.dev 
-B -@32  ~/scratch/data/novaseq.10m.cram;done
1.14 10.34 0.76
1.06 9.13 0.69
1.11 9.42 0.72
1.12 10.20 0.62
1.00 8.72 0.57
1.23 8.85 0.77
1.46 9.13 0.79
1.17 8.67 0.63
1.30 8.73 0.69
0.99 9.64 0.54


$ for i in `seq 1 10`;do /usr/bin/time -f '%e %U %S'  ./test/test_view.cram2bam -B -@32  ~/scratch/data/novaseq.10m.cram;done
0.50 11.83 0.98
0.50 10.32 0.82
0.45 10.13 0.82
0.42 10.10 0.78
0.50 10.19 0.87
0.47 10.07 0.81
0.48 10.15 0.98
0.49 10.03 1.00
0.51 10.06 0.85
0.49 10.28 0.76
```