### PR TITLE
Fix a divide by zero in cram_xdelta_decode.

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1813,6 +1813,9 @@ cram_codec *cram_xdelta_decode_init(cram_block_compression_hdr *hdr,
     c->describe = NULL;
 
     c->u.xdelta.word_size = vv->varint_get32(&cp, endp, NULL);
+    if (c->u.xdelta.word_size <= 0)
+        goto malformed;
+
     c->u.xdelta.last = 0;
 
     int encoding = vv->varint_get32(&cp, endp, NULL);


### PR DESCRIPTION
If word_size is zero we do modulo 0 and caused a divide-by-zero crash. Word size is stored in the input data and so we need to validate this, but it's constant so validation is done in the initialisation function only.

We also check for <0 as this has no meaning either.

With thanks to Team Atlanta.

Co-authored-by: Team Atlanta