### PR TITLE
Protect against uninitialised variable read with X_NOSZ codecs

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1665,7 +1665,7 @@ int cram_uncompress_block(cram_block *b) {
 #endif
 
     case RANS: {
-        unsigned int usize = b->uncomp_size, usize2;
+        unsigned int usize = b->uncomp_size, usize2 = 0;
         uncomp = (char *)rans_uncompress(b->data, b->comp_size, &usize2);
         if (!uncomp)
             return -1;
@@ -1696,7 +1696,7 @@ int cram_uncompress_block(cram_block *b) {
     }
 
     case RANS_PR0: {
-        unsigned int usize = b->uncomp_size, usize2;
+        unsigned int usize = b->uncomp_size, usize2 = 0;
         uncomp = (char *)rans_uncompress_4x16(b->data, b->comp_size, &usize2);
         if (!uncomp)
             return -1;
@@ -1715,7 +1715,7 @@ int cram_uncompress_block(cram_block *b) {
     }
 
     case ARITH_PR0: {
-        unsigned int usize = b->uncomp_size, usize2;
+        unsigned int usize = b->uncomp_size, usize2 = 0;
         uncomp = (char *)arith_uncompress_to(b->data, b->comp_size, NULL, &usize2);
         if (!uncomp)
             return -1;


### PR DESCRIPTION
If the rans or arith data block uses X_NOSZ then the encoded block doesn't have its own sizing information and instead uses the passed in size via *out_size.  This shouldn't be used in CRAM blocks (it's for internal streams such as the name tokeniser), however this isn't guarded against and usize2 is undefined.

We set this to zero so it's not uninitialised and it also triggers an early failure in the "if (usize != usize2)" check.

Fixes #2021