### PR TITLE
Fix an undefined behaviour in os/rand.c

### DIFF
--- a/os/rand.c
+++ b/os/rand.c
@@ -35,12 +35,12 @@ static unsigned short _rand48_seed[3] = {
 	RAND48_SEED_1,
 	RAND48_SEED_2
 };
-static unsigned short _rand48_mult[3] = {
+static unsigned long _rand48_mult[3] = {
 	RAND48_MULT_0,
 	RAND48_MULT_1,
 	RAND48_MULT_2
 };
-static unsigned short _rand48_add = RAND48_ADD;
+static unsigned long _rand48_add = RAND48_ADD;
 
 static void
 _dorand48(unsigned short xseed[3])
@@ -48,15 +48,16 @@ _dorand48(unsigned short xseed[3])
 	unsigned long accu;
 	unsigned short temp[2];
 
-	accu = (unsigned long) _rand48_mult[0] * (unsigned long) xseed[0] +
-	 (unsigned long) _rand48_add;
+	accu = _rand48_mult[0] * xseed[0] + _rand48_add;
 	temp[0] = (unsigned short) accu;	/* lower 16 bits */
 	accu >>= sizeof(unsigned short) * 8;
-	accu += (unsigned long) _rand48_mult[0] * (unsigned long) xseed[1] +
-	 (unsigned long) _rand48_mult[1] * (unsigned long) xseed[0];
+	accu += _rand48_mult[0] * xseed[1]
+	      + _rand48_mult[1] * xseed[0];
 	temp[1] = (unsigned short) accu;	/* middle 16 bits */
 	accu >>= sizeof(unsigned short) * 8;
-	accu += _rand48_mult[0] * xseed[2] + _rand48_mult[1] * xseed[1] + _rand48_mult[2] * xseed[0];
+	accu += _rand48_mult[0] * xseed[2]
+	      + _rand48_mult[1] * xseed[1]
+	      + _rand48_mult[2] * xseed[0];
 	xseed[0] = temp[0];
 	xseed[1] = temp[1];
 	xseed[2] = (unsigned short) accu;


### PR DESCRIPTION
This is really picky and I almost didn't bother given this is just code lifted from FreeBSD which hasn't changed it in 32 years.

https://github.com/lattera/freebsd/blame/401a161083850a9a4ce916f37520c084cff1543b/lib/libc/gen/_rand48.c#L32-L49

However undefined behaviour sanitizer whinges about signed overflows. This happens because the promotion of unsigned short in arithmetic expressions is to signed int, and then multiplying signed ints can overflow from signed to unsigned.

Eg:
```
    (gdb) p (unsigned short)50000 * (unsigned short)45000
    $1 = -2044967296
    (gdb) p (unsigned int)50000 * (unsigned int)45000
    $2 = 2250000000
```

Due to 2s complement this makes no difference and casting both to unsigned int before the multiplcation gives you the same bit pattern. It's just the resulting type that differs, as we change that in the assignment anyway.

(Note there are similar undefined behaviour issues with md5.c, which I didn't fix.)