### PR TITLE
Add validation for l_qseq >= 0 in bam_set1

### DIFF
--- a/sam.c
+++ b/sam.c
@@ -559,6 +559,14 @@ int bam_set1(bam1_t *bam,
     }
 
     // validate parameters
+    if (l_seq > INT32_MAX) {
+        // Unfortunately b->core.l_qseq is int32, so signed.
+        // Note an "(int)l_seq < 0" check is already covered by >INT32_MAX
+        hts_log_error("Sequence length too long");
+        errno = EINVAL;
+        return -1;
+    }
+
     if (l_qname > BAM_MAX_QNAME_LEN) {
         hts_log_error("Query name too long");
         errno = EINVAL;


### PR DESCRIPTION
Minimal extra protection against malformed CRAMs.

It shouldn't have any major impact except for faster and more reliable failure.