### PR TITLE
Don't try to access BGZF::errcode after bgzf_close()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -90,6 +90,9 @@ Bug fixes
 * Bounds-check refid when loading a CRAM .crai index.
   (PR #2029.  Thanks to Sidhartha Kumar)
 
+* In bgzip and tabix, when handling errors, don't try to access the
+  BGZF::errcode field after calling bgzf_close() as it may no longer be valid.
+  (PR #2035, #2042)
 
 Documentation updates
 ---------------------

--- a/bgzip.c
+++ b/bgzip.c
@@ -572,7 +572,7 @@ int main(int argc, char **argv)
                 error("Can not write index for stdin data without index filename, use -I option to set index file.\n");
             }
 
-            if ( bgzf_close(fp)<0 ) error("Close failed: Error %d\n",fp->errcode);
+            if ( bgzf_close(fp)<0 ) error("Close failed\n");
         }
         else
         {
@@ -717,7 +717,7 @@ int main(int argc, char **argv)
             start = start_reg;
             end = end_reg;
             free(buffer);
-            if (bgzf_close(fp) < 0) error("Close failed: Error %d\n",fp->errcode);
+            if (bgzf_close(fp) < 0) error("Close failed\n");
 
             if (statfilename) {
                 if (!write_fname) {
@@ -762,7 +762,7 @@ int main(int argc, char **argv)
             }
 
             if (bgzf_close(fp) < 0)
-                error("Output close failed: Error %d\n", fp->errcode);
+                error("Output close failed\n");
         } else {
             close(f_dst);
         }

--- a/tabix.c
+++ b/tabix.c
@@ -581,11 +581,11 @@ int reheader_file(const char *fname, const char *header, int ftype, tbx_conf_t *
         }
         if (bgzf_close(bgzf_out) < 0) {
             RELEASE_TPOOL(tpool);
-            error_errno("Error %d closing output", bgzf_out->errcode);
+            error_errno("Error closing output");
         }
         if (bgzf_close(fp) < 0) {
             RELEASE_TPOOL(tpool);
-            error_errno("Error %d closing \"%s\"", bgzf_out->errcode, fname);
+            error_errno("Error closing \"%s\"", fname);
         }
         free(buf);
     }


### PR DESCRIPTION
See also d8a7a34

Fix more instances of trying to read fp->errcode after calling `bgzf_close()`.  This is not safe as `bgzf_close()` may have freed the pointer passed into it.  Luckily all code paths call `exit(1)` straight after so the worst case result would probably be a slightly more messy exit than intended.