### PR TITLE
Simplify crai reading and zlib_mem_inflate()

### DIFF
--- a/cram/cram_index.c
+++ b/cram/cram_index.c
@@ -180,7 +180,7 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
     char buf[65536];
     ssize_t len;
     kstring_t kstr = {0};
-    hFILE *fp;
+    BGZF *fp = NULL;
     cram_index *idx;
     cram_index **idx_stack = NULL, *ep, e;
     int idx_stack_alloc = 0, idx_stack_ptr = 0;
@@ -221,38 +221,24 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
         fn_idx = tfn_idx;
     }
 
-    if (!(fp = hopen(fn_idx, "r"))) {
+    if (!(fp = bgzf_open(fn_idx, "r"))) {
         hts_log_error("Could not open index file '%s'", fn_idx);
         goto fail;
     }
 
     // Load the file into memory
-    while ((len = hread(fp, buf, sizeof(buf))) > 0) {
+    while ((len = bgzf_read(fp, buf, sizeof(buf))) > 0) {
         if (kputsn(buf, len, &kstr) < 0)
             goto fail;
     }
 
-    if (len < 0 || kstr.l < 2)
+    if (len < 0 || kstr.l < 1)
         goto fail;
 
-    if (hclose(fp) < 0)
+    int ret = bgzf_close(fp);
+    fp = NULL; // Prevent double close on failure
+    if (ret < 0)
         goto fail;
-
-    // Uncompress if required
-    if (kstr.s[0] == 31 && (uc)kstr.s[1] == 139) {
-        size_t l = 0;
-        char *s = zlib_mem_inflate(kstr.s, kstr.l, &l);
-        if (!s)
-            goto fail;
-
-        free(kstr.s);
-        kstr.s = s;
-        kstr.l = l;
-        kstr.m = l; // conservative estimate of the size allocated
-        if (kputsn("", 0, &kstr) < 0) // ensure kstr.s is NUL-terminated
-            goto fail;
-    }
-
 
     // refid indexes fd->index, so bound it to the header's reference count.
     int nref = sam_hdr_nref(fd->header);
@@ -364,6 +350,8 @@ int cram_index_load(cram_fd *fd, const char *fn, const char *fn_idx) {
     free(kstr.s);
     free(idx_stack);
     free(tfn_idx);
+    if (fp)
+        bgzf_close(fp);
     cram_index_free(fd); // Also sets fd->index = NULL
     return -1;
 }

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -1340,6 +1340,13 @@ int cram_uncompress_block(cram_block *b) {
         return 0;
 
     case GZIP:
+        if (b->uncomp_size / 2048 > b->comp_size) {
+            // The maximum compression ratio of gzip is 1032
+            // (LZ match of 258 bytes encoded in a 2bit huffman code)
+            // so catch blocks that claim to be wildly over this.
+            hts_log_error("GZIP cram block has impossibly large compression ratio");
+            return -1;
+        }
         uncomp_size = b->uncomp_size;
         uncomp = zlib_mem_inflate((char *)b->data, b->comp_size, &uncomp_size);
 

--- a/cram/cram_io.c
+++ b/cram/cram_io.c
@@ -827,39 +827,26 @@ int int32_put_blk(cram_block *b, int32_t val) {
 
 // Named the same as the version that uses zlib as we always use libdeflate for
 // decompression when available.
-char *zlib_mem_inflate(char *cdata, size_t csize, size_t *size) {
+static char *zlib_mem_inflate(char *cdata, size_t csize, size_t *size) {
     struct libdeflate_decompressor *z = libdeflate_alloc_decompressor();
     if (!z) {
         hts_log_error("Call to libdeflate_alloc_decompressor failed");
         return NULL;
     }
 
-    uint8_t *data = NULL, *new_data;
-    if (!*size)
-        *size = csize*2;
-    for(;;) {
-        new_data = realloc(data, *size);
-        if (!new_data) {
-            hts_log_error("Memory allocation failure");
-            goto fail;
-        }
-        data = new_data;
+    assert (*size > 0);
+    uint8_t *data = malloc(*size);
+    if (!data) {
+        hts_log_error("Memory allocation failure");
+        goto fail;
+    }
 
-        int ret = libdeflate_gzip_decompress(z, cdata, csize, data, *size, size);
 
-        // Auto grow output buffer size if needed and try again.
-        // Fortunately for all bar one call of this we know the size already.
-        if (ret == LIBDEFLATE_INSUFFICIENT_SPACE) {
-            (*size) *= 1.5;
-            continue;
-        }
+    int ret = libdeflate_gzip_decompress(z, cdata, csize, data, *size, size);
 
-        if (ret != LIBDEFLATE_SUCCESS) {
-            hts_log_error("Inflate operation failed: %d", ret);
-            goto fail;
-        } else {
-            break;
-        }
+    if (ret != LIBDEFLATE_SUCCESS) {
+        hts_log_error("Inflate operation failed: %d", ret);
+        goto fail;
     }
 
     libdeflate_free_decompressor(z);
@@ -919,23 +906,27 @@ static char *libdeflate_deflate(char *data, size_t size, size_t *cdata_size,
 char *zlib_mem_inflate(char *cdata, size_t csize, size_t *size) {
     z_stream s;
     unsigned char *data = NULL; /* Uncompressed output */
-    int data_alloc = 0;
     int err;
 
-    /* Starting point at uncompressed size, and scale after that */
-    data = malloc(data_alloc = csize*1.2+100);
+    assert(*size > 0);
+    // These should always be true due to type of cram_block::comp_size
+    // and cram_block::uncomp_size
+    assert(*size < UINT_MAX);
+    assert(csize < UINT_MAX);
+    data = malloc(*size);
     if (!data)
         return NULL;
 
     /* Initialise zlib stream */
     s.zalloc = Z_NULL; /* use default allocation functions */
     s.zfree  = Z_NULL;
+    s.msg    = Z_NULL;
     s.opaque = Z_NULL;
     s.next_in  = (unsigned char *)cdata;
-    s.avail_in = csize;
+    s.avail_in = (uInt) csize;
     s.total_in = 0;
     s.next_out  = data;
-    s.avail_out = data_alloc;
+    s.avail_out = (uInt) *size;
     s.total_out = 0;
 
     //err = inflateInit(&s);
@@ -947,32 +938,16 @@ char *zlib_mem_inflate(char *cdata, size_t csize, size_t *size) {
     }
 
     /* Decode to 'data' array */
-    for (;s.avail_in;) {
-        unsigned char *data_tmp;
-        int alloc_inc;
+    err = inflate(&s, Z_FINISH);
 
-        s.next_out = &data[s.total_out];
-        err = inflate(&s, Z_NO_FLUSH);
-        if (err == Z_STREAM_END)
-            break;
-
-        if (err != Z_OK) {
-            hts_log_error("Call to zlib inflate failed: %s", s.msg);
-            free(data);
-            inflateEnd(&s);
-            return NULL;
-        }
-
-        /* More to come, so realloc based on growth so far */
-        alloc_inc = (double)s.avail_in/s.total_in * s.total_out + 100;
-        data = realloc((data_tmp = data), data_alloc += alloc_inc);
-        if (!data) {
-            free(data_tmp);
-            inflateEnd(&s);
-            return NULL;
-        }
-        s.avail_out += alloc_inc;
+    if (err != Z_STREAM_END) {
+        hts_log_error("Call to zlib inflate failed: %s",
+                      err != Z_OK ? s.msg : "not enough data");
+        free(data);
+        inflateEnd(&s);
+        return NULL;
     }
+
     inflateEnd(&s);
 
     *size = s.total_out;

--- a/cram/cram_io.h
+++ b/cram/cram_io.h
@@ -137,14 +137,6 @@ int cram_write_block(cram_fd *fd, cram_block *b);
  */
 void cram_free_block(cram_block *b);
 
-/*! Uncompress a memory block using Zlib.
- *
- * @return
- * Returns 0 on success;
- *        -1 on failure
- */
-char *zlib_mem_inflate(char *cdata, size_t csize, size_t *size);
-
 /*! Uncompresses a CRAM block, if compressed.
  *
  * @return


### PR DESCRIPTION
Use BGZF interface in place of `hFILE` in `cram_index_load()` so it no longer has to include its own decompression code.  This allows `zlib_mem_inflate()` to be simplified as the only remaining caller both passes in the uncompressed size and rejects data that does not decompress to the size given, so logic for growing the output buffer can be removed.

Fixes a bug reported in #2081 where `zlib_mem_inflate()` could get stuck if the uncompressed size passed to it was 1, but the decompressed data needed more space.

Fixes a bug in `cram_index_load()` where the `hFILE` structure could be leaked if an error was detected when reading the index file.

Adds a quick test to `cram_uncompress_block()` so that GZIP blocks claiming an impossible compression ratio can be rejected without trying to decompress them first.

Closes #2081