### PR TITLE
Remove a divide-by-zero bug in cram_xpack_decode_char

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1416,7 +1416,8 @@ int cram_xpack_decode_char(cram_slice *slice, cram_codec *c, cram_block *in, cha
     // We therefore have to cache appropriate block info in slice and not codec.
     //    b = cram_get_block_by_id(slice, c->external.content_id);
     if (c->u.xpack.nval > 1) {
-        cram_xpack_decode_expand_char(slice, c);
+        if (cram_xpack_decode_expand_char(slice, c) < 0)
+            return -1;
         cram_block *b = slice->block_by_id[512 + c->codec_id];
         if (!b)
             return -1;
@@ -1775,12 +1776,14 @@ void cram_xdelta_decode_free(cram_codec *c) {
 }
 
 int cram_xdelta_decode_size(cram_slice *slice, cram_codec *c) {
-    cram_xdelta_decode_expand_char(slice, c);
+    if (cram_xdelta_decode_expand_char(slice, c) < 0)
+        return -1;
     return slice->block_by_id[512 + c->codec_id]->uncomp_size;
 }
 
 cram_block *cram_xdelta_get_block(cram_slice *slice, cram_codec *c) {
-    cram_xdelta_decode_expand_char(slice, c);
+    if (cram_xdelta_decode_expand_char(slice, c) < 0)
+        return NULL;
     return slice->block_by_id[512 + c->codec_id];
 }
 
@@ -2119,19 +2122,22 @@ static int cram_xrle_decode_expand_char(cram_slice *slice, cram_codec *c) {
 }
 
 int cram_xrle_decode_size(cram_slice *slice, cram_codec *c) {
-    cram_xrle_decode_expand_char(slice, c);
+    if (cram_xrle_decode_expand_char(slice, c) < 0)
+        return -1;
     return slice->block_by_id[512 + c->codec_id]->uncomp_size;
 }
 
 cram_block *cram_xrle_get_block(cram_slice *slice, cram_codec *c) {
-    cram_xrle_decode_expand_char(slice, c);
+    if (cram_xrle_decode_expand_char(slice, c) < 0)
+        return NULL;
     return slice->block_by_id[512 + c->codec_id];
 }
 
 int cram_xrle_decode_char(cram_slice *slice, cram_codec *c, cram_block *in, char *out, int *out_size) {
     int n = *out_size;
 
-    cram_xrle_decode_expand_char(slice, c);
+    if (cram_xrle_decode_expand_char(slice, c) < 0)
+        return -1;
     cram_block *b = slice->block_by_id[512 + c->codec_id];
 
     if (out)

--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -1444,12 +1444,14 @@ void cram_xpack_decode_free(cram_codec *c) {
 }
 
 int cram_xpack_decode_size(cram_slice *slice, cram_codec *c) {
-    cram_xpack_decode_expand_char(slice, c);
+    if (cram_xpack_decode_expand_char(slice, c) < 0)
+        return -1;
     return slice->block_by_id[512 + c->codec_id]->uncomp_size;
 }
 
 cram_block *cram_xpack_get_block(cram_slice *slice, cram_codec *c) {
-    cram_xpack_decode_expand_char(slice, c);
+    if (cram_xpack_decode_expand_char(slice, c) < 0)
+        return NULL;
     return slice->block_by_id[512 + c->codec_id];
 }
 
@@ -1484,7 +1486,8 @@ cram_codec *cram_xpack_decode_init(cram_block_compression_hdr *hdr,
     c->u.xpack.nbits = vv->varint_get32(&cp, endp, NULL);
     c->u.xpack.nval  = vv->varint_get32(&cp, endp, NULL);
     if (c->u.xpack.nbits >= 8  || c->u.xpack.nbits < 0 ||
-        c->u.xpack.nval  > 256 || c->u.xpack.nval < 0)
+        c->u.xpack.nval  > 256 || c->u.xpack.nval < 0 ||
+        (c->u.xpack.nval > 1 && c->u.xpack.nbits == 0))
         goto malformed;
     int i;
     for (i = 0; i < c->u.xpack.nval; i++) {


### PR DESCRIPTION
When xpack.nbits is zero we attempt a divide by zero in the argument passing to hts_unpack().  We now check for this case in the initialisation function, but only when nvals > 1 otherwise nbits becomes irrelevant due to it being a pre-determined constant instead.

With thanks to Team Atlanta.

Co-authored-by: Team Atlanta