### PR TITLE
Prevent semi-initialised kseq_t struct

### DIFF
--- a/htslib/kseq.h
+++ b/htslib/kseq.h
@@ -174,6 +174,7 @@
 		kseq_t *s = (kseq_t*)calloc(1, sizeof(kseq_t));					\
 		if (!s) return NULL;											\
 		s->f = ks_init(fd);												\
+		if (!s->f) { free(s); return NULL; }							\
 		return s;														\
 	}																	\
 	SCOPE void kseq_destroy(kseq_t *ks)									\


### PR DESCRIPTION
Add a check in `kseq_init()` to ensure `ks_init()` worked.  Prevents it from returning a structure that has not been completely set up.