### PR TITLE
Speed up hts_parse_decimal() handling of oversized exponents

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -94,6 +94,9 @@ Bug fixes
   BGZF::errcode field after calling bgzf_close() as it may no longer be valid.
   (PR #2035, #2042)
 
+* Speed up hts_parse_decimal() handling of oversized exponents
+  (PR #2045)
+
 Documentation updates
 ---------------------
 

--- a/hts.c
+++ b/hts.c
@@ -3923,8 +3923,8 @@ long long hts_parse_decimal(const char *str, char **strend, int flags)
     }
 
     e -= decimals;
-    while (e > 0) n *= 10, e--;
-    while (e < 0) lost += n % 10, n /= 10, e++;
+    while (e > 0 && n) n *= 10, e--;
+    while (e < 0 && n) lost += n % 10, n /= 10, e++;
 
     if (lost > 0) {
         hts_log_warning("Discarding fractional part of %.*s", (int)(s - str), str);


### PR DESCRIPTION
The loop to apply exponent values could be made to run for a very long time (although not forever) if the exponent value in the number passed to the function was very large.  As in both the +ve and -ve exponent cases this will eventually result in `n` becoming zero (the former through overflow), it's possible to short-cut the rest of the loop as the final value will no longer change.

Note that this does not try to add overflow detection, which would require more extensive changes and is left to future work.