### PR TITLE
Ensure PACKAGE_VERSION is set in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,13 @@ MACH_O_CURRENT_VERSION = 3.1.23
 version.h: $(if $(wildcard version.h),$(if $(findstring "$(PACKAGE_VERSION)",$(shell cat version.h)),,force))
 
 version.h:
-	echo '#define HTS_VERSION_TEXT "$(PACKAGE_VERSION)"' > $@
+	@if test 'x$(PACKAGE_VERSION)' != x ; then \
+		echo "echo '#define HTS_VERSION_TEXT "'"$(PACKAGE_VERSION)"'"' > $@" ; \
+		echo '#define HTS_VERSION_TEXT "$(PACKAGE_VERSION)"' > $@ ; \
+	else \
+		echo "Error: PACKAGE_VERSION is not defined.  Check version.sh works." 1>&2 ; \
+		false ; \
+	fi
 
 print-version:
 	@echo $(PACKAGE_VERSION)


### PR DESCRIPTION
This variable is set by expanding `$(shell version.sh)`.  As this is not in a normal Makefile rule, failing to run `version.sh` just results in an empty variable.  To check that it really was set, add a check to ensure it's not empty in the rule that builds the `version.h` file.

See also samtools/samtools#2337.  Failing here is unlikely to result in broken files, but we should probably catch it anyway.