### PR TITLE
Remove bits of CRAMv4 missed in #2020

### DIFF
--- a/cram/cram_codecs.c
+++ b/cram/cram_codecs.c
@@ -2228,12 +2228,12 @@ const char *cram_encoding2str(enum cram_encoding t) {
     }
 }
 
-static cram_codec *(*decode_init[])(cram_block_compression_hdr *hdr,
-                                    char *data,
-                                    int size,
-                                    enum cram_encoding codec,
-                                    enum cram_external_type option,
-                                    int version, varint_vec *vv) = {
+static cram_codec *(*decode_init[E_NUM_CODECS])(cram_block_compression_hdr *hdr,
+                                                char *data,
+                                                int size,
+                                                enum cram_encoding codec,
+                                                enum cram_external_type option,
+                                                int version, varint_vec *vv) = {
     // CRAM 3.0 valid codecs
     NULL, // null codec
     cram_external_decode_init,
@@ -2266,11 +2266,11 @@ cram_codec *cram_decoder_init(cram_block_compression_hdr *hdr,
     }
 }
 
-static cram_codec *(*encode_init[])(cram_stats *stx,
-                                    enum cram_encoding codec,
-                                    enum cram_external_type option,
-                                    void *opt,
-                                    int version, varint_vec *vv) = {
+static cram_codec *(*encode_init[E_NUM_CODECS])(cram_stats *stx,
+                                                enum cram_encoding codec,
+                                                enum cram_external_type option,
+                                                void *opt,
+                                                int version, varint_vec *vv) = {
     // CRAM 3.0 valid codecs
     NULL, // null codec
     cram_external_encode_init, // int/bytes in cram 3, byte only in cram 4

--- a/cram/cram_encode.c
+++ b/cram/cram_encode.c
@@ -983,16 +983,8 @@ static int cram_allocate_block(cram_codec *codec, cram_slice *s, int ds_id) {
         codec->out = s->block[0];
         break;
 
-    // Codecs which don't use external blocks
-    case E_CONST_BYTE:
-    case E_CONST_INT:
-       codec->out = NULL;
-       break;
-
     // Codecs that emit directly to external blocks
     case E_EXTERNAL:
-    case E_VARINT_UNSIGNED:
-    case E_VARINT_SIGNED:
         if (!(s->block[ds_id] = cram_new_block(EXTERNAL, ds_id)))
             return -1;
         codec->u.external.content_id = ds_id;
@@ -2862,13 +2854,9 @@ static sam_hrec_rg_t *cram_encode_aux(cram_fd *fd, bam_seq_t *b,
                 cram_byte_array_len_encoder e;
                 cram_stats st;
 
-                if (CRAM_MAJOR_VERS(fd->version) <= 3) {
-                    e.len_encoding = E_HUFFMAN;
-                    e.len_dat = NULL; // will get codes from st
-                } else {
-                    e.len_encoding = E_CONST_INT;
-                    e.len_dat = NULL; // will get codes from st
-                }
+                e.len_encoding = E_HUFFMAN;
+                e.len_dat = NULL; // will get codes from st
+
                 memset(&st, 0, sizeof(st));
                 if (cram_stats_add(&st, 1) < 0) goto block_err;
                 cram_stats_encoding(fd, &st);
@@ -2887,13 +2875,9 @@ static sam_hrec_rg_t *cram_encode_aux(cram_fd *fd, bam_seq_t *b,
                 cram_byte_array_len_encoder e;
                 cram_stats st;
 
-                if (CRAM_MAJOR_VERS(fd->version) <= 3) {
-                    e.len_encoding = E_HUFFMAN;
-                    e.len_dat = NULL; // will get codes from st
-                } else {
-                    e.len_encoding = E_CONST_INT;
-                    e.len_dat = NULL; // will get codes from st
-                }
+                e.len_encoding = E_HUFFMAN;
+                e.len_dat = NULL; // will get codes from st
+
                 memset(&st, 0, sizeof(st));
                 if (cram_stats_add(&st, 2) < 0) goto block_err;
                 cram_stats_encoding(fd, &st);
@@ -2911,13 +2895,9 @@ static sam_hrec_rg_t *cram_encode_aux(cram_fd *fd, bam_seq_t *b,
                 cram_byte_array_len_encoder e;
                 cram_stats st;
 
-                if (CRAM_MAJOR_VERS(fd->version) <= 3) {
-                    e.len_encoding = E_HUFFMAN;
-                    e.len_dat = NULL; // will get codes from st
-                } else {
-                    e.len_encoding = E_CONST_INT;
-                    e.len_dat = NULL; // will get codes from st
-                }
+                e.len_encoding = E_HUFFMAN;
+                e.len_dat = NULL; // will get codes from st
+
                 memset(&st, 0, sizeof(st));
                 if (cram_stats_add(&st, 4) < 0) goto block_err;
                 cram_stats_encoding(fd, &st);

--- a/cram/cram_stats.c
+++ b/cram/cram_stats.c
@@ -206,19 +206,7 @@ enum cram_encoding cram_stats_encoding(cram_fd *fd, cram_stats *st) {
      * Simple policy that everything is external unless it can be
      * encoded using zero bits as a unary item huffman table.
      */
-    if (CRAM_MAJOR_VERS(fd->version) >= 4) {
-        // Note, we're assuming integer data here as we don't have the
-        // type passed in.  Cram_encoder_init does know the type and
-        // will convert to E_CONST_BYTE or E_EXTERNAL as appropriate.
-        if (nvals == 1)
-            return E_CONST_INT;
-        else if (nvals == 0 || min_val < 0)
-            return E_VARINT_SIGNED;
-        else
-            return E_VARINT_UNSIGNED;
-    } else {
-        return nvals <= 1 ? E_HUFFMAN : E_EXTERNAL;
-    }
+    return nvals <= 1 ? E_HUFFMAN : E_EXTERNAL;
 }
 
 void cram_stats_free(cram_stats *st) {

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -103,21 +103,15 @@ typedef struct cram_stats {
 /* NB: matches java impl, not the spec */
 enum cram_encoding {
     E_NULL               = 0,
-    E_EXTERNAL           = 1,  // Only for BYTE type in CRAM 4
-    E_GOLOMB             = 2,  // Not in CRAM 4
-    E_HUFFMAN            = 3,  // Not in CRAM 4
+    E_EXTERNAL           = 1,
+    E_GOLOMB             = 2,
+    E_HUFFMAN            = 3,
     E_BYTE_ARRAY_LEN     = 4,
     E_BYTE_ARRAY_STOP    = 5,
-    E_BETA               = 6,  // Not in CRAM 4
-    E_SUBEXP             = 7,  // Not in CRAM 4
-    E_GOLOMB_RICE        = 8,  // Not in CRAM 4
-    E_GAMMA              = 9,  // Not in CRAM 4
-
-    // CRAM 4 specific codecs
-    E_VARINT_UNSIGNED    = 41, // Specialisation of EXTERNAL
-    E_VARINT_SIGNED      = 42, // Specialisation of EXTERNAL
-    E_CONST_BYTE         = 43, // Alternative to HUFFMAN with 1 symbol
-    E_CONST_INT          = 44, // Alternative to HUFFMAN with 1 symbol
+    E_BETA               = 6,
+    E_SUBEXP             = 7,
+    E_GOLOMB_RICE        = 8,
+    E_GAMMA              = 9,
 
     // Total number of codecs, not a real one.
     E_NUM_CODECS,


### PR DESCRIPTION
Some entries had been left in the cram_encoding enum, which caused some arrays to be incorrectly sized.

Removed residual code referencing the removed values.  As it is no longer possible to select CRAMv4, this code was no longer reachable.
