### PR TITLE
Remove an assert in cram_index_build.

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -820,7 +820,11 @@ int cram_index_build(cram_fd *fd, const char *fn_base, const char *fn_idx) {
 
         if (!(c->comp_hdr_block = cram_read_block(fd)))
             goto err;
-        assert(c->comp_hdr_block->content_type == COMPRESSION_HEADER);
+        if (c->comp_hdr_block->content_type != COMPRESSION_HEADER) {
+            hts_log_error("Expected a compression header block at pos %lld",
+                          (long long)hpos);
+            goto err;
+        }
 
         c->comp_hdr = cram_decode_compression_header(fd, c->comp_hdr_block);
         if (!c->comp_hdr)


### PR DESCRIPTION
If we don't have a compression header where expected it now fails in a more graceful manner.

Co-Authored-By: Shujie Xiang

Fixes #2060