### PR TITLE
Resolve cigar2 overflow

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -5404,86 +5404,111 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
     bam1_core_t *c = &b->core;
     uint32_t *cigar = bam_get_cigar(b);
     int k;
+
     // determine the current CIGAR operation
     //fprintf(stderr, "%s\tpos=%ld\tend=%ld\t(%d,%ld,%ld)\n", bam_get_qname(b), pos, s->end, s->k, s->x, s->y);
     if (s->k == -1) { // never processed
         p->qpos = 0;
         if (c->n_cigar == 1) { // just one operation, save a loop
-            if (_cop(cigar[0]) == BAM_CMATCH || _cop(cigar[0]) == BAM_CEQUAL || _cop(cigar[0]) == BAM_CDIFF) s->k = 0, s->x = c->pos, s->y = 0;
-        } else { // find the first match or deletion
+            int op = _cop(cigar[0]);
+            if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF)
+                s->k = 0, s->x = c->pos, s->y = 0;
+        } else { // find the first reference base (match, mismatch or deletion)
             for (k = 0, s->x = c->pos, s->y = 0; k < c->n_cigar; ++k) {
                 int op = _cop(cigar[k]);
                 int l = _cln(cigar[k]);
-                if (op == BAM_CMATCH || op == BAM_CDEL || op == BAM_CREF_SKIP ||
-                    op == BAM_CEQUAL || op == BAM_CDIFF) break;
-                else if (op == BAM_CINS || op == BAM_CSOFT_CLIP) s->y += l;
+                if (bam_cigar_type(op) & 2)      // consumes ref
+                    break;
+                else if (bam_cigar_type(op) & 1) // consumes query
+                    s->y += l;
             }
             assert(k < c->n_cigar);
             s->k = k;
         }
+
     } else { // the read has been processed before
-        int op, l = _cln(cigar[s->k]);
+        int op = _cop(cigar[s->k]);
+        int l  = _cln(cigar[s->k]);
         if (pos - s->x >= l) { // jump to the next operation
-            assert(s->k < c->n_cigar); // otherwise a bug: this function should not be called in this case
-            op = _cop(cigar[s->k+1]);
-            if (op == BAM_CMATCH || op == BAM_CDEL || op == BAM_CREF_SKIP || op == BAM_CEQUAL || op == BAM_CDIFF) { // jump to the next without a loop
-                if (_cop(cigar[s->k]) == BAM_CMATCH|| _cop(cigar[s->k]) == BAM_CEQUAL || _cop(cigar[s->k]) == BAM_CDIFF) s->y += l;
+            // otherwise a bug: this function should not be called in this case
+            assert(s->k < c->n_cigar);
+            int next_op = _cop(cigar[s->k+1]);
+            if (bam_cigar_type(next_op) & 2) { // consumes ref
+                // jump to the next without a loop
+                if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF)
+                    s->y += l;
                 s->x += l;
                 ++s->k;
             } else { // find the next M/D/N/=/X
-                if (_cop(cigar[s->k]) == BAM_CMATCH|| _cop(cigar[s->k]) == BAM_CEQUAL || _cop(cigar[s->k]) == BAM_CDIFF) s->y += l;
+                if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF)
+                    s->y += l;
                 s->x += l;
                 for (k = s->k + 1; k < c->n_cigar; ++k) {
                     op = _cop(cigar[k]), l = _cln(cigar[k]);
-                    if (op == BAM_CMATCH || op == BAM_CDEL || op == BAM_CREF_SKIP || op == BAM_CEQUAL || op == BAM_CDIFF) break;
-                    else if (op == BAM_CINS || op == BAM_CSOFT_CLIP) s->y += l;
+                    if (bam_cigar_type(op) & 2)      // consumes ref
+                        break;
+                    else if (bam_cigar_type(op) & 1) // consumes query
+                        s->y += l;
                 }
                 s->k = k;
             }
             assert(s->k < c->n_cigar); // otherwise a bug
         } // else, do nothing
     }
