### PR TITLE
Use memchr() to skip over variable-length string tags in skip_aux()

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -4431,9 +4431,10 @@ static inline uint8_t *skip_aux(uint8_t *s, uint8_t *end)
     size = aux_type2size(*s); ++s; // skip type
     switch (size) {
     case 'Z':
-    case 'H':
-        while (s < end && *s) ++s;
-        return s < end ? s + 1 : end;
+    case 'H': {
+        uint8_t *terminator = memchr(s, '\0', end - s);
+        return terminator ? terminator + 1 : end;
+    }
     case 'B':
         if (end - s < 5) return NULL;
         size = aux_type2size(*s); ++s;


### PR DESCRIPTION
Oxford Nanopore modification annotations include a potentially large `MM` string tag. HTSlib’s auxiliary-field iterator previously found NUL terminators in `Z` and `H` tags with a byte-at-a-time loop. This patch uses the `memchr()` implementation instead.


Workload | Original traversal | memchr() traversal | Improvement
-- | -- | -- | --
Bare reader | 4.88 s | 4.89 s | N/A
Bare reader + aux-tag walk | 10.85 s | 5.12 s | 53%

The benchmark uses a small HTSlib-only reader program, with 16 decompression threads. It opens the BAM, reads every record, and nothing else. The aux-tag variant adds only
```
for (uint8_t *aux = bam_aux_first(record);  aux != NULL; aux = bam_aux_next(record, aux)) {
    ++aux_count;
}
```

Timings are from a 17 GB coordinate-sorted BAM containing the `chr1` slice of a larger ONT HG002 alignment:
* 684,377 mapped records and no unmapped records
* Contains modification annotations

