### PR TITLE
Ignore CURLOPT_FTP_FILEMETHOD errors.

### DIFF
--- a/hfile_libcurl.c
+++ b/hfile_libcurl.c
@@ -1373,8 +1373,13 @@ libcurl_open(const char *url, const char *modes, http_headers *headers)
 
     // Avoid many repeated CWD calls with FTP, instead requesting the filename
     // by full path (but not strictly compliant with RFC1738).
-    err |= curl_easy_setopt(fp->easy, CURLOPT_FTP_FILEMETHOD,
-                            (long) CURLFTPMETHOD_NOCWD);
+    // Note as this is just an optimation, we don't care if it succeeds.
+    // Some libcurls are built without ftp support and this would fail in such
+    // cases (even if our URL is http://).  If we attempt to do an ftp on such
+    // a machine we'll then get a more informative error, such as protocol
+    // not supported, instead of function not implemented.
+    curl_easy_setopt(fp->easy, CURLOPT_FTP_FILEMETHOD,
+                     (long) CURLFTPMETHOD_NOCWD);
 
     if (mode == 'r') {
         err |= curl_easy_setopt(fp->easy, CURLOPT_WRITEFUNCTION, recv_callback);


### PR DESCRIPTION
On OpenSUSE libcurl is built without ftp support.  Our setting of CURLOPT_FTP_FILEMETHOD means we get curl not-implemented error codes, even if we are asking for an http URL.  While we could check the URL prefix, it's easier to just ignore the error and let a later condition report the lack of ftp (should we be asking for that).