### PR TITLE
Use bash and pipefail for tests using simple_test_driver.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -711,13 +711,13 @@ check test: all $(HTSCODECS_TEST_TARGETS)
 	fi
 	test/test_bgzf test/bgziptest.txt
 	test/test-parse-reg -t test/colons.bam
-	cd test/faidx && ./test-faidx.sh faidx.tst
-	cd test/sam_filter && ./filter.sh filter.tst
-	cd test/tabix && ./test-tabix.sh tabix.tst
-	cd test/mpileup && ./test-pileup.sh mpileup.tst
-	cd test/fastq && ./test-fastq.sh
-	cd test/base_mods && ./base-mods.sh base-mods.tst
-	cd test/tlen && ./tlen.sh tlen.tst
+	cd test/faidx && bash ./test-faidx.sh faidx.tst
+	cd test/sam_filter && bash ./filter.sh filter.tst
+	cd test/tabix && bash ./test-tabix.sh tabix.tst
+	cd test/mpileup && bash ./test-pileup.sh mpileup.tst
+	cd test/fastq && bash ./test-fastq.sh
+	cd test/base_mods && bash ./base-mods.sh base-mods.tst
+	cd test/tlen && bash ./tlen.sh tlen.tst
 	REF_PATH=: test/sam test/ce.fa test/faidx/faidx.fa test/faidx/fastqs.fq
 	test/test-regidx
 	cd test && \

--- a/test/base_mods/base-mods.sh
+++ b/test/base_mods/base-mods.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Copyright (C) 2020 Genome Research Ltd.
 #
@@ -21,6 +21,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+
+set -o pipefail
 
 # Load in the test driver
 . ../simple_test_driver.sh

--- a/test/faidx/test-faidx.sh
+++ b/test/faidx/test-faidx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Copyright (C) 2022 Genome Research Ltd.
 #
@@ -21,6 +21,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+
+set -o pipefail
 
 # Load in the test driver
 . ../simple_test_driver.sh

--- a/test/fastq/test-fastq.sh
+++ b/test/fastq/test-fastq.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Copyright (C) 2020 Genome Research Ltd.
 #
@@ -21,6 +21,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+
+set -o pipefail
 
 . ../simple_test_driver.sh
 

--- a/test/mpileup/test-pileup.sh
+++ b/test/mpileup/test-pileup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Copyright (C) 2017-2018 Genome Research Ltd.
 #
@@ -21,6 +21,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+
+set -o pipefail
 
 # Load in the test driver
 . ../simple_test_driver.sh

--- a/test/sam_filter/filter.sh
+++ b/test/sam_filter/filter.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Copyright (C) 2020 Genome Research Ltd.
 #
@@ -21,6 +21,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+
+set -o pipefail
 
 # Load in the test driver
 . ../simple_test_driver.sh

--- a/test/simple_test_driver.sh
+++ b/test/simple_test_driver.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # simple_test_driver.sh -- shell functions for test scripts
 #
 #    Copyright (C) 2017-2018 Genome Research Ltd.

--- a/test/tabix/test-tabix.sh
+++ b/test/tabix/test-tabix.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Copyright (C) 2017-2018 Genome Research Ltd.
 #
@@ -21,6 +21,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+
+set -o pipefail
 
 # Load in the test driver
 . ../simple_test_driver.sh

--- a/test/tlen/tlen.sh
+++ b/test/tlen/tlen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #    Copyright (C) 2025 Genome Research Ltd.
 #
@@ -21,6 +21,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+
+set -o pipefail
 
 # Load in the test driver
 . ../simple_test_driver.sh


### PR DESCRIPTION
A number of tests using this infrastructure run pipelines, so really need `pipefail` to ensure that all stages have worked correctly.  And as `pipefail` is not supported by all shells, the easiest way to get it is to use `bash`.

All scripts using `simple_test_driver.sh` are updated even if the tests they run don't use pipelines so they will work without needing updates should a pipeline be added in the future.  As bash isn't always installed under `/bin`, it's also invoked directly from the Makefile so it can be found via `PATH`.  The scripts use directly without having to remember they need `bash`.