### PR TITLE
Make sam_format_aux1 'A' type be nul terminated.

### DIFF
--- a/htslib/sam.h
+++ b/htslib/sam.h
@@ -1515,7 +1515,7 @@ static inline const uint8_t *sam_format_aux1(const uint8_t *key,
         } else goto bad_aux;
     } else if (type == 'A') {
         r |= kputsn_("A:", 2, ks) < 0;
-        r |= kputc_(*s, ks) < 0;
+        r |= kputc(*s, ks) < 0;
         ++s;
     } else if (type == 'f') {
         if (end - s >= 4) {


### PR DESCRIPTION
Of all the types converted to string, only 'A' missed off the nul-termination.