### PR TITLE
Add option to strip UR tags from CRAM

### DIFF
--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -4729,6 +4729,13 @@ int cram_write_SAM_hdr(cram_fd *fd, sam_hdr_t *hdr) {
         }
     }
 
+    if (fd->remove_ur) {
+        if (sam_hdr_remove_tag_all(hdr, "SQ", "UR") < 0) {
+            hts_log_error("Unable to remove UR tags");
+            return -1;
+        }
+    }
+
     /* Length */
     header_len = sam_hdr_length(hdr);
     if (header_len > INT32_MAX) {
@@ -5610,6 +5617,10 @@ int cram_set_voption(cram_fd *fd, enum hts_fmt_option opt, va_list args) {
 
     case CRAM_OPT_STORE_NM:
         fd->store_nm = va_arg(args, int);
+        break;
+
+    case CRAM_OPT_RM_UR:
+        fd->remove_ur = va_arg(args, int);
         break;
 
     case HTS_OPT_COMPRESSION_LEVEL:

--- a/cram/cram_structs.h
+++ b/cram/cram_structs.h
@@ -828,6 +828,7 @@ struct cram_fd {
     unsigned int required_fields;
     int store_md;
     int store_nm;
+    int remove_ur;
     cram_range range;
 
     // lookup tables, stored here so we can be trivially multi-threaded

--- a/header.c
+++ b/header.c
@@ -3206,17 +3206,12 @@ int sam_hdr_remove_tag_all(sam_hdr_t *bh, const char *type, const char *tag_id) 
     t1 = t2 = kh_val(hrecs->h, k);
 
     do {
-        sam_hrec_tag_t *tag;
-        for (tag = t1->tag; tag; tag = tag->next) {
-            if (tag->str[0] == tag_id[0] && tag->str[1] == tag_id[1]) {
-                if ((ret = sam_hrecs_remove_key(hrecs, t1, tag_id)) > 0) {
-                    deleted++;
-                    break;
-                } else {
-                    return -1;
-                }
-            }
+        if ((ret = sam_hrecs_remove_key(hrecs, t1, tag_id)) == 1) {
+            deleted++;
+        } else if (ret == -1) {
+            return -1;
         }
+
         t1 = t1->next;
     } while (t1 != t2);
 

--- a/header.c
+++ b/header.c
@@ -3174,3 +3174,51 @@ enum sam_group_order sam_hrecs_group_order(sam_hrecs_t *hrecs) {
 
     return go;
 }
+
+
+/*
+ *
+ * Removes all the instances of a tag.
+ * Returns number removed (can be 0) or -1 on a fail.
+ *
+ */
+int sam_hdr_remove_tag_all(sam_hdr_t *bh, const char *type, const char *tag_id) {
+    sam_hrecs_t *hrecs;
+    sam_hrec_type_t *t1, *t2;
+    khint_t k;
+    int ret = 0;
+    int deleted = 0;
+
+    if (!bh || !type || !tag_id)
+        return -1;
+
+    if (!(hrecs = bh->hrecs)) {
+        if (sam_hdr_fill_hrecs(bh) != 0)
+            return -1;
+        hrecs = bh->hrecs;
+    }
+
+    k = kh_get(sam_hrecs_t, hrecs->h, TYPEKEY(type));
+
+    if (k == kh_end(hrecs->h))
+        return 0;
+
+    t1 = t2 = kh_val(hrecs->h, k);
+
+    do {
+        sam_hrec_tag_t *tag;
+        for (tag = t1->tag; tag; tag = tag->next) {
+            if (tag->str[0] == tag_id[0] && tag->str[1] == tag_id[1]) {
+                if ((ret = sam_hrecs_remove_key(hrecs, t1, tag_id)) > 0) {
+                    deleted++;
+                    break;
+                } else {
+                    return -1;
+                }
+            }
+        }
+        t1 = t1->next;
+    } while (t1 != t2);
+
+    return deleted;
+}

--- a/hts.c
+++ b/hts.c
@@ -1170,11 +1170,11 @@ int hts_opt_add(hts_opt **opts, const char *c_arg) {
         o->opt = CRAM_OPT_PREFIX, o->val.s = val;
 
     else if (strcmp(o->arg, "store_md") == 0 ||
-             strcmp(o->arg, "store_md") == 0)
+             strcmp(o->arg, "STORE_MD") == 0)
         o->opt = CRAM_OPT_STORE_MD, o->val.i = atoi(val);
 
     else if (strcmp(o->arg, "store_nm") == 0 ||
-             strcmp(o->arg, "store_nm") == 0)
+             strcmp(o->arg, "STORE_NM") == 0)
         o->opt = CRAM_OPT_STORE_NM, o->val.i = atoi(val);
 
     else if (strcmp(o->arg, "block_size") == 0 ||
@@ -1216,6 +1216,10 @@ int hts_opt_add(hts_opt **opts, const char *c_arg) {
     else if (strcmp(o->arg, "fastq_umi_regex") == 0 ||
         strcmp(o->arg, "FASTQ_UMI_REGEX") == 0)
         o->opt = FASTQ_OPT_UMI_REGEX, o->val.s = val;
+
+    else if (strcmp(o->arg, "remove_ur") == 0 ||
+        strcmp(o->arg, "REMOVE_UR") == 0)
+        o->opt = CRAM_OPT_RM_UR, o->val.i = atoi(val);
 
     else {
         hts_log_error("Unknown option '%s'", o->arg);

--- a/htslib/hts.h
+++ b/htslib/hts.h
@@ -1,7 +1,7 @@
 /// @file htslib/hts.h
 /// Format-neutral I/O, indexing, and iterator API functions.
 /*
-    Copyright (C) 2012-2022 Genome Research Ltd.
+    Copyright (C) 2012-2022, 2026 Genome Research Ltd.
     Copyright (C) 2010, 2012 Broad Institute.
     Portions copyright (C) 2003-2006, 2008-2010 by Heng Li <lh3@live.co.uk>
 
@@ -322,6 +322,7 @@ enum hts_fmt_option {
     CRAM_OPT_USE_FQZ,
     CRAM_OPT_USE_ARITH,
     CRAM_OPT_POS_DELTA,  // force delta for AP, even on non-pos sorted data
+    CRAM_OPT_RM_UR,  // remove any UR tags
 
     // General purpose
     HTS_OPT_COMPRESSION_LEVEL = 100,

--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1,7 +1,7 @@
 /// @file htslib/sam.h
 /// High-level SAM/BAM/CRAM sequence file operations.
 /*
-    Copyright (C) 2008, 2009, 2013-2023, 2025 Genome Research Ltd.
+    Copyright (C) 2008, 2009, 2013-2023, 2025-26 Genome Research Ltd.
     Copyright (C) 2010, 2012, 2013 Broad Institute.
 
     Author: Heng Li <lh3@sanger.ac.uk>
@@ -831,6 +831,15 @@ char *stringify_argv(int argc, char *argv[]);
  */
 HTSLIB_EXPORT
 void sam_hdr_incr_ref(sam_hdr_t *h);
+
+/// Remove the tag from all lines identified by type.
+/*!
+ * @param type      Type of the line to which the tag belongs. Eg. "SQ"
+ * @param tag_id    The name of the targeted tag. Eg. "UR"
+ * @return          the number of tags removed (can be 0); -1 on error
+ */
+HTSLIB_EXPORT
+int sam_hdr_remove_tag_all(sam_hdr_t *bh, const char *type, const char *tag_id);
 
 /*
  * Macros for changing the \@HD line. They eliminate the need to use NULL method arguments.


### PR DESCRIPTION
Add a function to the header manipulation code to remove all tags of a certain name from one type of header entry.

Add a cram format option to remove the UR tags from the SQ lines in the header. There is also a small fix for options that should of had an uppercase equivalent.

Part of the solution to samtools/samtools#2327 with a further PR to add an option to `samtools view`.