### PR TITLE
Bounds-check refid when loading a CRAM .crai index

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -254,6 +254,9 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
     }
 
 
+    // refid indexes fd->index, so bound it to the header's reference count.
+    int nref = sam_hdr_nref(fd->header);
+
     // Parse it line at a time
     while (pos < kstr.l) {
         /* 1.1 layout */
@@ -278,7 +281,7 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
         e.end += e.start-1;
         //printf("%d/%d..%d-offset=%" PRIu64 ",len=%d,slice=%d\n", e.refid, e.start, e.end, e.offset, e.len, e.slice);
 
-        if (e.refid < -1) {
+        if (e.refid < -1 || e.refid >= nref) {
             hts_log_error("Malformed index file, refid %d", e.refid);
             goto fail;
         }


### PR DESCRIPTION
# Bounds-check refid when loading a CRAM `.crai` index

`cram_index_load` reads the reference id from each `.crai` line but only checks
its lower bound, so an out-of-range value flows unchecked into index-array
grow arithmetic and an array subscript. The result is a heap out-of-bounds
write (`refid == INT_MAX`) or an unbounded allocation (large `refid`). This
patch adds the upper bound — the header's reference count — that the other
on-disk index parsers already apply.

## Bug

`cram_index_load` (`cram/cram_index.c:177`) parses a `.crai` index a line at a
time. Column 1, `e.refid`, is read straight from the index bytes:

```c
if (kget_int32(&kstr, &pos, &e.refid) == -1)   // :260  attacker-controlled
    goto fail;
```

The only validation is a lower bound — there is no upper bound:

```c
if (e.refid < -1) {                            // :281  lower bound only
    hts_log_error("Malformed index file, refid %d", e.refid);
    goto fail;
}
```

`e.refid` is then used (a) to size the index array and (b) as the subscript:

```c
if (e.refid != idx->refid) {
    if (fd->index_sz < e.refid+2) {            // :287  grow guard
        cram_index *new_idx;
        int new_sz = e.refid+2;                // :289  allocation count
        ...
        new_idx = hts_realloc_p(fd->index, sizeof(*fd->index), new_sz);  // :291
        ...
    }
    idx = &fd->index[e.refid+1];               // :301  subscript
    idx->refid = e.refid;                      // :302  store
```

Two failure modes once an out-of-range `refid` reaches this block:

| `e.refid` | Path | Site | Effect |
|---|---|---|---|
| `2147483647` (`INT_MAX`) | `e.refid+2` overflows to negative, so the grow guard at `:287` is false and the array is **not** grown | `:301-302` `idx = &fd->index[e.refid+1]; idx->refid = e.refid;` | signed-integer overflow (UB), then a heap **OOB write** through a wild `fd->index` slot |
| large but non-overflowing (e.g. `5000000`) | grow guard true → `new_sz = e.refid+2` | `:291` `hts_realloc_p(fd->index, sizeof(*fd->index), new_sz)` | unbounded allocation (`new_sz × sizeof(cram_index)`): memory-exhaustion DoS |

A well-formed `.crai` only ever stores reference ids in `[-1, nref-1]`, where
`nref` is the number of references in the CRAM header, so the upper bound is
simply missing here.

**Reachability.** The sink is on the public region-query path — any consumer
that opens a CRAM with an attacker-supplied `.crai` reaches it:

```
sam_index_load2(fp, data.cram, index.crai)
  -> index_load            (sam.c:1658)
     -> cram_index_load     (cram/cram_index.c)   <-- sink
```

e.g. `samtools view data.cram chr:beg-end`, or `pysam` `fetch()`.

The remaining on-disk index parsers already validate this way, which is why
`cram_index_load` stands out:

| On-disk index | Loader | Upper-bound / overflow guard present? |
|---|---|---|
| BAI/CSI/TBI | `idx_read_core` (`hts.c`) | yes — `n < 0` reject + `> SIZE_MAX/elem` guard |
| `.gzi` | `bgzf_index_load_hfile` (`bgzf.c`) | yes — `x >= SIZE_MAX/sizeof/2` reject |
| `.fai` | `fai_insert_index` (`faidx.c`) | yes — bounds `line_len`/`line_blen` |
| `.crai` | `cram_index_load` | **no — lower bound only** |

## Reproduction

Reproducer models the public path above (`hts_open` → `sam_index_load2` →
`cram_index_load`); no private symbols. `oob.crai` is a one-line index whose
column-1 refid is `2147483647`.

```
# libhts.a built with: gcc -g -O1 -fsanitize=address,undefined -fno-omit-frame-pointer -I. -c ...
gcc -g -O1 -fsanitize=address,undefined -fno-omit-frame-pointer -I. \
    -o repro_crai repro_crai.c libhts.a -lz -lpthread -lm
./repro_crai test/range.cram oob.crai
```

Pre-patch (htslib 1.23.1-35-g87bf518):

```
cram/cram_index.c:287:30: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
    #0 cram_index_load cram/cram_index.c:287
==…==ERROR: AddressSanitizer: SEGV on unknown address 0x507c00000330
==…==The signal is caused by a WRITE memory access.
    #0 cram_index_load cram/cram_index.c:302
    #1 index_load          sam.c:1658
    #2 sam_index_load2      sam.c:1679
    #3 main                 repro_crai.c:34
SUMMARY: AddressSanitizer: SEGV cram/cram_index.c:302 in cram_index_load
```

UBSan flags the signed overflow at the grow guard (`:287`); the array is then
not grown, and the store at `:302` writes out of bounds (ASan SEGV).

## Fix

Bound `refid` against the header's reference count, mirroring the check
`cram_decode.c` already applies to the same value (`cr->ref_id < -1 ||
cr->ref_id >= nref`, `cram_decode.c:2606`):

```diff
@@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
     }
 
 
+    // refid indexes fd->index, so bound it to the header's reference count.
+    int nref = sam_hdr_nref(fd->header);
+
     // Parse it line at a time
     while (pos < kstr.l) {
@@
         e.end += e.start-1;
 
-        if (e.refid < -1) {
+        if (e.refid < -1 || e.refid >= nref) {
             hts_log_error("Malformed index file, refid %d", e.refid);
             goto fail;
         }
```

`sam_hdr_nref(fd->header)` is the public NULL-safe accessor (returns `-1` for a
NULL header). A reader `cram_fd` always has `fd->header` populated — `cram_open`
fails the open if `cram_read_SAM_hdr` returns NULL (`cram_io.c:5319`) — so the
bound is the header's real reference count on every reachable path, and a
hypothetical header-less fd degrades to a safe rejection rather than an OOB.

One bound closes both failure modes: a refid `< nref` (a small count) can no
longer overflow `e.refid+2` / `e.refid+1`, so the grow arithmetic and the
allocation are both bounded. Valid indices store only `[-1, nref-1]`, so nothing
legitimate is rejected. The `hts_log_error` message is unchanged and already
covers an out-of-range refid.

## Verification

`libhts.a` built with `-fsanitize=address,undefined` (optional bz2/lzma/curl
disabled in this environment — headers absent; CRAM's default gzip+rANS codecs
are unaffected). `nref(test/range.cram) = 7`, so valid refids are `[-1, 6]`.

| `.crai` (col-1 refid) | Pre-patch | Post-patch |
|---|---|---|
| `benign` (refid `0`, in range) | loads | **loads** — `sam_index_load2` returns non-NULL; RSS 25 MB |
| `oob` (refid `2147483647`) | UBSan overflow `:287` → ASan SEGV **WRITE** `:302` | **`[E::cram_index_load] Malformed index file, refid 2147483647`**, returns NULL; no ASan/UBSan trip; RSS 25 MB |
| `dos_alloc` (refid `5000000`) | succeeds but **4.3 s / 331 MB** RSS | **`[E::cram_index_load] Malformed index file, refid 5000000`**, returns NULL; 2.3 s / **25 MB** RSS |

The previously OOB / over-allocating inputs are now rejected cleanly, and the
in-range index still loads.

The full `make check` suite was not run in this environment (optional codec /
network libraries absent blocked the complete build). The change is additive: it
only widens the existing malformed-refid rejection. Valid refids (`-1 … nref-1`),
the rest of the parse loop, and every other input path are unchanged, so no
valid-input regression is possible by construction.
