### PR TITLE
GCS overriding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 Noteworthy changes in release a.b
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* New environment variable HTS_GCS_HOST, analogous to the existing
+  HTS_S3_HOST, to redirect gs:// URLs to a caller-specified endpoint
+  (e.g. a local GCS emulator such as fake-gcs-server) using path-style
+  addressing instead of the normal BUCKET.storage.googleapis.com
+  virtual-hosted-style addressing.
+
 Noteworthy changes in release 1.24 (9th July 2026)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/hfile_gcs.c
+++ b/hfile_gcs.c
@@ -43,6 +43,7 @@ gcs_rewrite(const char *gsurl, const char *mode, int mode_has_colon,
             va_list *argsp)
 {
     const char *bucket, *path, *access_token, *requester_pays_project;
+    const char *host_override;
     kstring_t mode_colon = { 0, 0, NULL };
     kstring_t url = { 0, 0, NULL };
     kstring_t auth_hdr = { 0, 0, NULL };
@@ -63,11 +64,23 @@ gcs_rewrite(const char *gsurl, const char *mode, int mode_has_colon,
 
     path = bucket + strcspn(bucket, "/?#");
 
-    kputsn(bucket, path - bucket, &url);
-    if (strchr(mode, 'r')) kputs(".storage-download", &url);
-    else if (strchr(mode, 'w')) kputs(".storage-upload", &url);
-    else kputs(".storage", &url);
-    kputs(".googleapis.com", &url);
+    host_override = getenv("HTS_GCS_HOST");
+    if (host_override) {
+        // Path-style addressing against a caller-specified endpoint, e.g. a
+        // local mock server such as fake-gcs-server used for testing.  Such
+        // servers can't offer the wildcard DNS needed for the normal
+        // virtual-hosted-style BUCKET.HOST addressing below.
+        kputs(host_override, &url);
+        kputc('/', &url);
+        kputsn(bucket, path - bucket, &url);
+    }
+    else {
+        kputsn(bucket, path - bucket, &url);
+        if (strchr(mode, 'r')) kputs(".storage-download", &url);
+        else if (strchr(mode, 'w')) kputs(".storage-upload", &url);
+        else kputs(".storage", &url);
+        kputs(".googleapis.com", &url);
+    }
 
     kputs(path, &url);
 


### PR DESCRIPTION
I added a `HTS_GCS_HOST` variable that, when set, mocks the server for GCS. This matches the approach used for S3 mocking. I did this because I'm building a spark library on top of htslib and would like to be able to do a full local integration test. Is this something you're interested in?

I ran my own integration test on fake-gcs-server, but it doesn't seem like there's an integration test for S3 against an S3 mock (like moto). Do you want me to add one to both?

I am also interested in adding Azure storage support.