### PR TITLE
Report when khash can no longer expand

### DIFF
--- a/htslib/khash.h
+++ b/htslib/khash.h
@@ -247,6 +247,14 @@ static const double __ac_HASH_UPPER = 0.77;
 	}																	\
 	SCOPE int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets) \
 	{ /* This function uses 0.25*n_buckets bytes of working space instead of [sizeof(key_t+val_t)+.25]*n_buckets. */ \
+		const int small_size_t = sizeof(size_t)/2 < sizeof(khint_t);	\
+		const int big_keys = sizeof(khkey_t) > ((size_t) 1 << sizeof(size_t) * 4); \
+		const int big_vals = sizeof(khval_t) > ((size_t) 1 << sizeof(size_t) * 4); \
+		const khint_t max_n_buckets = (khint_t) 1 << (sizeof(khint_t) * 8 - 1); \
+		if (new_n_buckets > max_n_buckets) { /* Prevent overflow on roundup */ \
+			errno = ENOMEM; /* Not quite true, but close enough*/ 		\
+			return -1;													\
+		}																\
 		khint32_t *new_flags = 0;										\
 		khint_t j = 1;													\
 		{																\
@@ -258,10 +266,22 @@ static const double __ac_HASH_UPPER = 0.77;
 				if (!new_flags) return -1;								\
 				memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khint32_t)); \
 				if (h->n_buckets < new_n_buckets) {	/* expand */		\
+					if ((small_size_t || big_keys)						\
+						&& SIZE_MAX / new_n_buckets < sizeof(khkey_t)) { \
+						kfree(new_flags);								\
+						errno = ENOMEM;									\
+						return -1;										\
+					}													\
 					khkey_t *new_keys = (khkey_t*)krealloc((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
 					if (!new_keys) { kfree(new_flags); return -1; }		\
 					h->keys = new_keys;									\
 					if (kh_is_map) {									\
+						if ((small_size_t || big_vals)					\
+							&& SIZE_MAX / new_n_buckets < sizeof(khkey_t)) { \
+							kfree(new_flags);							\
+							errno = ENOMEM;								\
+							return -1;									\
+						}												\
 						khval_t *new_vals = (khval_t*)krealloc((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
 						if (!new_vals) { kfree(new_flags); return -1; }	\
 						h->vals = new_vals;								\


### PR DESCRIPTION
As `khint_t` is a 32-bit unsigned value, it's possible on 64-bit platforms to fill a hash table to the point where it can no longer expand without overflowing the `n_buckets` member.  This commit adds a check so that `kh_resize()` will return an error if this happens.  It also adds overflow checks for allocations of the key and value arrays, mainly for 32-bit platforms where this could be a problem.  The checks should be eliminated on 64-bit platforms where the multiplication cannot overflow unless either the key or value structs are massive.

Failing to check for the n_buckets overflow case caused `kh_put()` to incorrectly report duplicates. This happened because `kh_resize()` returned 0 without resizing the table, so `kh_put()` added new entries to the existing table until it ran out of available slots. As `kh_put()` includes the assumption that dropping out of its slot-finding loop with a filled bucket is caused by a duplicate, it reported that as the cause instead of the real reason.

The new test currently limits the number of hash table entries to 2^31*0.77 (1653562408).  This is only about 38% of the theoretical maximum given the size of `khint_t`, however fixing that would involve changing how the n_buckets struct member works, which is difficult when it is visible as part of the khash interface.  If this becomes a problem then it would probably be better to create a new 64-bit capable hash table rather than attempt to extend the existing interface.