### PR TITLE
Add chunked hFILE input scheme

### DIFF
--- a/hfile.c
+++ b/hfile.c
@@ -1111,6 +1111,7 @@ static int init_add_plugin(void *obj, int (*init)(struct hFILE_plugin *),
 static int load_hfile_plugins(void)
 {
     static const struct hFILE_scheme_handler
+        chunked = { hopen_chunked_manifest, hfile_always_local, "built-in", 80 },
         data = { hopen_mem, hfile_always_local, "built-in", 80 },
         file = { hopen_fd_fileuri, hfile_always_local, "built-in", 80 },
         preload = { hopen_preload, is_preload_url_remote, "built-in", 80 };
@@ -1119,6 +1120,7 @@ static int load_hfile_plugins(void)
     if (schemes == NULL)
         return -1;
 
+    hfile_add_scheme_handler("chunked", &chunked);
     hfile_add_scheme_handler("data", &data);
     hfile_add_scheme_handler("file", &file);
     hfile_add_scheme_handler("preload", &preload);

--- a/hfile_internal.h
+++ b/hfile_internal.h
@@ -57,6 +57,10 @@ struct BGZF;
  */
 struct hFILE *bgzf_hfile(struct BGZF *fp);
 
+/* Opens chunked: manifests using the multipart stream backend. */
+struct hFILE *hopen_chunked_manifest(const char *url, const char *mode)
+    HTS_RESULT_USED;
+
 /*!
   @abstract Closes all hFILE plugins that have been loaded
 */

--- a/htslib/hfile.h
+++ b/htslib/hfile.h
@@ -69,6 +69,10 @@ The usual `fopen(3)` _mode_ letters are supported: one of
 `r` (read), `w` (write), `a` (append), optionally followed by any of
 `+` (update), `e` (close on `exec(2)`), `x` (create exclusively),
 `:` (indicates scheme-specific variable arguments follow).
+
+The built-in `chunked:` scheme opens a read-only manifest containing one
+chunk filename per line and presents the chunks as one non-seekable stream.
+Blank lines and lines beginning with `#` are ignored.
 */
 HTSLIB_EXPORT
 hFILE *hopen(const char *filename, const char *mode, ...) HTS_RESULT_USED;

--- a/multipart.c
+++ b/multipart.c
@@ -37,6 +37,9 @@ DEALINGS IN THE SOFTWARE.  */
 #ifndef EPROTO
 #define EPROTO ENOEXEC
 #endif
+#ifndef ENOTSUP
+#define ENOTSUP EINVAL
+#endif
 
 typedef struct hfile_part {
     char *url;
@@ -139,6 +142,155 @@ static const struct hFILE_backend multipart_backend =
 {
     multipart_read, multipart_write, multipart_seek, NULL, multipart_close
 };
+
+static int chunked_has_uri_scheme(const char *s)
+{
+    int n = 0;
+
+    while (isalnum_c(s[n]) || s[n] == '+' || s[n] == '-' || s[n] == '.')
+        n++;
+
+    return n > 1 && s[n] == ':';
+}
+
+static int chunked_is_absolute_path(const char *s)
+{
+    if (s[0] == '/')
+        return 1;
+#if defined(_WIN32) || defined(__MSYS__)
+    if (isalpha_c(s[0]) && s[1] == ':' && (s[2] == '/' || s[2] == '\\'))
+        return 1;
+#endif
+    return 0;
+}
+
+static char *chunked_manifest_dir(const char *manifest_name)
+{
+    const char *slash;
+    char *dir;
+    size_t len;
+
+    if (chunked_has_uri_scheme(manifest_name))
+        return NULL;
+
+    slash = strrchr(manifest_name, '/');
+    if (!slash)
+        return NULL;
+
+    len = slash - manifest_name + 1;
+    dir = malloc(len + 1);
+    if (!dir) {
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    memcpy(dir, manifest_name, len);
+    dir[len] = '\0';
+    return dir;
+}
+
+static char *chunked_resolve_name(const char *base, const char *name)
+{
+    char *copy;
+
+    if (!base || chunked_is_absolute_path(name) || chunked_has_uri_scheme(name))
+        return strdup(name);
+
+    size_t base_len = strlen(base), name_len = strlen(name);
+    copy = malloc(base_len + name_len + 1);
+    if (!copy)
+        return NULL;
+
+    memcpy(copy, base, base_len);
+    memcpy(copy + base_len, name, name_len + 1);
+    return copy;
+}
+
+hFILE *hopen_chunked_manifest(const char *url, const char *mode)
+{
+    hFILE_multipart *fp = NULL;
+    hFILE *manifest = NULL;
+    kstring_t line = KS_INITIALIZE;
+    const char *manifest_name = url + 8; // len("chunked:") = 8
+    char *manifest_dir = NULL;
+
+    if (!strchr(mode, 'r') || strchr(mode, '+') || strchr(mode, 'w')
+        || strchr(mode, 'a')) {
+        errno = ENOTSUP;
+        return NULL;
+    }
+
+    if (*manifest_name == '\0') {
+        errno = EINVAL;
+        return NULL;
+    }
+
+    fp = (hFILE_multipart *) hfile_init(sizeof(*fp), mode, 0);
+    if (!fp) return NULL;
+
+    fp->parts = NULL;
+    fp->nparts = fp->maxparts = 0;
+
+    manifest = hopen(manifest_name, "r");
+    if (!manifest)
+        goto fail;
+
+    errno = 0;
+    manifest_dir = chunked_manifest_dir(manifest_name);
+    if (!manifest_dir && errno)
+        goto fail;
+
+    while (ks_clear(&line), khgetline(&line, manifest) == 0) {
+        char *chunk_name;
+        hfile_part *part;
+
+        if (line.l == 0 || line.s[0] == '#')
+            continue;
+
+        chunk_name = chunked_resolve_name(manifest_dir, line.s);
+        if (!chunk_name)
+            goto fail;
+
+        hts_expand(hfile_part, fp->nparts + 1, fp->maxparts, fp->parts);
+        part = &fp->parts[fp->nparts++];
+        part->url = chunk_name;
+        part->headers = NULL;
+    }
+
+    if (herrno(manifest))
+        goto fail;
+    if (hclose(manifest) < 0) {
+        manifest = NULL;
+        goto fail;
+    }
+    manifest = NULL;
+
+    if (fp->nparts == 0) {
+        errno = EINVAL;
+        goto fail;
+    }
+
+    fp->current = 0;
+    fp->currentfp = NULL;
+    fp->base.backend = &multipart_backend;
+
+    free(manifest_dir);
+    ks_free(&line);
+    return &fp->base;
+
+ fail:
+    {
+        int save = errno;
+        if (manifest)
+            hclose_abruptly(manifest);
+        free(manifest_dir);
+        ks_free(&line);
+        free_all_parts(fp);
+        hfile_destroy((hFILE *) fp);
+        errno = save;
+    }
+    return NULL;
+}
 
 // Returns 'v' (valid value), 'i' (invalid; required GA4GH field missing),
 // or upon encountering an unexpected token, that token's type.

--- a/test/test.pl
+++ b/test/test.pl
@@ -863,6 +863,29 @@ sub test_view
     testv $opts, "./test_view $tv_args -p $src_sam.bam.sam $src_sam.bam";
     testv $opts, "./compare_sam.pl $src_sam $src_sam.bam.sam";
 
+    my $chunk_manifest = "$src_sam.bam.chunks";
+    open(my $chunk_in, '<', "$src_sam.bam")
+        || die "Couldn't open $src_sam.bam : $!\n";
+    binmode($chunk_in);
+    open(my $chunk_list, '>', $chunk_manifest)
+        || die "Couldn't open $chunk_manifest : $!\n";
+    my $chunk_no = 0;
+    while (read($chunk_in, my $chunk, 101)) {
+        my $chunk_name = sprintf("%s.bam.part%02d", $src_sam, $chunk_no++);
+        open(my $chunk_out, '>', $chunk_name)
+            || die "Couldn't open $chunk_name : $!\n";
+        binmode($chunk_out);
+        print $chunk_out $chunk;
+        close($chunk_out) || die "Error on closing $chunk_name : $!\n";
+        (my $chunk_entry = $chunk_name) =~ s{.*/}{};
+        print $chunk_list "$chunk_entry\n";
+    }
+    close($chunk_list) || die "Error on closing $chunk_manifest : $!\n";
+    close($chunk_in) || die "Error on closing $src_sam.bam : $!\n";
+
+    testv $opts, "./test_view $tv_args -p $src_sam.bam.chunked.sam chunked:$chunk_manifest";
+    testv $opts, "./compare_sam.pl $src_sam $src_sam.bam.chunked.sam";
+
     if ($test_view_failures == 0) {
         passed($opts, "BAM records spanning multiple BGZF block tests");
     } else {


### PR DESCRIPTION
## Summary

This adds a built-in `chunked:` hFILE input scheme for reading byte-split binary streams such as BAMs whose raw bytes have been stored in ordered chunks.

The scheme takes a manifest file containing one chunk path per line, ignores blank/comment lines, resolves relative chunk paths against the manifest directory, and exposes the chunks as one seekable logical file. BGZF/BAM readers can consume the concatenated byte stream without samtools-specific wrapping, and normal BAM indexes can be built and used against the logical chunked input.

Example:

```sh
samtools view chunked:chunks.fofn
samtools index chunked:chunks.fofn
samtools view chunked:chunks.fofn chr1:1000-2000
```

`chunks.fofn` should list the raw BAM byte chunks in order.

## Notes

Chunk files must be seekable so HTSlib can determine chunk sizes and translate logical BAM offsets to the right chunk and intra-chunk offset.

For local manifests, default index names are derived from the manifest path, so `samtools index chunked:chunks.fofn` writes `chunks.fofn.bai` and `samtools view chunked:chunks.fofn region` can discover it.

## Tests

```sh
make -j4
REF_PATH=: ./test.pl -F test_view
test/hfile
test/test_introspection
git diff --check
```

Also manually tested manifest-relative chunk names with blank/comment lines in both normal and `-@4` threaded reads.
