### PR TITLE
Fix a gcc "null format string" warning.

### DIFF
--- a/test/test-vcf-api.c
+++ b/test/test-vcf-api.c
@@ -36,7 +36,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include "../htslib/kstring.h"
 #include "../htslib/kseq.h"
 
-void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) error(const char *format, ...)
+static void HTS_FORMAT(HTS_PRINTF_FMT, 1, 2) error(const char *format, ...)
 {
     va_list ap;
     va_start(ap, format);


### PR DESCRIPTION
This is a false positive, but avoided if we just make the function static, which it can be.