### PR TITLE
Fix leak of region list in hts_itr_multi_bam()

### DIFF
--- a/hts.c
+++ b/hts.c
@@ -3637,6 +3637,8 @@ int hts_itr_multi_bam(const hts_idx_t *idx, hts_itr_t *iter)
                 case HTS_IDX_START:
                 case HTS_IDX_REST:
                     iter->curr_off = t_off;
+                    // reglist is no longer needed
+                    hts_reglist_free(iter->reg_list, iter->n_reg);
                     iter->n_reg = 0;
                     iter->reg_list = NULL;
                     iter->read_rest = 1;


### PR DESCRIPTION
If the regions include one of the special tid values `HTS_IDX_NONE`, `HTS_IDX_START`, or `HTS_IDX_REST` then the `hts_itr_t::reg_list` array is dropped and set to `NULL`, and `hts_itr_t::n_reg` is set to zero.  As the pointer is set to `NULL`, it's necessary to call `hts_reglist_free()` here to clean up the structure first else the contents are no longer accessible and get leaked.