### PR TITLE
Protect against high memory usage in malformed CRAM files.

### DIFF
--- a/cram/cram_decode.c
+++ b/cram/cram_decode.c
@@ -994,7 +994,9 @@ cram_block_slice_hdr *cram_decode_slice_header(cram_fd *fd, cram_block *b) {
     hdr->num_blocks      = fd->vv.varint_get32((char **)&cp, (char *)cp_end, &err);
     hdr->num_content_ids = fd->vv.varint_get32((char **)&cp, (char *)cp_end, &err);
     if (hdr->num_content_ids < 1 ||
-        hdr->num_content_ids >= 10000) {
+        hdr->num_content_ids >= 10000 ||
+        hdr->num_blocks < 1 ||
+        hdr->num_blocks >= 10000) {
         // Slice must have at least one data block, and there is no need
         // for more than 2 per possible aux-tag plus ancillary.
         free(hdr);

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -3632,6 +3632,15 @@ cram_container *cram_read_container(cram_fd *fd) {
         return NULL;
     }
 #endif
+    // We already have an upper limit of 10,000 blocks per slice to prevent
+    // bad data using excessive memory.  We could in theory have many slices
+    // per container, but in practice we only ever stick to 1 in modern
+    // implementations.  Nonetheless, let's use a limit here too on
+    // landmarks (which are offsets relative to this container position).
+    if (c->num_landmarks > 1000000) {
+        cram_free_container(c);
+        return NULL;
+    }
     if (c->num_landmarks && !(c->landmark = hts_malloc_p(sizeof(*c->landmark), c->num_landmarks))) {
         fd->err = errno;
         cram_free_container(c);


### PR DESCRIPTION
Replication the 10,000 block limit in slices.  We already had it for allocating Content IDs (which is 1 per block), but oddly not for the block pointers themselves.

Also add a similar check for the container header too.

These won't limit valid or real-world CRAM usage.