-    { // collect pileup information
-        int op, l;
-        op = _cop(cigar[s->k]); l = _cln(cigar[s->k]);
+
+    // collect pileup information
+    {
+        int op = _cop(cigar[s->k]);
+        int l  = _cln(cigar[s->k]);
         p->is_del = indel = p->is_refskip = 0;
-        if (s->x + l - 1 == pos && s->k + 1 < c->n_cigar) { // peek the next operation
+
+        // peek the next operation
+        if (s->x + l - 1 == pos && s->k + 1 < c->n_cigar) {
             int op2 = _cop(cigar[s->k+1]);
-            int l2 = _cln(cigar[s->k+1]);
+            int l2  = _cln(cigar[s->k+1]);
             if (op2 == BAM_CDEL && op != BAM_CDEL) {
                 // At start of a new deletion, merge e.g. 1D2D to 3D.
                 // Within a deletion (the 2D in 1D2D) we keep indel=0
                 // and rely on is_del=1 as we would for 3D.
-                indel = -(int)l2;
+                indel = -l2;
                 for (k = s->k+2; k < c->n_cigar; ++k) {
-                    op2 = _cop(cigar[k]); l2 = _cln(cigar[k]);
-                    if (op2 == BAM_CDEL) indel -= l2;
-                    else break;
+                    op2 = _cop(cigar[k]);
+                    l2  = _cln(cigar[k]);
+                    if (op2 == BAM_CDEL)
+                        indel -= l2;
+                    else
+                        break;
                 }
             } else if (op2 == BAM_CINS) {
                 indel = l2;
                 for (k = s->k+2; k < c->n_cigar; ++k) {
-                    op2 = _cop(cigar[k]); l2 = _cln(cigar[k]);
-                    if (op2 == BAM_CINS) indel += l2;
-                    else if (op2 != BAM_CPAD) break;
+                    op2 = _cop(cigar[k]);
+                    l2  = _cln(cigar[k]);
+                    if (op2 == BAM_CINS)
+                        indel += l2;
+                    else if (op2 != BAM_CPAD)
+                        break;
                 }
             } else if (op2 == BAM_CPAD && s->k + 2 < c->n_cigar) {
-                int l3 = 0;
                 for (k = s->k + 2; k < c->n_cigar; ++k) {
-                    op2 = _cop(cigar[k]); l2 = _cln(cigar[k]);
-                    if (op2 == BAM_CINS) l3 += l2;
-                    else if (op2 == BAM_CDEL || op2 == BAM_CMATCH || op2 == BAM_CREF_SKIP || op2 == BAM_CEQUAL || op2 == BAM_CDIFF) break;
+                    op2 = _cop(cigar[k]);
+                    l2  = _cln(cigar[k]);
+                    if (op2 == BAM_CINS)
+                        indel += l2;
+                    else if (bam_cigar_type(op2) & 2) // consumes ref
+                        break;
                 }
-                if (l3 > 0) indel = l3;
             }
         }
         if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF) {
             p->qpos = s->y + (pos - s->x);
         } else if (op == BAM_CDEL || op == BAM_CREF_SKIP) {
-            p->is_del = 1; p->qpos = s->y; // FIXME: distinguish D and N!!!!!
+            p->is_del = 1; // FIXME: distinguish D and N!!!!!
+            p->qpos = s->y;
             p->is_refskip = (op == BAM_CREF_SKIP);
         } // cannot be other operations; otherwise a bug
-        p->is_head = (pos == c->pos); p->is_tail = (pos == s->end);
+        p->is_head = (pos == c->pos);
+        p->is_tail = (pos == s->end);
     }
     p->cigar_ind = s->k;
 

--- a/sam.c
+++ b/sam.c
@@ -5385,6 +5385,12 @@ static inline void mp_free(mempool_t *mp, lbnode_t *p)
  *** CIGAR resolver ***
  **********************/
 
+// Lookup variables, so we can do "if (MEX & (1<<op))" instead of
+// "if (op==BAM_CMATCH || op==BAM_CEQUAL || op==BAM_CDIFF)".
+static const int MEX = (1<<BAM_CMATCH) | (1<<BAM_CEQUAL) | (1<<BAM_CDIFF);
+static const int MEXDN = MEX | (1<<BAM_CDEL) | (1<<BAM_CREF_SKIP);
+static const int IS = (1<<BAM_CINS) | (1<<BAM_CSOFT_CLIP);
+
 /* s->k: the index of the CIGAR operator that has just been processed.
    s->x: the reference coordinate of the start of s->k
    s->y: the query coordinate of the start of s->k
@@ -5397,9 +5403,7 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
 #define _cop(c) ((c)&BAM_CIGAR_MASK)
 #define _cln(c) ((c)>>BAM_CIGAR_SHIFT)
 
-    // Take 64-bit copies of 32-bit values so we can detect overflows.
-    hts_pos_t indel = p->indel;
-
+    hts_pos_t indel;
     bam1_t *b = p->b;
     bam1_core_t *c = &b->core;
     uint32_t *cigar = bam_get_cigar(b);
@@ -5409,46 +5413,42 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
     //fprintf(stderr, "%s\tpos=%ld\tend=%ld\t(%d,%ld,%ld)\n", bam_get_qname(b), pos, s->end, s->k, s->x, s->y);
     if (s->k == -1) { // never processed
         p->qpos = 0;
-        if (c->n_cigar == 1) { // just one operation, save a loop
-            int op = _cop(cigar[0]);
-            if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF)
-                s->k = 0, s->x = c->pos, s->y = 0;
+        if (c->n_cigar == 1 && (MEX & (1<<_cop(cigar[0])))) {
+            // just one M/=/X operation, save a loop
+            s->k = 0, s->x = c->pos, s->y = 0;
         } else { // find the first reference base (match, mismatch or deletion)
             for (k = 0, s->x = c->pos, s->y = 0; k < c->n_cigar; ++k) {
-                int op = _cop(cigar[k]);
-                int l = _cln(cigar[k]);
+                const int op = _cop(cigar[k]);
                 if (bam_cigar_type(op) & 2)      // consumes ref
                     break;
                 else if (bam_cigar_type(op) & 1) // consumes query
-                    s->y += l;
+                    s->y += _cln(cigar[k]);
             }
             assert(k < c->n_cigar);
             s->k = k;
         }
 
     } else { // the read has been processed before
-        int op = _cop(cigar[s->k]);
-        int l  = _cln(cigar[s->k]);
+        const int l  = _cln(cigar[s->k]);
         if (pos - s->x >= l) { // jump to the next operation
             // otherwise a bug: this function should not be called in this case
-            assert(s->k < c->n_cigar);
-            int next_op = _cop(cigar[s->k+1]);
-            if (bam_cigar_type(next_op) & 2) { // consumes ref
+            assert(s->k+1 < c->n_cigar);
+
+            // Common bit between M=X and M=XDN
+            if (MEX & (1 << _cop(cigar[s->k])))
+                s->y += l;
+            s->x += l;
+
+            if (MEXDN & (1 << _cop(cigar[s->k+1]))) { // next op consumes ref
                 // jump to the next without a loop
-                if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF)
-                    s->y += l;
-                s->x += l;
                 ++s->k;
             } else { // find the next M/D/N/=/X
-                if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF)
-                    s->y += l;
-                s->x += l;
                 for (k = s->k + 1; k < c->n_cigar; ++k) {
-                    op = _cop(cigar[k]), l = _cln(cigar[k]);
-                    if (bam_cigar_type(op) & 2)      // consumes ref
+                    const int op = _cop(cigar[k]);
+                    if (MEXDN & (1 << op))
                         break;
-                    else if (bam_cigar_type(op) & 1) // consumes query
-                        s->y += l;
+                    else if (IS & (1<<op))
+                        s->y += _cln(cigar[k]);
                 }
                 s->k = k;
             }
@@ -5458,49 +5458,49 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
 
     // collect pileup information
     {
-        int op = _cop(cigar[s->k]);
-        int l  = _cln(cigar[s->k]);
+        const int op = _cop(cigar[s->k]);
+        const int l  = _cln(cigar[s->k]);
         p->is_del = indel = p->is_refskip = 0;
 
         // peek the next operation
         if (s->x + l - 1 == pos && s->k + 1 < c->n_cigar) {
-            int op2 = _cop(cigar[s->k+1]);
-            int l2  = _cln(cigar[s->k+1]);
+            const int op2 = _cop(cigar[s->k+1]);
+            const int l2  = _cln(cigar[s->k+1]);
             if (op2 == BAM_CDEL && op != BAM_CDEL) {
                 // At start of a new deletion, merge e.g. 1D2D to 3D.
                 // Within a deletion (the 2D in 1D2D) we keep indel=0
                 // and rely on is_del=1 as we would for 3D.
                 indel = -l2;
                 for (k = s->k+2; k < c->n_cigar; ++k) {
-                    op2 = _cop(cigar[k]);
-                    l2  = _cln(cigar[k]);
+                    const int op2 = _cop(cigar[k]);
                     if (op2 == BAM_CDEL)
-                        indel -= l2;
+                        indel -= _cln(cigar[k]);
                     else
                         break;
                 }
             } else if (op2 == BAM_CINS) {
                 indel = l2;
                 for (k = s->k+2; k < c->n_cigar; ++k) {
-                    op2 = _cop(cigar[k]);
-                    l2  = _cln(cigar[k]);
+                    const int op2 = _cop(cigar[k]);
                     if (op2 == BAM_CINS)
-                        indel += l2;
+                        indel += _cln(cigar[k]);
                     else if (op2 != BAM_CPAD)
                         break;
                 }
             } else if (op2 == BAM_CPAD && s->k + 2 < c->n_cigar) {
                 for (k = s->k + 2; k < c->n_cigar; ++k) {
-                    op2 = _cop(cigar[k]);
-                    l2  = _cln(cigar[k]);
+                    const int op2 = _cop(cigar[k]);
                     if (op2 == BAM_CINS)
-                        indel += l2;
+                        indel += _cln(cigar[k]);
                     else if (bam_cigar_type(op2) & 2) // consumes ref
                         break;
                 }
             }
         }
-        if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF) {
+        if (MEX & (1<<op)) {
+            // Could overflow if pos - s->x pushes s->y from +ve to -ve.
+            // For this to happen we need over 2billion bases in our SEQ.
+            // We rely on b->core.l_qseq having been sanity checked first.
             p->qpos = s->y + (pos - s->x);
         } else if (op == BAM_CDEL || op == BAM_CREF_SKIP) {
             p->is_del = 1; // FIXME: distinguish D and N!!!!!

--- a/sam.c
+++ b/sam.c
@@ -5409,7 +5409,7 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
     if (s->k == -1) { // never processed
         p->qpos = 0;
         if (c->n_cigar == 1) { // just one operation, save a loop
-          if (_cop(cigar[0]) == BAM_CMATCH || _cop(cigar[0]) == BAM_CEQUAL || _cop(cigar[0]) == BAM_CDIFF) s->k = 0, s->x = c->pos, s->y = 0;
+            if (_cop(cigar[0]) == BAM_CMATCH || _cop(cigar[0]) == BAM_CEQUAL || _cop(cigar[0]) == BAM_CDIFF) s->k = 0, s->x = c->pos, s->y = 0;
         } else { // find the first match or deletion
             for (k = 0, s->x = c->pos, s->y = 0; k < c->n_cigar; ++k) {
                 int op = _cop(cigar[k]);
@@ -5427,11 +5427,11 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
             assert(s->k < c->n_cigar); // otherwise a bug: this function should not be called in this case
             op = _cop(cigar[s->k+1]);
             if (op == BAM_CMATCH || op == BAM_CDEL || op == BAM_CREF_SKIP || op == BAM_CEQUAL || op == BAM_CDIFF) { // jump to the next without a loop
-              if (_cop(cigar[s->k]) == BAM_CMATCH|| _cop(cigar[s->k]) == BAM_CEQUAL || _cop(cigar[s->k]) == BAM_CDIFF) s->y += l;
+                if (_cop(cigar[s->k]) == BAM_CMATCH|| _cop(cigar[s->k]) == BAM_CEQUAL || _cop(cigar[s->k]) == BAM_CDIFF) s->y += l;
                 s->x += l;
                 ++s->k;
             } else { // find the next M/D/N/=/X
-              if (_cop(cigar[s->k]) == BAM_CMATCH|| _cop(cigar[s->k]) == BAM_CEQUAL || _cop(cigar[s->k]) == BAM_CDIFF) s->y += l;
+                if (_cop(cigar[s->k]) == BAM_CMATCH|| _cop(cigar[s->k]) == BAM_CEQUAL || _cop(cigar[s->k]) == BAM_CDIFF) s->y += l;
                 s->x += l;
                 for (k = s->k + 1; k < c->n_cigar; ++k) {
                     op = _cop(cigar[k]), l = _cln(cigar[k]);

--- a/sam.c
+++ b/sam.c
@@ -5434,7 +5434,7 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
             // otherwise a bug: this function should not be called in this case
             assert(s->k+1 < c->n_cigar);
 
-            // Common bit between M=X and M=XDN
+            // Update cstate_t ref and query positions for the next CIGAR op
             if (MEX & (1 << _cop(cigar[s->k])))
                 s->y += l;
             s->x += l;
@@ -5464,13 +5464,13 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
 
         // peek the next operation
         if (s->x + l - 1 == pos && s->k + 1 < c->n_cigar) {
-            const int op2 = _cop(cigar[s->k+1]);
-            const int l2  = _cln(cigar[s->k+1]);
-            if (op2 == BAM_CDEL && op != BAM_CDEL) {
+            const int op_next = _cop(cigar[s->k+1]);
+            const int l_next  = _cln(cigar[s->k+1]);
+            if (op_next == BAM_CDEL && op != BAM_CDEL) {
                 // At start of a new deletion, merge e.g. 1D2D to 3D.
                 // Within a deletion (the 2D in 1D2D) we keep indel=0
                 // and rely on is_del=1 as we would for 3D.
-                indel = -l2;
+                indel = -l_next;
                 for (k = s->k+2; k < c->n_cigar; ++k) {
                     const int op2 = _cop(cigar[k]);
                     if (op2 == BAM_CDEL)
@@ -5478,8 +5478,8 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
                     else
                         break;
                 }
-            } else if (op2 == BAM_CINS) {
-                indel = l2;
+            } else if (op_next == BAM_CINS) {
+                indel = l_next;
                 for (k = s->k+2; k < c->n_cigar; ++k) {
                     const int op2 = _cop(cigar[k]);
                     if (op2 == BAM_CINS)
@@ -5487,7 +5487,7 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
                     else if (op2 != BAM_CPAD)
                         break;
                 }
-            } else if (op2 == BAM_CPAD && s->k + 2 < c->n_cigar) {
+            } else if (op_next == BAM_CPAD && s->k + 2 < c->n_cigar) {
                 for (k = s->k + 2; k < c->n_cigar; ++k) {
                     const int op2 = _cop(cigar[k]);
                     if (op2 == BAM_CINS)

--- a/sam.c
+++ b/sam.c
@@ -5330,8 +5330,8 @@ char *bam_flag2str(int flag)
  *******************/
 
 typedef struct {
-    int k, y;
-    hts_pos_t x, end;
+    int k;
+    hts_pos_t x, y, end;
 } cstate_t;
 
 static cstate_t g_cstate_null = { -1, 0, 0, 0 };
@@ -5388,18 +5388,24 @@ static inline void mp_free(mempool_t *mp, lbnode_t *p)
 /* s->k: the index of the CIGAR operator that has just been processed.
    s->x: the reference coordinate of the start of s->k
    s->y: the query coordinate of the start of s->k
+
+   Returns 1 on success
+           0 on error
  */
 static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
 {
 #define _cop(c) ((c)&BAM_CIGAR_MASK)
 #define _cln(c) ((c)>>BAM_CIGAR_SHIFT)
 
+    // Take 64-bit copies of 32-bit values so we can detect overflows.
+    hts_pos_t indel = p->indel;
+
     bam1_t *b = p->b;
     bam1_core_t *c = &b->core;
     uint32_t *cigar = bam_get_cigar(b);
     int k;
     // determine the current CIGAR operation
-    //fprintf(stderr, "%s\tpos=%ld\tend=%ld\t(%d,%ld,%d)\n", bam_get_qname(b), pos, s->end, s->k, s->x, s->y);
+    //fprintf(stderr, "%s\tpos=%ld\tend=%ld\t(%d,%ld,%ld)\n", bam_get_qname(b), pos, s->end, s->k, s->x, s->y);
     if (s->k == -1) { // never processed
         p->qpos = 0;
         if (c->n_cigar == 1) { // just one operation, save a loop
@@ -5440,25 +5446,25 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
     { // collect pileup information
         int op, l;
         op = _cop(cigar[s->k]); l = _cln(cigar[s->k]);
-        p->is_del = p->indel = p->is_refskip = 0;
+        p->is_del = indel = p->is_refskip = 0;
         if (s->x + l - 1 == pos && s->k + 1 < c->n_cigar) { // peek the next operation
             int op2 = _cop(cigar[s->k+1]);
             int l2 = _cln(cigar[s->k+1]);
             if (op2 == BAM_CDEL && op != BAM_CDEL) {
                 // At start of a new deletion, merge e.g. 1D2D to 3D.
-                // Within a deletion (the 2D in 1D2D) we keep p->indel=0
+                // Within a deletion (the 2D in 1D2D) we keep indel=0
                 // and rely on is_del=1 as we would for 3D.
-                p->indel = -(int)l2;
+                indel = -(int)l2;
                 for (k = s->k+2; k < c->n_cigar; ++k) {
                     op2 = _cop(cigar[k]); l2 = _cln(cigar[k]);
-                    if (op2 == BAM_CDEL) p->indel -= l2;
+                    if (op2 == BAM_CDEL) indel -= l2;
                     else break;
                 }
             } else if (op2 == BAM_CINS) {
-                p->indel = l2;
+                indel = l2;
                 for (k = s->k+2; k < c->n_cigar; ++k) {
                     op2 = _cop(cigar[k]); l2 = _cln(cigar[k]);
-                    if (op2 == BAM_CINS) p->indel += l2;
+                    if (op2 == BAM_CINS) indel += l2;
                     else if (op2 != BAM_CPAD) break;
                 }
             } else if (op2 == BAM_CPAD && s->k + 2 < c->n_cigar) {
@@ -5468,7 +5474,7 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
                     if (op2 == BAM_CINS) l3 += l2;
                     else if (op2 == BAM_CDEL || op2 == BAM_CMATCH || op2 == BAM_CREF_SKIP || op2 == BAM_CEQUAL || op2 == BAM_CDIFF) break;
                 }
-                if (l3 > 0) p->indel = l3;
+                if (l3 > 0) indel = l3;
             }
         }
         if (op == BAM_CMATCH || op == BAM_CEQUAL || op == BAM_CDIFF) {
@@ -5480,7 +5486,19 @@ static inline int resolve_cigar2(bam_pileup1_t *p, hts_pos_t pos, cstate_t *s)
         p->is_head = (pos == c->pos); p->is_tail = (pos == s->end);
     }
     p->cigar_ind = s->k;
-    return 1;
+
+    // Check for overflows and write our 64-bit values back to their 32-bit
+    // locations.
+    int ret = 1;
+    if (s->y > INT_MAX)
+        ret = 0;
+
+    if (indel >= INT_MIN && indel <= INT_MAX)
+        p->indel = indel;
+    else
+        ret = 0;
+
+    return ret;
 }
 
 /*******************************
@@ -6018,7 +6036,14 @@ const bam_pileup1_t *bam_plp64_next(bam_plp_t iter, int *_tid, hts_pos_t *_pos, 
                     }
                     iter->plp[n_plp].b = &p->b;
                     iter->plp[n_plp].cd = p->cd;
-                    if (resolve_cigar2(iter->plp + n_plp, iter->pos, &p->s)) ++n_plp; // actually always true...
+                    if (resolve_cigar2(iter->plp + n_plp, iter->pos, &p->s)) {
+                        ++n_plp;
+                    } else {
+                        hts_log_error("Excessive element size in CIGAR");
+                        iter->error = 1;
+                        *_n_plp = -1;
+                        return NULL;
+                    }
                 }
                 pptr = &(*pptr)->next;
             }

--- a/sam.c
+++ b/sam.c
@@ -5631,8 +5631,17 @@ int bam_plp_insertion_mod(const bam_pileup1_t *p,
             break;
         case BAM_CDEL:
             // eg cigar 1M2I1D gives mpileup output in T+2AA-1C style
-            if (del_len)
-                *del_len = cigar[k]>>BAM_CIGAR_SHIFT;
+            if (del_len) {
+                uint64_t len64 = cigar[k]>>BAM_CIGAR_SHIFT;
+                while (k+1 < p->b->core.n_cigar &&
+                       (cigar[k+1] & BAM_CIGAR_MASK) == BAM_CDEL) {
+                    len64 += cigar[++k] >> BAM_CIGAR_SHIFT;
+                }
+                if (len64 < INT32_MAX)
+                    *del_len = len64;
+                else
+                    return -1;
+            }
             // fall through
         default:
             k = p->b->core.n_cigar;


### PR DESCRIPTION
This PR is does two things.

1.  Fixes overflow bugs with long consecutive indels.  Eg 250000D x10.  We now basically fail as it represents something we cannot store in p->indel due to size limitations.  It shouldn't ever happen, but I was wary of it being a vector for curious bugs given it could turn deletions into insertions and vice versa.  This doesn't seem to trigger really bad behaviour with our code, but it could potentially elsewhere.

2. Refactor the resolve_cigar2 function, and try and speed it up somewhat to mitigate the performance hit of step 1 (which is surprisingly high given it's just swapping int for int64 essentially).

On short read data, this is around 8% slower (clang) and 11% slower (gcc).
On long read data it's 2% slower (clang) and 5% slower (gcc).

Note those timings are `resolve_cigar2` only, measured using `-fno-inline` and `perf record` to check function counters.
